### PR TITLE
Updates for 3.0.0.PRE-1 release

### DIFF
--- a/cqf-fhir-api/pom.xml
+++ b/cqf-fhir-api/pom.xml
@@ -5,14 +5,14 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-api</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <name>FHIR Clinical Reasoning (APIs)</name>
   <description>FHIR Repository APIs used by this project. Implement these to incorporate clinical reasoning on your platform</description>
 
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
     <relativePath>../cqf-fhir/pom.xml</relativePath>
   </parent>
 

--- a/cqf-fhir-bom/pom.xml
+++ b/cqf-fhir-bom/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-bom</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <packaging>pom</packaging>
   <name>FHIR Clinical Reasoning (Bill Of Materials)</name>
   <description>This bom can be used to simplify dependency management when using this project</description>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
     <relativePath>../cqf-fhir/pom.xml</relativePath>
   </parent>
 

--- a/cqf-fhir-cdshooks/pom.xml
+++ b/cqf-fhir-cdshooks/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-cdshooks</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
 
   <name>FHIR Clinical Reasoning (CDS Hooks)</name>
   <description>CDS Hooks components for FHIR Clinical Reasoning</description>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
     <relativePath>../cqf-fhir/pom.xml</relativePath>
   </parent>
 
@@ -21,27 +21,27 @@
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-cql</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-cr</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-utility</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-test</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/cqf-fhir-cql-dstu3/pom.xml
+++ b/cqf-fhir-cql-dstu3/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-cql-dstu3</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
 
   <name>FHIR Clinical Reasoning (CQL DSTU3)</name>
   <description>CQL Authoring Support for DSTU3</description>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
     <relativePath>../cqf-fhir/pom.xml</relativePath>
   </parent>
 
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
   </dependencies>
 </project>

--- a/cqf-fhir-cql-r4/pom.xml
+++ b/cqf-fhir-cql-r4/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-cql-r4</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
 
   <name>FHIR Clinical Reasoning (CQL R4)</name>
   <description>CQL Authoring Support for R4</description>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
     <relativePath>../cqf-fhir/pom.xml</relativePath>
   </parent>
 
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
   </dependencies>
 </project>

--- a/cqf-fhir-cql-r5/pom.xml
+++ b/cqf-fhir-cql-r5/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-cql-r5</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
 
   <name>FHIR Clinical Reasoning (CQL R5)</name>
   <description>CQL Authoring Support for R5</description>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
     <relativePath>../cqf-fhir/pom.xml</relativePath>
   </parent>
 
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
   </dependencies>
 </project>

--- a/cqf-fhir-cql/pom.xml
+++ b/cqf-fhir-cql/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-cql</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
 
   <name>FHIR Clinical Reasoning (CQL)</name>
   <description>Tools, utilities, code gen to support CQL in FHIR Clinical Reasoning operations</description>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
     <relativePath>../cqf-fhir/pom.xml</relativePath>
   </parent>
 
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
   </dependencies>
 </project>

--- a/cqf-fhir-cr/pom.xml
+++ b/cqf-fhir-cr/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-cr</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
 
   <name>FHIR Clinical Reasoning (Operations)</name>
   <description>Implementations of clinical reasoning operations</description>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
     <relativePath>../cqf-fhir/pom.xml</relativePath>
   </parent>
 
@@ -21,22 +21,22 @@
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-cql</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-utility</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-test</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/cqf-fhir-elm/pom.xml
+++ b/cqf-fhir-elm/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-elm</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
 
   <name>FHIR Clinical Reasoning (ELM)</name>
   <description>Runtime support for CQL/ELM</description>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
     <relativePath>../cqf-fhir/pom.xml</relativePath>
   </parent>
 
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
   </dependencies>
 </project>

--- a/cqf-fhir-jackson/pom.xml
+++ b/cqf-fhir-jackson/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.cql</groupId>
   <artifactId>evaluator.jackson-deps</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <packaging>pom</packaging>
 
 
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.opencds.cqf.cql</groupId>
     <artifactId>evaluator.shared</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
   </parent>
 
   <dependencies>

--- a/cqf-fhir-jaxb/pom.xml
+++ b/cqf-fhir-jaxb/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.cql</groupId>
   <artifactId>evaluator.jaxb-deps</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <packaging>pom</packaging>
 
   <name>evaluator.jaxb-deps</name>
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.opencds.cqf.cql</groupId>
     <artifactId>evaluator.shared</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
   </parent>
 
   <dependencies>

--- a/cqf-fhir-test/pom.xml
+++ b/cqf-fhir-test/pom.xml
@@ -5,14 +5,14 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-test</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <name>FHIR Clinical Reasoning (Test Utilities)</name>
   <description>Utilities to support unit testing clinical reasoning operations</description>
 
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
     <relativePath>../cqf-fhir/pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
   </dependencies>
 </project>

--- a/cqf-fhir-utility/pom.xml
+++ b/cqf-fhir-utility/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-utility</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
 
   <name>FHIR Clinical Reasoning (Utilities)</name>
   <description>Utilities to help develop clinical reasoning operations</description>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
     <relativePath>../cqf-fhir/pom.xml</relativePath>
   </parent>
 

