### PR TITLE
Issue with namespace info being lost when Libraries are recompiled 

### DIFF
--- a/evaluator.plandefinition/src/test/java/org/opencds/cqf/cql/evaluator/plandefinition/r4/PlanDefinitionProcessorTests.java
+++ b/evaluator.plandefinition/src/test/java/org/opencds/cqf/cql/evaluator/plandefinition/r4/PlanDefinitionProcessorTests.java
@@ -62,6 +62,20 @@ public class PlanDefinitionProcessorTests {
         .applyR5().isEqualsTo("anc-dak/tests/Bundle-ANCDT17.json");
   }
 
+  @Test
+  public void testANCDT17WithElm() {
+    PlanDefinition.Assert.that(
+            "ANCDT17",
+            "Patient/5946f880-b197-400b-9caa-a3c661d23041",
+            "Encounter/ANCDT17-encounter"
+        )
+        .withData("anc-dak/data-bundle.json")
+        .withContent("anc-dak/content-bundle.json")
+        .withTerminology("anc-dak/terminology-bundle.json")
+        .apply()
+        .isEqualsTo("anc-dak/output-careplan.json");
+  }
+
   @Test(enabled = false) // Need patient data to test this
   public void testECRWithFhirPath() {
     var planDefinitionID = "us-ecr-specification";

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r4/anc-dak/data-bundle.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r4/anc-dak/data-bundle.json
@@ -1,0 +1,236 @@
+{
+	"resourceType": "Bundle",
+	"id": "1b36355c-ee52-4d1a-ae06-45c6f08380td",
+	"meta": {
+		"versionId": "9b2459d6-ffa8-4ecb-97e5-7bf0fac15e87",
+		"lastUpdated": "2020-12-23T14:39:37.969+00:00",
+		"profile": [
+			"https://fhir.hl7.org.uk/StructureDefinition/UKCore-Bundle"
+		]
+	},
+	"type": "message",
+	"entry": [{
+			"resource": {
+				"resourceType": "Observation",
+				"id": "anc-b8-de17-example",
+				"meta": {
+					"profile": ["http://fhir.org/guides/who/anc-cds/StructureDefinition/anc-b8-de17"]
+				},
+				"identifier": [{
+					"use": "official",
+					"system": "http://example.org/fhir/NamingSystem/identifiers",
+					"value": "anc-b8-de17-example"
+				}],
+				"status": "final",
+				"code": {
+					"coding": [{
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"code": "ANC.B8.DE17",
+						"display": "Systolic blood pressure"
+					}, {
+						"system": "http://snomed.info/sct",
+						"code": "271649006",
+						"display": "Systolic blood pressure (observable entity)"
+					}, {
+						"system": "http://loinc.org",
+						"code": "8480-6",
+						"display": "Systolic blood pressure"
+					}, {
+						"system": "http://hl7.org/fhir/sid/icf-nl",
+						"code": "b4209",
+						"display": "Blood pressure functions, unspecified"
+					}]
+				},
+				"subject": {
+					"reference": "Patient/5946f880-b197-400b-9caa-a3c661d23041"
+				},
+				"encounter": {
+					"reference": "Encounter/ANCDT17-encounter"
+				},
+				"performer": [{
+					"reference": "PractitionerRole/anc-practitionerrole-example"
+				}],
+				"valueQuantity": {
+					"value": 160,
+					"system": "http://unitsofmeasure.org",
+					"code": "mm[Hg]"
+				}
+			}
+		},
+		{
+			"resource": {
+				"resourceType": "Observation",
+				"id": "anc-b8-de20-example",
+				"meta": {
+					"profile": ["http://fhir.org/guides/who/anc-cds/StructureDefinition/anc-b8-de20"]
+				},
+				"identifier": [{
+					"use": "official",
+					"system": "http://example.org/fhir/NamingSystem/identifiers",
+					"value": "anc-b8-de20-example"
+				}],
+				"status": "final",
+				"code": {
+					"coding": [{
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"code": "ANC.B8.DE20",
+						"display": "Repeat systolic blood pressure"
+					}, {
+						"system": "http://snomed.info/sct",
+						"code": "271649006",
+						"display": "Systolic blood pressure (observable entity)"
+					}, {
+						"system": "http://loinc.org",
+						"code": "8480-6",
+						"display": "Systolic blood pressure"
+					}, {
+						"system": "http://hl7.org/fhir/sid/icf-nl",
+						"code": "b4209",
+						"display": "Blood pressure functions, unspecified"
+					}]
+				},
+				"subject": {
+					"reference": "Patient/5946f880-b197-400b-9caa-a3c661d23041"
+				},
+				"encounter": {
+					"reference": "Encounter/ANCDT17-encounter"
+				},
+				"performer": [{
+					"reference": "PractitionerRole/anc-practitionerrole-example"
+				}],
+				"valueQuantity": {
+					"value": 160,
+					"system": "http://unitsofmeasure.org",
+					"code": "mm[Hg]"
+				}
+			}
+		},
+		{
+			"resource": {
+				"resourceType": "Observation",
+				"id": "anc-b8-de27-example",
+				"meta": {
+					"profile": ["http://fhir.org/guides/who/anc-cds/StructureDefinition/anc-b8-de27"]
+				},
+				"identifier": [{
+					"use": "official",
+					"system": "http://example.org/fhir/NamingSystem/identifiers",
+					"value": "anc-b8-de27-example"
+				}],
+				"status": "final",
+				"code": {
+					"coding": [{
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"code": "ANC.B8.DE27",
+						"display": "Symptoms of severe pre-eclampsia"
+					}]
+				},
+				"subject": {
+					"reference": "Patient/5946f880-b197-400b-9caa-a3c661d23041"
+				},
+				"encounter": {
+					"reference": "Encounter/ANCDT17-encounter"
+				},
+				"performer": [{
+					"reference": "PractitionerRole/anc-practitionerrole-example"
+				}],
+				"valueCodeableConcept": {
+					"coding": [{
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"code": "ANC.B8.DE29",
+						"display": "Vomiting"
+					}]
+				}
+			}
+		},
+		{
+			"resource": {
+				"resourceType": "Observation",
+				"id": "anc-b9-de144-example",
+				"meta": {
+					"profile": ["http://fhir.org/guides/who/anc-cds/StructureDefinition/anc-b9-de144"]
+				},
+				"identifier": [{
+					"use": "official",
+					"system": "http://example.org/fhir/NamingSystem/identifiers",
+					"value": "anc-b9-de144-example"
+				}],
+				"status": "final",
+				"code": {
+					"coding": [{
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"code": "ANC.B9.DE144",
+						"display": "Urine dipstick result - protein"
+					}]
+				},
+				"subject": {
+					"reference": "Patient/5946f880-b197-400b-9caa-a3c661d23041"
+				},
+				"encounter": {
+					"reference": "Encounter/ANCDT17-encounter"
+				},
+				"performer": [{
+					"reference": "PractitionerRole/anc-practitionerrole-example"
+				}],
+				"valueCodeableConcept": {
+					"coding": [{
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"code": "ANC.B9.DE146",
+						"display": "+"
+					}]
+				}
+			}
+		},
+		{
+			"resource": {
+				"resourceType": "Encounter",
+				"id": "ANCDT17-encounter",
+				"meta": {
+					"profile": ["http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"]
+				},
+				"status": "finished",
+				"class": {
+					"system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+					"code": "AMB",
+					"display": "ambulatory"
+				},
+				"type": [{
+					"coding": [{
+						"system": "http://snomed.info/sct",
+						"version": "2020-09",
+						"code": "185463005",
+						"display": "Visit out of hours (procedure)"
+					}]
+				}],
+				"subject": {
+					"reference": "Patient/5946f880-b197-400b-9caa-a3c661d23041"
+				},
+				"period": {
+					"start": "2020-01-01T10:00:00-07:00",
+					"end": "2020-01-01T11:00:00-07:00"
+				}
+			},
+			"request": {
+				"method": "PUT",
+				"url": "Encounter/ANCDT17-encounter"
+			}
+		},
+		{
+		     "resource": {
+		        "resourceType": "Patient",
+		        "id": "Patient/5946f880-b197-400b-9caa-a3c661d23041",
+		        "active": true,
+		        "name": [
+		          {
+		            "family": "Hadi",
+		            "given": [
+		              "Bareera"
+		            ]
+		          }
+		        ],
+		        "gender": "female",
+		        "birthDate": "1999-01-14"
+	      	}
+      	}
+]
+}

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r4/anc-dak/output-careplan.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r4/anc-dak/output-careplan.json
@@ -1,0 +1,61 @@
+{
+  "resourceType": "CarePlan",
+  "id": "ANCDT17",
+  "contained": [ {
+    "resourceType": "RequestGroup",
+    "id": "ANCDT17",
+    "instantiatesCanonical": [ "http://fhir.org/guides/who/anc-cds/PlanDefinition/ANCDT17" ],
+    "status": "draft",
+    "intent": "proposal",
+    "subject": {
+      "reference": "Patient/5946f880-b197-400b-9caa-a3c661d23041"
+    },
+    "encounter": {
+      "reference": "Encounter/ANCDT17-encounter"
+    },
+    "action": [ {
+      "id": "1",
+      "title": "Refer urgently to a hospital",
+      "description": "Refer urgently to a hospital",
+      "textEquivalent": "Symptom(s) of severe pre-eclampsia! Refer urgently to hospital!\nWoman has hypertension. If she is experiencing a symptom of severe pre-eclampsia, then refer urgently to the hospital for further investigation and management.\n\nProcedure\n– Give magnesium sulphate\n– Give appropriate anti-hypertensives\n– Revise the birth plan\n– Refer urgently to hospital",
+      "documentation": [ {
+        "type": "citation",
+        "label": "Pregnancy, childbirth, postpartum and newborn care guide (IMPAC) (2015): recommendation C3 (1)\nManaging complications guide (IMPAC) (2017): Section S-53, Table S-12 (5)"
+      } ]
+    }, {
+      "id": "3",
+      "title": "Refer urgently to a hospital",
+      "description": "Refer urgently to a hospital 3",
+      "textEquivalent": "Woman has severe hypertension. If SBP is 160 mmHg or higher and/or DBP is 110 mmHg or higher, then refer urgently to the hospital for further investigation and management.",
+      "documentation": [ {
+        "type": "citation",
+        "label": "Managing complications guide (IMPAC) (2017): S-61 (5)\nWHO pre-eclampsia and eclampsia recommendations (2011): 4 (7)"
+      } ]
+    }, {
+      "id": "4",
+      "title": "Conduct hypertension counselling",
+      "description": "Conduct hypertension counselling",
+      "textEquivalent": "Woman has hypertension – SBP of 140 mmHg or higher and/or DBP of 90 mmHg or higher and no proteinuria.\n\nCounselling:\n– Advice to reduce workload and to rest\n– Advise on danger signs\n– Reassess at the next contact or in 1 week if 8 months pregnant\n– If hypertension persists after 1 week or at next contact, refer to hospital or discuss case with the doctor, if available",
+      "documentation": [ {
+        "type": "citation",
+        "label": "Pregnancy, childbirth, postpartum and newborn care guide (IMPAC) (2015): C3 (1)"
+      } ]
+    }, {
+      "title": "ANC.DT.17 Pre-eclampsia, severe pre-eclampsia and hypertension diagnosis"
+    } ]
+  } ],
+  "instantiatesCanonical": [ "http://fhir.org/guides/who/anc-cds/PlanDefinition/ANCDT17" ],
+  "status": "draft",
+  "intent": "proposal",
+  "subject": {
+    "reference": "Patient/5946f880-b197-400b-9caa-a3c661d23041"
+  },
+  "encounter": {
+    "reference": "Encounter/ANCDT17-encounter"
+  },
+  "activity": [ {
+    "reference": {
+      "reference": "#RequestGroup/ANCDT17"
+    }
+  } ]
+}

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r4/anc-dak/terminology-bundle.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r4/anc-dak/terminology-bundle.json
@@ -1,0 +1,594 @@
+{
+	"resourceType": "Bundle",
+	"id": "ANCDT17-terminology-bundle",
+	"type": "transaction",
+	"entry": [{
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "anc-b8-de17",
+				"meta": {
+					"profile": ["http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset"]
+				},
+				"extension": [{
+					"url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+					"valueString": "executable"
+				}, {
+					"url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+					"valueString": "executable"
+				}],
+				"url": "http://fhir.org/guides/who/anc-cds/ValueSet/anc-b8-de17",
+				"name": "Systolicbloodpressure",
+				"title": "Systolic blood pressure",
+				"status": "draft",
+				"experimental": false,
+				"description": "Codes representing possible values for the Systolic blood pressure element",
+				"immutable": true,
+				"compose": {
+					"include": [{
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"concept": [{
+							"code": "ANC.B8.DE17",
+							"display": "Systolic blood pressure"
+						}]
+					}]
+				},
+				"expansion": {
+					"timestamp": "2021-11-30T07:11:23-07:00",
+					"contains": [{
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"code": "ANC.B8.DE17",
+						"display": "Systolic blood pressure"
+					}]
+				}
+			}
+		},
+		{
+			"resource": {
+				"resourceType": "ValueSet",
+				  "id": "anc-b8-de19",
+				  "meta": {
+				    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+				  },
+				  "extension": [ {
+				    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+				    "valueString": "executable"
+				  }, {
+				    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+				    "valueString": "executable"
+				  } ],
+				  "url": "http://fhir.org/guides/who/anc-cds/ValueSet/anc-b8-de19",
+				  "name": "Diastolicbloodpressure",
+				  "title": "Diastolic blood pressure",
+				  "status": "draft",
+				  "experimental": false,
+				  "description": "Codes representing possible values for the Diastolic blood pressure element",
+				  "immutable": true,
+				  "compose": {
+				    "include": [ {
+				      "system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+				      "concept": [ {
+				        "code": "ANC.B8.DE19",
+				        "display": "Diastolic blood pressure"
+				      } ]
+				    } ]
+				  },
+				  "expansion": {
+				    "timestamp": "2021-11-30T07:11:23-07:00",
+				    "contains": [ {
+				      "system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+				      "code": "ANC.B8.DE19",
+				      "display": "Diastolic blood pressure"
+				    } ]
+				  }
+			}
+		},
+		{
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "anc-b8-de20",
+				"meta": {
+					"profile": ["http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset"]
+				},
+				"extension": [{
+					"url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+					"valueString": "executable"
+				}, {
+					"url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+					"valueString": "executable"
+				}],
+				"url": "http://fhir.org/guides/who/anc-cds/ValueSet/anc-b8-de20",
+				"name": "Repeatsystolicbloodpressure",
+				"title": "Repeat systolic blood pressure",
+				"status": "draft",
+				"experimental": false,
+				"description": "Codes representing possible values for the Repeat systolic blood pressure element",
+				"immutable": true,
+				"compose": {
+					"include": [{
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"concept": [{
+							"code": "ANC.B8.DE20",
+							"display": "Repeat systolic blood pressure"
+						}]
+					}]
+				},
+				"expansion": {
+					"timestamp": "2021-11-30T07:11:23-07:00",
+					"contains": [{
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"code": "ANC.B8.DE20",
+						"display": "Repeat systolic blood pressure"
+					}]
+				}
+			}
+		},
+		{
+			"resource": {
+				"resourceType": "ValueSet",
+				  "id": "anc-b8-de21",
+				  "meta": {
+				    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+				  },
+				  "extension": [ {
+				    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+				    "valueString": "executable"
+				  }, {
+				    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+				    "valueString": "executable"
+				  } ],
+				  "url": "http://fhir.org/guides/who/anc-cds/ValueSet/anc-b8-de21",
+				  "name": "Repeatdiastolicbloodpressure",
+				  "title": "Repeat diastolic blood pressure",
+				  "status": "draft",
+				  "experimental": false,
+				  "description": "Codes representing possible values for the Repeat diastolic blood pressure element",
+				  "immutable": true,
+				  "compose": {
+				    "include": [ {
+				      "system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+				      "concept": [ {
+				        "code": "ANC.B8.DE21",
+				        "display": "Repeat diastolic blood pressure"
+				      } ]
+				    } ]
+				  },
+				  "expansion": {
+				    "timestamp": "2021-11-30T07:11:23-07:00",
+				    "contains": [ {
+				      "system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+				      "code": "ANC.B8.DE21",
+				      "display": "Repeat diastolic blood pressure"
+				    } ]
+				  }
+			}
+		},
+		{
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "anc-b8-de27",
+				"meta": {
+					"profile": ["http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset"]
+				},
+				"extension": [{
+					"url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+					"valueString": "executable"
+				}, {
+					"url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+					"valueString": "executable"
+				}],
+				"url": "http://fhir.org/guides/who/anc-cds/ValueSet/anc-b8-de27",
+				"name": "Symptomsofseverepreeclampsia",
+				"title": "Symptoms of severe pre-eclampsia",
+				"status": "draft",
+				"experimental": false,
+				"description": "Codes representing possible values for the Symptoms of severe pre-eclampsia element",
+				"immutable": true,
+				"compose": {
+					"include": [{
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"concept": [{
+							"code": "ANC.B8.DE27",
+							"display": "Symptoms of severe pre-eclampsia"
+						}]
+					}]
+				},
+				"expansion": {
+					"timestamp": "2021-11-30T07:11:23-07:00",
+					"contains": [{
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"code": "ANC.B8.DE27",
+						"display": "Symptoms of severe pre-eclampsia"
+					}]
+				}
+			}
+		},
+		{
+			"resource": {
+				"resourceType": "ValueSet",
+				  "id": "anc-b8-de28",
+				  "meta": {
+				    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+				  },
+				  "extension": [ {
+				    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+				    "valueString": "executable"
+				  }, {
+				    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+				    "valueString": "executable"
+				  } ],
+				  "url": "http://fhir.org/guides/who/anc-cds/ValueSet/anc-b8-de28",
+				  "name": "SymptomsofseverepreeclampsiaNosymptomsChoices",
+				  "title": "Symptoms of severe pre-eclampsia - No symptoms Choices",
+				  "status": "draft",
+				  "experimental": false,
+				  "description": "Codes representing possible values for the Symptoms of severe pre-eclampsia - No symptoms Choices element",
+				  "immutable": true,
+				  "compose": {
+				    "include": [ {
+				      "system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+				      "concept": [ {
+				        "code": "ANC.B8.DE28",
+				        "display": "No symptoms of severe pre-eclampsia"
+				      } ]
+				    } ]
+				  },
+				  "expansion": {
+				    "timestamp": "2021-11-30T07:11:23-07:00",
+				    "contains": [ {
+				      "system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+				      "code": "ANC.B8.DE28",
+				      "display": "No symptoms of severe pre-eclampsia"
+				    } ]
+				  }
+			}
+		},
+		{
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "anc-b8-de29",
+				"meta": {
+					"profile": ["http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset"]
+				},
+				"extension": [{
+					"url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+					"valueString": "executable"
+				}, {
+					"url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+					"valueString": "executable"
+				}],
+				"url": "http://fhir.org/guides/who/anc-cds/ValueSet/anc-b8-de29",
+				"name": "SymptomsofseverepreeclampsiaChoices",
+				"title": "Symptoms of severe pre-eclampsia Choices",
+				"status": "draft",
+				"experimental": false,
+				"description": "Codes representing possible values for the Symptoms of severe pre-eclampsia Choices element",
+				"immutable": true,
+				"compose": {
+					"include": [{
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"concept": [{
+							"code": "ANC.B8.DE29",
+							"display": "Severe headache"
+						}, {
+							"code": "ANC.B8.DE30",
+							"display": "Visual disturbance"
+						}, {
+							"code": "ANC.B8.DE31",
+							"display": "Epigastric pain"
+						}, {
+							"code": "ANC.B8.DE32",
+							"display": "Dizziness"
+						}, {
+							"code": "ANC.B8.DE33",
+							"display": "Vomiting"
+						}]
+					}]
+				},
+				"expansion": {
+					"timestamp": "2021-11-30T07:11:23-07:00",
+					"contains": [{
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"code": "ANC.B8.DE29",
+						"display": "Severe headache"
+					}, {
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"code": "ANC.B8.DE30",
+						"display": "Visual disturbance"
+					}, {
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"code": "ANC.B8.DE31",
+						"display": "Epigastric pain"
+					}, {
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"code": "ANC.B8.DE32",
+						"display": "Dizziness"
+					}, {
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"code": "ANC.B8.DE33",
+						"display": "Vomiting"
+					}]
+				}
+			}
+		},
+		{
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "anc-b9-de144",
+				"meta": {
+					"profile": ["http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset"]
+				},
+				"extension": [{
+					"url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+					"valueString": "executable"
+				}, {
+					"url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+					"valueString": "executable"
+				}],
+				"url": "http://fhir.org/guides/who/anc-cds/ValueSet/anc-b9-de144",
+				"name": "Urinedipstickresultprotein",
+				"title": "Urine dipstick result - protein",
+				"status": "draft",
+				"experimental": false,
+				"description": "Codes representing possible values for the Urine dipstick result - protein element",
+				"immutable": true,
+				"compose": {
+					"include": [{
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"concept": [{
+							"code": "ANC.B9.DE144",
+							"display": "Urine dipstick result - protein"
+						}]
+					}]
+				},
+				"expansion": {
+					"timestamp": "2021-11-30T07:11:23-07:00",
+					"contains": [{
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"code": "ANC.B9.DE144",
+						"display": "Urine dipstick result - protein"
+					}]
+				}
+			}
+		},
+		{
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "anc-b9-de146",
+				"meta": {
+					"profile": ["http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset"]
+				},
+				"extension": [{
+					"url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+					"valueString": "executable"
+				}, {
+					"url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+					"valueString": "executable"
+				}],
+				"url": "http://fhir.org/guides/who/anc-cds/ValueSet/anc-b9-de146",
+				"name": "Urinedipstickresultprotein1plusChoices",
+				"title": "Urine dipstick result - protein - 1 plus Choices",
+				"status": "draft",
+				"experimental": false,
+				"description": "Codes representing possible values for the Urine dipstick result - protein - 1 plus Choices element",
+				"immutable": true,
+				"compose": {
+					"include": [{
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"concept": [{
+							"code": "ANC.B9.DE146",
+							"display": "+"
+						}]
+					}]
+				},
+				"expansion": {
+					"timestamp": "2021-11-30T07:11:23-07:00",
+					"contains": [{
+						"system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+						"code": "ANC.B9.DE146",
+						"display": "+"
+					}]
+				}
+			}
+		},
+		{
+			"resource": {
+				"resourceType": "ValueSet",
+				  "id": "anc-b9-de147",
+				  "meta": {
+				    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+				  },
+				  "extension": [ {
+				    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+				    "valueString": "executable"
+				  }, {
+				    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+				    "valueString": "executable"
+				  } ],
+				  "url": "http://fhir.org/guides/who/anc-cds/ValueSet/anc-b9-de147",
+				  "name": "Urinedipstickresultprotein2plusChoices",
+				  "title": "Urine dipstick result - protein - 2 plus Choices",
+				  "status": "draft",
+				  "experimental": false,
+				  "description": "Codes representing possible values for the Urine dipstick result - protein - 2 plus Choices element",
+				  "immutable": true,
+				  "compose": {
+				    "include": [ {
+				      "system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+				      "concept": [ {
+				        "code": "ANC.B9.DE147",
+				        "display": "++"
+				      } ]
+				    } ]
+				  },
+				  "expansion": {
+				    "timestamp": "2021-11-30T07:11:23-07:00",
+				    "contains": [ {
+				      "system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+				      "code": "ANC.B9.DE147",
+				      "display": "++"
+				    } ]
+				  }
+			}
+		},
+		{
+			"resource": {
+				"resourceType": "ValueSet",
+				  "id": "anc-b9-de148",
+				  "meta": {
+				    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+				  },
+				  "extension": [ {
+				    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+				    "valueString": "executable"
+				  }, {
+				    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+				    "valueString": "executable"
+				  } ],
+				  "url": "http://fhir.org/guides/who/anc-cds/ValueSet/anc-b9-de148",
+				  "name": "Urinedipstickresultprotein3plusChoices",
+				  "title": "Urine dipstick result - protein - 3 plus Choices",
+				  "status": "draft",
+				  "experimental": false,
+				  "description": "Codes representing possible values for the Urine dipstick result - protein - 3 plus Choices element",
+				  "immutable": true,
+				  "compose": {
+				    "include": [ {
+				      "system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+				      "concept": [ {
+				        "code": "ANC.B9.DE148",
+				        "display": "+++"
+				      } ]
+				    } ]
+				  },
+				  "expansion": {
+				    "timestamp": "2021-11-30T07:11:23-07:00",
+				    "contains": [ {
+				      "system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+				      "code": "ANC.B9.DE148",
+				      "display": "+++"
+				    } ]
+				  }
+			}
+		},
+		{
+			"resource": {
+				"resourceType": "ValueSet",
+				  "id": "anc-b9-de149",
+				  "meta": {
+				    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+				  },
+				  "extension": [ {
+				    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+				    "valueString": "executable"
+				  }, {
+				    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+				    "valueString": "executable"
+				  } ],
+				  "url": "http://fhir.org/guides/who/anc-cds/ValueSet/anc-b9-de149",
+				  "name": "Urinedipstickresultprotein4plusChoices",
+				  "title": "Urine dipstick result - protein - 4 plus Choices",
+				  "status": "draft",
+				  "experimental": false,
+				  "description": "Codes representing possible values for the Urine dipstick result - protein - 4 plus Choices element",
+				  "immutable": true,
+				  "compose": {
+				    "include": [ {
+				      "system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+				      "concept": [ {
+				        "code": "ANC.B9.DE149",
+				        "display": "++++"
+				      } ]
+				    } ]
+				  },
+				  "expansion": {
+				    "timestamp": "2021-11-30T07:11:23-07:00",
+				    "contains": [ {
+				      "system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+				      "code": "ANC.B9.DE149",
+				      "display": "++++"
+				    } ]
+				  }
+			}
+		},
+		{
+			"resource": {
+				"resourceType": "ValueSet",
+				  "id": "anc-b9-de145",
+				  "meta": {
+				    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+				  },
+				  "extension": [ {
+				    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+				    "valueString": "executable"
+				  }, {
+				    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+				    "valueString": "executable"
+				  } ],
+				  "url": "http://fhir.org/guides/who/anc-cds/ValueSet/anc-b9-de145",
+				  "name": "UrinedipstickresultproteinNoneChoices",
+				  "title": "Urine dipstick result - protein - None Choices",
+				  "status": "draft",
+				  "experimental": false,
+				  "description": "Codes representing possible values for the Urine dipstick result - protein - None Choices element",
+				  "immutable": true,
+				  "compose": {
+				    "include": [ {
+				      "system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+				      "concept": [ {
+				        "code": "ANC.B9.DE145",
+				        "display": "None"
+				      } ]
+				    } ]
+				  },
+				  "expansion": {
+				    "timestamp": "2021-11-30T07:11:23-07:00",
+				    "contains": [ {
+				      "system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+				      "code": "ANC.B9.DE145",
+				      "display": "None"
+				    } ]
+				  }
+			}
+		},
+		{
+			"resource": {
+				"resourceType": "ValueSet",
+				  "id": "anc-b6-de83",
+				  "meta": {
+				    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+				  },
+				  "extension": [ {
+				    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+				    "valueString": "executable"
+				  }, {
+				    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+				    "valueString": "executable"
+				  } ],
+				  "url": "http://fhir.org/guides/who/anc-cds/ValueSet/anc-b6-de83",
+				  "name": "Existingchronichealthconditions",
+				  "title": "Existing chronic health conditions",
+				  "status": "draft",
+				  "experimental": false,
+				  "description": "Codes representing possible values for the Existing chronic health conditions element",
+				  "immutable": true,
+				  "compose": {
+				    "include": [ {
+				      "system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+				      "concept": [ {
+				        "code": "ANC.B6.DE83",
+				        "display": "Existing chronic health conditions"
+				      } ]
+				    } ]
+				  },
+				  "expansion": {
+				    "timestamp": "2021-11-30T07:11:23-07:00",
+				    "contains": [ {
+				      "system": "http://fhir.org/guides/who/anc-cds/CodeSystem/anc-custom-codes",
+				      "code": "ANC.B6.DE83",
+				      "display": "Existing chronic health conditions"
+				    } ]
+				  }
+			}
+		}
+	]
+}

--- a/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
+++ b/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
@@ -94,7 +94,7 @@ public class TranslatingLibraryLoader implements TranslatorOptionAwareLibraryLoa
     }
 
     // Need to ensure namespaces are preserved when recompiling
-    if (libraryIdentifier.getSystem() != null && !libraryIdentifier.getSystem().isBlank()
+    if (libraryIdentifier.getSystem() != null && !libraryIdentifier.getSystem().isEmpty()
         && libraryManager.getNamespaceManager().getNamespaceInfoFromUri(libraryIdentifier.getSystem()) == null) {
       libraryManager.getNamespaceManager().addNamespace(new NamespaceInfo(libraryIdentifier.getId(), libraryIdentifier.getSystem()));
     }

--- a/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
+++ b/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
@@ -22,9 +22,9 @@ import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.cql2elm.LibrarySourceProvider;
 import org.cqframework.cql.cql2elm.ModelManager;
 import org.cqframework.cql.cql2elm.model.CompiledLibrary;
+import org.cqframework.cql.elm.execution.ExpressionDef;
 import org.cqframework.cql.elm.execution.FunctionDef;
 import org.cqframework.cql.elm.execution.Library;
-import org.cqframework.cql.elm.execution.ExpressionDef;
 import org.cqframework.cql.elm.execution.VersionedIdentifier;
 import org.hl7.cql.model.NamespaceInfo;
 import org.opencds.cqf.cql.engine.exception.CqlException;
@@ -89,14 +89,17 @@ public class TranslatingLibraryLoader implements TranslatorOptionAwareLibraryLoa
       requireFunctionSignature = true;
     }
 