--- a/cqf-fhir/pom.xml
+++ b/cqf-fhir/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <packaging>pom</packaging>
   <name>FHIR Clinical Reasoning</name>
   <description>FHIR Clinical Reasoning Implementations</description>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>docs</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
 
   <name>FHIR Clinical Reasoning (Documentation)</name>
   <description>Documentation website for FHIR Clinical Reasoning</description>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
     <relativePath>../cqf-fhir/pom.xml</relativePath>
   </parent>
 

--- a/evaluator.activitydefinition/pom.xml
+++ b/evaluator.activitydefinition/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.cql</groupId>
   <artifactId>evaluator.activitydefinition</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <packaging>jar</packaging>
 
   <name>evaluator.activitydefinition</name>
@@ -14,29 +14,29 @@
   <parent>
     <groupId>org.opencds.cqf.cql</groupId>
     <artifactId>evaluator.shared</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.fhir</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.library</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.builder</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
 
     <dependency>

--- a/evaluator.builder/pom.xml
+++ b/evaluator.builder/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.cql</groupId>
   <artifactId>evaluator.builder</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <packaging>jar</packaging>
 
   <name>evaluator.builder</name>
@@ -14,24 +14,24 @@
   <parent>
     <groupId>org.opencds.cqf.cql</groupId>
     <artifactId>evaluator.shared</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.fhir</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.fhir-npm</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>

--- a/evaluator.cli/pom.xml
+++ b/evaluator.cli/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.cql</groupId>
   <artifactId>evaluator.cli</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <packaging>jar</packaging>
 
   <name>evaluator.cli</name>
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.opencds.cqf.cql</groupId>
     <artifactId>evaluator.shared</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
   </parent>
 
   <description>CQL Evaluator - CLI</description>
@@ -23,17 +23,17 @@
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.builder</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.jackson-deps</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
       <type>pom</type>
     </dependency>
     <dependency>

--- a/evaluator.cli/src/main/java/org/opencds/cqf/cql/evaluator/cli/command/CqlCommand.java
+++ b/evaluator.cli/src/main/java/org/opencds/cqf/cql/evaluator/cli/command/CqlCommand.java
@@ -137,6 +137,11 @@ public class CqlCommand implements Callable<Integer> {
     public void logDebugMessage(LogCategory logCategory, String s) {
       log.debug("{}: {}", logCategory, s);
     }
+
+    @Override
+    public boolean isDebugLogging() {
+      return log.isDebugEnabled();
+    }
   }
 
   private String toVersionNumber(FhirVersionEnum fhirVersion) {

--- a/evaluator.content-test/pom.xml
+++ b/evaluator.content-test/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.cql</groupId>
   <artifactId>evaluator.content-test</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <packaging>jar</packaging>
 
   <name>evaluator.content-test</name>
@@ -14,29 +14,29 @@
   <parent>
     <groupId>org.opencds.cqf.cql</groupId>
     <artifactId>evaluator.shared</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.fhir</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.builder</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.spring</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
 
     <dependency>
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.jackson-deps</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
       <type>pom</type>
     </dependency>
   </dependencies>

--- a/evaluator.content-test/src/test/java/org/opencds/cqf/cql/evaluator/content_test/opioid_mme_r4/OpioidMmeR4SpringTests.java
+++ b/evaluator.content-test/src/test/java/org/opencds/cqf/cql/evaluator/content_test/opioid_mme_r4/OpioidMmeR4SpringTests.java
@@ -57,7 +57,7 @@ public class OpioidMmeR4SpringTests extends AbstractTestNGSpringContextTests {
   }
 
   private String getSubject(Parameters parameters) {
-    StringType subject = (StringType) parameters.getParameter("subject");
+    StringType subject = (StringType) parameters.getParameter("subject").getValue();
 
     return subject.getValue().replace("Patient/", "");
   }

--- a/evaluator.expression/pom.xml
+++ b/evaluator.expression/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.cql</groupId>
   <artifactId>evaluator.expression</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <packaging>jar</packaging>
 
   <description>CQL Evaluator - Expression Evaluation</description>
@@ -13,34 +13,34 @@
   <parent>
     <groupId>org.opencds.cqf.cql</groupId>
     <artifactId>evaluator.shared</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.fhir</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.builder</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.library</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.jackson-deps</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
       <type>pom</type>
       <scope>test</scope>
     </dependency>

--- a/evaluator.fhir-npm/pom.xml
+++ b/evaluator.fhir-npm/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.cql</groupId>
   <artifactId>evaluator.fhir-npm</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <packaging>jar</packaging>
 
   <name>evaluator.fhir-npm</name>
@@ -14,19 +14,19 @@
   <parent>
     <groupId>org.opencds.cqf.cql</groupId>
     <artifactId>evaluator.shared</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.fhir</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
 
     <!-- Translator Dependencies -->

--- a/evaluator.fhir-npm/src/main/java/org/opencds/cqf/cql/evaluator/fhir/npm/LoggerAdapter.java
+++ b/evaluator.fhir-npm/src/main/java/org/opencds/cqf/cql/evaluator/fhir/npm/LoggerAdapter.java
@@ -17,6 +17,11 @@ public class LoggerAdapter implements IWorkerContext.ILoggingService {
 
   @Override
   public void logDebugMessage(LogCategory logCategory, String s) {
-    innerLogger.debug(String.format("%s: %s", logCategory.toString(), s));
+    innerLogger.debug("{}: {}", logCategory, s);
+  }
+
+  @Override
+  public boolean isDebugLogging() {
+    return this.innerLogger.isDebugEnabled();
   }
 }

--- a/evaluator.fhir/pom.xml
+++ b/evaluator.fhir/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.cql</groupId>
   <artifactId>evaluator.fhir</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <packaging>jar</packaging>
 
   <name>evaluator.fhir</name>
@@ -14,24 +14,24 @@
   <parent>
     <groupId>org.opencds.cqf.cql</groupId>
     <artifactId>evaluator.shared</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-utility</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <!-- Engine Dependencies for FHIR -->
     <dependency>

--- a/evaluator.fhir/src/test/java/org/opencds/cqf/cql/evaluator/fhir/util/r4/ParametersTest.java
+++ b/evaluator.fhir/src/test/java/org/opencds/cqf/cql/evaluator/fhir/util/r4/ParametersTest.java
@@ -67,80 +67,80 @@ class ParametersTest {
             urlPart("r4UrlPart", "https://example.com"),
             uuidPart("r4UuidPart", "urn:uuid:c757873d-ec9a-4326-a141-556f43239520"));
 
-    Type r4Type = parameters.getParameter("r4Base64BinaryPart");
+    Type r4Type = parameters.getParameter("r4Base64BinaryPart").getValue();
     assertTrue(r4Type instanceof Base64BinaryType);
     assertEquals("SGVsbG8gV29ybGQh", ((Base64BinaryType) r4Type).getValueAsString());
 
-    r4Type = parameters.getParameter("r4BooleanPart");
+    r4Type = parameters.getParameter("r4BooleanPart").getValue();
     assertTrue(r4Type instanceof BooleanType);
     assertTrue(((BooleanType) r4Type).getValue());
 
-    r4Type = parameters.getParameter("r4CanonicalPart");
+    r4Type = parameters.getParameter("r4CanonicalPart").getValue();
     assertTrue(r4Type instanceof CanonicalType);
     assertEquals("https://example.com/Library/example-library",
         ((CanonicalType) r4Type).getValueAsString());
 
-    r4Type = parameters.getParameter("r4CodePart");
+    r4Type = parameters.getParameter("r4CodePart").getValue();
     assertTrue(r4Type instanceof CodeType);
     assertEquals("active", ((CodeType) r4Type).getValueAsString());
 
-    r4Type = parameters.getParameter("r4DatePart");
+    r4Type = parameters.getParameter("r4DatePart").getValue();
     assertTrue(r4Type instanceof DateType);
     assertEquals("2012-12-31", ((DateType) r4Type).getValueAsString());
 
-    r4Type = parameters.getParameter("r4DateTimePart");
+    r4Type = parameters.getParameter("r4DateTimePart").getValue();
     assertTrue(r4Type instanceof DateTimeType);
     assertEquals("2015-02-07T13:28:17-05:00", ((DateTimeType) r4Type).getValueAsString());
 
-    r4Type = parameters.getParameter("r4DecimalPart");
+    r4Type = parameters.getParameter("r4DecimalPart").getValue();
     assertTrue(r4Type instanceof DecimalType);
     assertEquals("72.42", ((DecimalType) r4Type).getValueAsString());
 
-    r4Type = parameters.getParameter("r4IdPart");
+    r4Type = parameters.getParameter("r4IdPart").getValue();
     assertTrue(r4Type instanceof IdType);
     assertEquals("example-id", ((IdType) r4Type).getValueAsString());
 
-    r4Type = parameters.getParameter("r4InstantPart");
+    r4Type = parameters.getParameter("r4InstantPart").getValue();
     assertTrue(r4Type instanceof InstantType);
     assertEquals("2015-02-07T13:28:17.239+02:00", ((InstantType) r4Type).getValueAsString());
 
-    r4Type = parameters.getParameter("r4IntegerPart");
+    r4Type = parameters.getParameter("r4IntegerPart").getValue();
     assertTrue(r4Type instanceof IntegerType);
     assertEquals((Integer) 72, ((IntegerType) r4Type).getValue());
 
-    r4Type = parameters.getParameter("r4MarkdownPart");
+    r4Type = parameters.getParameter("r4MarkdownPart").getValue();
     assertTrue(r4Type instanceof MarkdownType);
     assertEquals("## Markdown Title", ((MarkdownType) r4Type).getValueAsString());
 
-    r4Type = parameters.getParameter("r4OidPart");
+    r4Type = parameters.getParameter("r4OidPart").getValue();
     assertTrue(r4Type instanceof OidType);
     assertEquals("urn:oid:1.2.3.4.5", ((OidType) r4Type).getValueAsString());
 
-    r4Type = parameters.getParameter("r4PositiveIntPart");
+    r4Type = parameters.getParameter("r4PositiveIntPart").getValue();
     assertTrue(r4Type instanceof PositiveIntType);
     assertEquals((Integer) 1, ((PositiveIntType) r4Type).getValue());
 
-    r4Type = parameters.getParameter("r4StringPart");
+    r4Type = parameters.getParameter("r4StringPart").getValue();
     assertTrue(r4Type instanceof StringType);
     assertEquals("example string", ((StringType) r4Type).getValueAsString());
 
-    r4Type = parameters.getParameter("r4TimePart");
+    r4Type = parameters.getParameter("r4TimePart").getValue();
     assertTrue(r4Type instanceof TimeType);
     assertEquals("12:30:30.500", ((TimeType) r4Type).getValueAsString());
 
-    r4Type = parameters.getParameter("r4UnsignedIntPart");
+    r4Type = parameters.getParameter("r4UnsignedIntPart").getValue();
     assertTrue(r4Type instanceof UnsignedIntType);
     assertEquals((Integer) 0, ((UnsignedIntType) r4Type).getValue());
 
-    r4Type = parameters.getParameter("r4UriPart");
+    r4Type = parameters.getParameter("r4UriPart").getValue();
     assertTrue(r4Type instanceof UriType);
     assertEquals("s:comp.infosystems.www.servers.unix", ((UriType) r4Type).getValueAsString());
 
-    r4Type = parameters.getParameter("r4UrlPart");
+    r4Type = parameters.getParameter("r4UrlPart").getValue();
     assertTrue(r4Type instanceof UrlType);
     assertEquals("https://example.com", ((UrlType) r4Type).getValueAsString());
 
-    r4Type = parameters.getParameter("r4UuidPart");
+    r4Type = parameters.getParameter("r4UuidPart").getValue();
     assertTrue(r4Type instanceof UuidType);
     assertEquals("urn:uuid:c757873d-ec9a-4326-a141-556f43239520",
         ((UuidType) r4Type).getValueAsString());

--- a/evaluator.fhir/src/test/java/org/opencds/cqf/cql/evaluator/fhir/util/r5/ParametersTest.java
+++ b/evaluator.fhir/src/test/java/org/opencds/cqf/cql/evaluator/fhir/util/r5/ParametersTest.java
@@ -49,91 +49,92 @@ class ParametersTest {
         urlPart("r5UrlPart", "https://example.com"),
         uuidPart("r5UuidPart", "urn:uuid:c757873d-ec9a-4326-a141-556f43239520"));
 
-    org.hl7.fhir.r5.model.DataType r5Type = parameters.getParameter("r5Base64BinaryPart");
+    org.hl7.fhir.r5.model.DataType r5Type =
+        parameters.getParameter("r5Base64BinaryPart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.Base64BinaryType);
     assertEquals("SGVsbG8gV29ybGQh",
         ((org.hl7.fhir.r5.model.Base64BinaryType) r5Type).getValueAsString());
 
-    r5Type = parameters.getParameter("r5BooleanPart");
+    r5Type = parameters.getParameter("r5BooleanPart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.BooleanType);
     assertTrue(((org.hl7.fhir.r5.model.BooleanType) r5Type).getValue());
 
-    r5Type = parameters.getParameter("r5CanonicalPart");
+    r5Type = parameters.getParameter("r5CanonicalPart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.CanonicalType);
     assertEquals("https://example.com/Library/example-library",
         ((org.hl7.fhir.r5.model.CanonicalType) r5Type).getValueAsString());
 
-    r5Type = parameters.getParameter("r5CodePart");
+    r5Type = parameters.getParameter("r5CodePart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.CodeType);
     assertEquals("active", ((org.hl7.fhir.r5.model.CodeType) r5Type).getValueAsString());
 
-    r5Type = parameters.getParameter("r5DatePart");
+    r5Type = parameters.getParameter("r5DatePart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.DateType);
     assertEquals("2012-12-31", ((org.hl7.fhir.r5.model.DateType) r5Type).getValueAsString());
 
-    r5Type = parameters.getParameter("r5DateTimePart");
+    r5Type = parameters.getParameter("r5DateTimePart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.DateTimeType);
     assertEquals("2015-02-07T13:28:17-05:00",
         ((org.hl7.fhir.r5.model.DateTimeType) r5Type).getValueAsString());
 
-    r5Type = parameters.getParameter("r5DecimalPart");
+    r5Type = parameters.getParameter("r5DecimalPart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.DecimalType);
     assertEquals("72.42", ((org.hl7.fhir.r5.model.DecimalType) r5Type).getValueAsString());
 
-    r5Type = parameters.getParameter("r5IdPart");
+    r5Type = parameters.getParameter("r5IdPart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.IdType);
     assertEquals("example-id", ((org.hl7.fhir.r5.model.IdType) r5Type).getValueAsString());
 
-    r5Type = parameters.getParameter("r5InstantPart");
+    r5Type = parameters.getParameter("r5InstantPart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.InstantType);
     assertEquals("2015-02-07T13:28:17.239+02:00",
         ((org.hl7.fhir.r5.model.InstantType) r5Type).getValueAsString());
 
-    r5Type = parameters.getParameter("r5IntegerPart");
+    r5Type = parameters.getParameter("r5IntegerPart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.IntegerType);
     assertEquals((Integer) 72, ((org.hl7.fhir.r5.model.IntegerType) r5Type).getValue());
 
-    r5Type = parameters.getParameter("r5Integer64Part");
+    r5Type = parameters.getParameter("r5Integer64Part").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.Integer64Type);
     assertEquals((Long) 9223372036854775807L,
         ((org.hl7.fhir.r5.model.Integer64Type) r5Type).getValue());
 
-    r5Type = parameters.getParameter("r5MarkdownPart");
+    r5Type = parameters.getParameter("r5MarkdownPart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.MarkdownType);
     assertEquals("## Markdown Title",
         ((org.hl7.fhir.r5.model.MarkdownType) r5Type).getValueAsString());
 
-    r5Type = parameters.getParameter("r5OidPart");
+    r5Type = parameters.getParameter("r5OidPart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.OidType);
     assertEquals("urn:oid:1.2.3.4.5", ((org.hl7.fhir.r5.model.OidType) r5Type).getValueAsString());
 
-    r5Type = parameters.getParameter("r5PositiveIntPart");
+    r5Type = parameters.getParameter("r5PositiveIntPart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.PositiveIntType);
     assertEquals((Integer) 1, ((org.hl7.fhir.r5.model.PositiveIntType) r5Type).getValue());
 
-    r5Type = parameters.getParameter("r5StringPart");
+    r5Type = parameters.getParameter("r5StringPart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.StringType);
     assertEquals("example string", ((org.hl7.fhir.r5.model.StringType) r5Type).getValueAsString());
 
-    r5Type = parameters.getParameter("r5TimePart");
+    r5Type = parameters.getParameter("r5TimePart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.TimeType);
     assertEquals("12:30:30.500", ((org.hl7.fhir.r5.model.TimeType) r5Type).getValueAsString());
 
-    r5Type = parameters.getParameter("r5UnsignedIntPart");
+    r5Type = parameters.getParameter("r5UnsignedIntPart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.UnsignedIntType);
     assertEquals((Integer) 0, ((org.hl7.fhir.r5.model.UnsignedIntType) r5Type).getValue());
 
-    r5Type = parameters.getParameter("r5UriPart");
+    r5Type = parameters.getParameter("r5UriPart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.UriType);
     assertEquals("s:comp.infosystems.www.servers.unix",
         ((org.hl7.fhir.r5.model.UriType) r5Type).getValueAsString());
 
-    r5Type = parameters.getParameter("r5UrlPart");
+    r5Type = parameters.getParameter("r5UrlPart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.UrlType);
     assertEquals("https://example.com",
         ((org.hl7.fhir.r5.model.UrlType) r5Type).getValueAsString());
 
-    r5Type = parameters.getParameter("r5UuidPart");
+    r5Type = parameters.getParameter("r5UuidPart").getValue();
     assertTrue(r5Type instanceof org.hl7.fhir.r5.model.UuidType);
     assertEquals("urn:uuid:c757873d-ec9a-4326-a141-556f43239520",
         ((org.hl7.fhir.r5.model.UuidType) r5Type).getValueAsString());

--- a/evaluator.library/pom.xml
+++ b/evaluator.library/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.cql</groupId>
   <artifactId>evaluator.library</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <packaging>jar</packaging>
 
   <name>evaluator.library</name>
@@ -14,29 +14,29 @@
   <parent>
     <groupId>org.opencds.cqf.cql</groupId>
     <artifactId>evaluator.shared</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.fhir</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.builder</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.jackson-deps</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
       <type>pom</type>
       <scope>test</scope>
     </dependency>

--- a/evaluator.measure-hapi/pom.xml
+++ b/evaluator.measure-hapi/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.cql</groupId>
   <artifactId>evaluator.measure-hapi</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <packaging>jar</packaging>
 
   <description>CQL Evaluator - Measure Evaluation for HAPI FHIR</description>
@@ -13,48 +13,48 @@
   <parent>
     <groupId>org.opencds.cqf.cql</groupId>
     <artifactId>evaluator.shared</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.fhir</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.measure</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.builder</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.jackson-deps</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
       <type>pom</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-utility</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/evaluator.measure/pom.xml
+++ b/evaluator.measure/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.cql</groupId>
   <artifactId>evaluator.measure</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <packaging>jar</packaging>
 
   <description>CQL Evaluator - Measure Evaluation</description>
@@ -13,14 +13,14 @@
   <parent>
     <groupId>org.opencds.cqf.cql</groupId>
     <artifactId>evaluator.shared</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
   </dependencies>
 </project>

--- a/evaluator.plandefinition/pom.xml
+++ b/evaluator.plandefinition/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.cql</groupId>
   <artifactId>evaluator.plandefinition</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <packaging>jar</packaging>
 
   <name>evaluator.plandefinition</name>
@@ -14,55 +14,55 @@
   <parent>
     <groupId>org.opencds.cqf.cql</groupId>
     <artifactId>evaluator.shared</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.activitydefinition</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.expression</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.fhir</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.library</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.builder</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.questionnaire</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.questionnaireresponse</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.jackson-deps</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
       <type>pom</type>
       <scope>test</scope>
     </dependency>

--- a/evaluator.plandefinition/src/main/java/org/opencds/cqf/cql/evaluator/plandefinition/BasePlanDefinitionProcessor.java
+++ b/evaluator.plandefinition/src/main/java/org/opencds/cqf/cql/evaluator/plandefinition/BasePlanDefinitionProcessor.java
@@ -35,6 +35,9 @@ public abstract class BasePlanDefinitionProcessor<T> {
   protected static final String REQUEST_GROUP_EXT =
       "http://fl7.org/fhir/StructureDefinition/RequestGroup-Goal";
 
+  protected static final String REQUEST_ORCHESTRATION_EXT =
+      "http://fl7.org/fhir/StructureDefinition/RequestOrchestration-Goal";
+
   protected static final String subjectType = "Patient";
 
   protected final OperationParametersParser operationParametersParser;

--- a/evaluator.plandefinition/src/test/java/org/opencds/cqf/cql/evaluator/plandefinition/dstu3/PlanDefinitionProcessorTests.java
+++ b/evaluator.plandefinition/src/test/java/org/opencds/cqf/cql/evaluator/plandefinition/dstu3/PlanDefinitionProcessorTests.java
@@ -9,7 +9,7 @@ import org.opencds.cqf.cql.evaluator.fhir.repository.dstu3.FhirRepository;
 import org.opencds.cqf.cql.evaluator.fhir.util.Repositories;
 import org.testng.annotations.Test;
 
-public class PlanDefinitionProcessorTests extends PlanDefinition {
+public class PlanDefinitionProcessorTests {
   @Test
   public void testChildRoutineVisit() {
     PlanDefinition.Assert

--- a/evaluator.plandefinition/src/test/java/org/opencds/cqf/cql/evaluator/plandefinition/r4/PlanDefinitionProcessorTests.java
+++ b/evaluator.plandefinition/src/test/java/org/opencds/cqf/cql/evaluator/plandefinition/r4/PlanDefinitionProcessorTests.java
@@ -11,7 +11,7 @@ import org.opencds.cqf.cql.evaluator.fhir.util.Repositories;
 import org.opencds.cqf.fhir.api.Repository;
 import org.testng.annotations.Test;
 
-public class PlanDefinitionProcessorTests extends PlanDefinition {
+public class PlanDefinitionProcessorTests {
   private Repository createRepositoryForPath(String path) {
     var data = new FhirRepository(this.getClass(), List.of(path + "/tests"), false);
     var content = new FhirRepository(this.getClass(), List.of(path + "/content"), false);
@@ -54,9 +54,11 @@ public class PlanDefinitionProcessorTests extends PlanDefinition {
     var encounterID = "Encounter/helloworld-patient-1-encounter-1";
     var repository = createRepositoryForPath("anc-dak");
     var parameters = parameters(part("encounter", "helloworld-patient-1-encounter-1"));
-    PlanDefinition.Assert.that(planDefinitionID, patientID, encounterID).withRepository(repository).withParameters(parameters)
+    PlanDefinition.Assert.that(planDefinitionID, patientID, encounterID).withRepository(repository)
+        .withParameters(parameters)
         .apply().isEqualsTo("anc-dak/tests/CarePlan-ANCDT17.json");
-    PlanDefinition.Assert.that(planDefinitionID, patientID, encounterID).withRepository(repository).withParameters(parameters)
+    PlanDefinition.Assert.that(planDefinitionID, patientID, encounterID).withRepository(repository)
+        .withParameters(parameters)
         .applyR5().isEqualsTo("anc-dak/tests/Bundle-ANCDT17.json");
   }
 

--- a/evaluator.plandefinition/src/test/java/org/opencds/cqf/cql/evaluator/plandefinition/r5/PlanDefinitionProcessorTests.java
+++ b/evaluator.plandefinition/src/test/java/org/opencds/cqf/cql/evaluator/plandefinition/r5/PlanDefinitionProcessorTests.java
@@ -10,7 +10,7 @@ import org.opencds.cqf.cql.evaluator.fhir.repository.r5.FhirRepository;
 import org.opencds.cqf.cql.evaluator.fhir.util.Repositories;
 import org.testng.annotations.Test;
 
-public class PlanDefinitionProcessorTests extends PlanDefinition {
+public class PlanDefinitionProcessorTests {
 
   @Test()
   public void testChildRoutineVisit() {

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/child-routine-visit/child_routine_visit_bundle.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/child-routine-visit/child_routine_visit_bundle.json
@@ -5,11 +5,11 @@
   "entry": [
     {
       "resource": {
-        "resourceType": "RequestGroup",
+        "resourceType": "RequestOrchestration",
         "id": "ChildRoutineVisit-PlanDefinition-1.0.0",
         "extension": [
           {
-            "url": "http://fl7.org/fhir/StructureDefinition/RequestGroup-Goal",
+            "url": "http://fl7.org/fhir/StructureDefinition/RequestOrchestration-Goal",
             "valueReference": {
               "reference": "Goal/1"
             }

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/extract-questionnaireresponse/bundle.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/extract-questionnaireresponse/bundle.json
@@ -5,7 +5,7 @@
   "entry": [
     {
       "resource": {
-        "resourceType": "RequestGroup",
+        "resourceType": "RequestOrchestration",
         "id": "prepopulate",
         "instantiatesCanonical": [
           "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/prepopulate"

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/hello-world/hello-world-bundle.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/hello-world/hello-world-bundle.json
@@ -4,7 +4,7 @@
   "entry": [
     {
       "resource": {
-        "resourceType": "RequestGroup",
+        "resourceType": "RequestOrchestration",
         "id": "hello-world-patient-view",
         "instantiatesCanonical": [
           "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/hello-world-patient-view"

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/opioid-Rec10-patient-view/tests/Bundle-opioid-Rec10-patient-view.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/opioid-Rec10-patient-view/tests/Bundle-opioid-Rec10-patient-view.json
@@ -5,7 +5,7 @@
   "entry": [
     {
       "resource": {
-        "resourceType": "RequestGroup",
+        "resourceType": "RequestOrchestration",
         "id": "opioidcds-10-patient-view",
         "instantiatesCanonical": [
           "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/opioidcds-10-patient-view"

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/prepopulate/prepopulate-bundle-noLibrary.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/prepopulate/prepopulate-bundle-noLibrary.json
@@ -4,7 +4,7 @@
   "entry": [
     {
       "resource": {
-        "resourceType": "RequestGroup",
+        "resourceType": "RequestOrchestration",
         "id": "prepopulate",
         "instantiatesCanonical": [
           "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/prepopulate"
@@ -682,8 +682,8 @@
         "id": "complete-questionnaire",
         "basedOn": [
           {
-            "reference": "RequestGroup/prepopulate",
-            "type": "RequestGroup"
+            "reference": "RequestOrchestration/prepopulate",
+            "type": "RequestOrchestration"
           }
         ],
         "status": "draft",

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/prepopulate/prepopulate-bundle.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/prepopulate/prepopulate-bundle.json
@@ -4,7 +4,7 @@
   "entry": [
     {
       "resource": {
-        "resourceType": "RequestGroup",
+        "resourceType": "RequestOrchestration",
         "id": "prepopulate",
         "instantiatesCanonical": [
           "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/prepopulate"
@@ -682,8 +682,8 @@
         "id": "complete-questionnaire",
         "basedOn": [
           {
-            "reference": "RequestGroup/prepopulate",
-            "type": "RequestGroup"
+            "reference": "RequestOrchestration/prepopulate",
+            "type": "RequestOrchestration"
           }
         ],
         "status": "draft",

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/rule-filters/NotReportableBundle.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/rule-filters/NotReportableBundle.json
@@ -4,7 +4,7 @@
   "entry": [
     {
       "resource": {
-        "resourceType": "RequestGroup",
+        "resourceType": "RequestOrchestration",
         "id": "plandefinition-RuleFilters-1.0.0",
         "instantiatesCanonical": [
           "http://hl7.org/fhir/us/ecr/PlanDefinition/plandefinition-RuleFilters-1.0.0"
@@ -104,7 +104,7 @@
         ],
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "ready",
@@ -290,7 +290,7 @@
         ],
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",
@@ -341,7 +341,7 @@
         ],
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",
@@ -354,7 +354,7 @@
         "id": "check-reportable",
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",
@@ -380,7 +380,7 @@
         ],
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",
@@ -431,7 +431,7 @@
         ],
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",
@@ -482,7 +482,7 @@
         ],
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",
@@ -495,7 +495,7 @@
         "id": "create-and-report-eicr",
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",
@@ -521,7 +521,7 @@
         ],
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",
@@ -547,7 +547,7 @@
         ],
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",
@@ -560,7 +560,7 @@
         "id": "route-and-send-eicr",
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/rule-filters/ReportableBundle.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/rule-filters/ReportableBundle.json
@@ -4,7 +4,7 @@
   "entry": [
     {
       "resource": {
-        "resourceType": "RequestGroup",
+        "resourceType": "RequestOrchestration",
         "id": "plandefinition-RuleFilters-1.0.0",
         "instantiatesCanonical": [
           "http://hl7.org/fhir/us/ecr/PlanDefinition/plandefinition-RuleFilters-1.0.0"
@@ -104,7 +104,7 @@
         ],
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "ready",
@@ -290,7 +290,7 @@
         ],
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",
@@ -341,7 +341,7 @@
         ],
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",
@@ -354,7 +354,7 @@
         "id": "check-reportable",
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",
@@ -380,7 +380,7 @@
         ],
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",
@@ -431,7 +431,7 @@
         ],
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",
@@ -482,7 +482,7 @@
         ],
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",
@@ -495,7 +495,7 @@
         "id": "create-and-report-eicr",
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",
@@ -521,7 +521,7 @@
         ],
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",
@@ -547,7 +547,7 @@
         ],
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",
@@ -560,7 +560,7 @@
         "id": "route-and-send-eicr",
         "basedOn": [
           {
-            "reference": "RequestGroup/plandefinition-RuleFilters-1.0.0"
+            "reference": "RequestOrchestration/plandefinition-RuleFilters-1.0.0"
           }
         ],
         "status": "draft",

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/tests/Bundle-extract-questionnaireresponse.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/tests/Bundle-extract-questionnaireresponse.json
@@ -5,7 +5,7 @@
   "entry": [
     {
       "resource": {
-        "resourceType": "RequestGroup",
+        "resourceType": "RequestOrchestration",
         "id": "prepopulate",
         "instantiatesCanonical": [
           "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/prepopulate"
@@ -739,8 +739,8 @@
         "id": "complete-questionnaire",
         "basedOn": [
           {
-            "reference": "RequestGroup/prepopulate",
-            "type": "RequestGroup"
+            "reference": "RequestOrchestration/prepopulate",
+            "type": "RequestOrchestration"
           }
         ],
         "status": "draft",

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/tests/Bundle-generate-questionnaire.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/tests/Bundle-generate-questionnaire.json
@@ -5,7 +5,7 @@
   "entry": [
     {
       "resource": {
-        "resourceType": "RequestGroup",
+        "resourceType": "RequestOrchestration",
         "id": "generate-questionnaire",
         "instantiatesCanonical": [
           "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/generate-questionnaire",
@@ -19,7 +19,7 @@
         "action": [
           {
             "resource": {
-              "reference": "RequestGroup/route-one"
+              "reference": "RequestOrchestration/route-one"
             }
           }
         ]
@@ -27,7 +27,7 @@
     },
     {
       "resource": {
-        "resourceType": "RequestGroup",
+        "resourceType": "RequestOrchestration",
         "id": "route-one",
         "instantiatesCanonical": [
           "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/route-one"

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/tests/Bundle-prepopulate-noLibrary.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/tests/Bundle-prepopulate-noLibrary.json
@@ -5,7 +5,7 @@
   "entry": [
     {
       "resource": {
-        "resourceType": "RequestGroup",
+        "resourceType": "RequestOrchestration",
         "id": "prepopulate-noLibrary",
         "instantiatesCanonical": [
           "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/prepopulate-noLibrary"
@@ -749,8 +749,8 @@
         "id": "complete-questionnaire",
         "basedOn": [
           {
-            "reference": "RequestGroup/prepopulate-noLibrary",
-            "type": "RequestGroup"
+            "reference": "RequestOrchestration/prepopulate-noLibrary",
+            "type": "RequestOrchestration"
           }
         ],
         "status": "draft",

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/tests/Bundle-prepopulate.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r5/tests/Bundle-prepopulate.json
@@ -5,7 +5,7 @@
   "entry": [
     {
       "resource": {
-        "resourceType": "RequestGroup",
+        "resourceType": "RequestOrchestration",
         "id": "prepopulate",
         "instantiatesCanonical": [
           "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/prepopulate"
@@ -739,8 +739,8 @@
         "id": "complete-questionnaire",
         "basedOn": [
           {
-            "reference": "RequestGroup/prepopulate",
-            "type": "RequestGroup"
+            "reference": "RequestOrchestration/prepopulate",
+            "type": "RequestOrchestration"
           }
         ],
         "status": "draft",

--- a/evaluator.questionnaire/pom.xml
+++ b/evaluator.questionnaire/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>evaluator.shared</artifactId>
     <groupId>org.opencds.cqf.cql</groupId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -13,17 +13,17 @@
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.fhir</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.expression</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.library</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.skyscreamer</groupId>
@@ -39,14 +39,14 @@
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.jackson-deps</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
       <type>pom</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.builder</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/evaluator.questionnaireresponse/pom.xml
+++ b/evaluator.questionnaireresponse/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>evaluator.shared</artifactId>
     <groupId>org.opencds.cqf.cql</groupId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -13,12 +13,12 @@
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.fhir</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.builder</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.skyscreamer</groupId>

--- a/evaluator.spring/pom.xml
+++ b/evaluator.spring/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.cql</groupId>
   <artifactId>evaluator.spring</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <packaging>jar</packaging>
 
   <name>evaluator.spring</name>
@@ -14,40 +14,40 @@
   <parent>
     <groupId>org.opencds.cqf.cql</groupId>
     <artifactId>evaluator.shared</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.builder</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.library</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.expression</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.measure</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.measure-hapi</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/evaluator/pom.xml
+++ b/evaluator/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.cql</groupId>
   <artifactId>evaluator</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <packaging>jar</packaging>
 
   <name>evaluator</name>
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.opencds.cqf.cql</groupId>
     <artifactId>evaluator.shared</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.PRE-1</version>
   </parent>
 
   <dependencies>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.opencds.cqf.cql</groupId>
       <artifactId>evaluator.jackson-deps</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
       <type>pom</type>
       <scope>test</scope>
     </dependency>
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0.PRE-1</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.cql</groupId>
   <artifactId>evaluator.shared</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0.PRE-1</version>
   <packaging>pom</packaging>
 
   <name>evaluator.shared</name>
@@ -15,12 +15,12 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <cql.version>2.7.0-SNAPSHOT</cql.version>
-    <spring.version>5.3.19</spring.version>
-    <fhir-core.version>5.6.68</fhir-core.version>
-    <hapi.version>6.2.1</hapi.version>
+    <cql.version>2.7.0</cql.version>
+    <spring.version>5.3.23</spring.version>
+    <fhir-core.version>5.6.971</fhir-core.version>
+    <hapi.version>6.4.4</hapi.version>
     <picocli.version>4.6.1</picocli.version>
-    <slf4j.version>1.7.29</slf4j.version>
+    <slf4j.version>2.0.3</slf4j.version>
     <caffeine.version>2.9.0</caffeine.version>
     <org.mapstruct.version>1.4.2.Final</org.mapstruct.version>
     <guava.version>31.0.1-jre</guava.version>


### PR DESCRIPTION
* Update version to 3.0.0.PRE-1 release
* Update relevant HAPI/FHIR Core dependencies
* Fixes needed due to those updates

NOTE: the tag for this release should be `v3.0.0.PRE-1` when we do the release. Post release we should revert the version to `3.0.0-SNAPSHOT`.