-    if (library != null && !requireFunctionSignature && this.translatorOptionsMatch(library)) {
+    if (library != null && !requireFunctionSignature
+        && Boolean.TRUE.equals(this.translatorOptionsMatch(library))) {
       return library;
     }
 
     // Need to ensure namespaces are preserved when recompiling
     if (libraryIdentifier.getSystem() != null && !libraryIdentifier.getSystem().isEmpty()
-        && libraryManager.getNamespaceManager().getNamespaceInfoFromUri(libraryIdentifier.getSystem()) == null) {
-      libraryManager.getNamespaceManager().addNamespace(new NamespaceInfo(libraryIdentifier.getId(), libraryIdentifier.getSystem()));
+        && libraryManager.getNamespaceManager()
+            .getNamespaceInfoFromUri(libraryIdentifier.getSystem()) == null) {
+      libraryManager.getNamespaceManager().addNamespace(
+          new NamespaceInfo(libraryIdentifier.getId(), libraryIdentifier.getSystem()));
     }
 
     this.cqlTranslatorOptions.setEnableCqlOnly(true);
@@ -211,11 +214,11 @@ public class TranslatingLibraryLoader implements TranslatorOptionAwareLibraryLoa
         return false;
       }
 
-      FunctionSig func = (FunctionSig) other;
-
-      if (func == null) {
+      if (this.getClass() != other.getClass()) {
         return false;
       }
+
+      FunctionSig func = (FunctionSig) other;
 
       return this.name.equals(func.name) && this.numArguments == func.numArguments;
     }

--- a/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
+++ b/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
@@ -93,6 +93,12 @@ public class TranslatingLibraryLoader implements TranslatorOptionAwareLibraryLoa
       return library;
     }
 
+    // Need to ensure namespaces are preserved when recompiling
+    if (libraryIdentifier.getSystem() != null && !libraryIdentifier.getSystem().isBlank()
+        && libraryManager.getNamespaceManager().getNamespaceInfoFromUri(libraryIdentifier.getSystem()) == null) {
+      libraryManager.getNamespaceManager().addNamespace(new NamespaceInfo(libraryIdentifier.getId(), libraryIdentifier.getSystem()));
+    }
+
     this.cqlTranslatorOptions.setEnableCqlOnly(true);
     return this.translate(libraryIdentifier);
   }


### PR DESCRIPTION
I am not 100% sure that the solution I implemented is ideal, but it does work.

 - Added namespace preservation logic when recompiling libraries due to function overloads 
 - Added test with ELM and overloaded functions