### PR TITLE
Instantiate a single ModelResolver in the ResourceMatchers

### DIFF
--- a/evaluator.fhir/src/main/java/org/opencds/cqf/cql/evaluator/fhir/repository/matcher/ResourceMatcherDSTU3.java
+++ b/evaluator.fhir/src/main/java/org/opencds/cqf/cql/evaluator/fhir/repository/matcher/ResourceMatcherDSTU3.java
@@ -19,9 +19,11 @@ import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.param.InternalCodingDt;
 
 public class ResourceMatcherDSTU3 implements BaseResourceMatcher {
+  private final ModelResolver modelResolver = new Dstu3FhirModelResolver();
+
   @Override
   public ModelResolver getModelResolver() {
-    return new Dstu3FhirModelResolver();
+    return modelResolver;
   }
 
   @Override

--- a/evaluator.fhir/src/main/java/org/opencds/cqf/cql/evaluator/fhir/repository/matcher/ResourceMatcherR4.java
+++ b/evaluator.fhir/src/main/java/org/opencds/cqf/cql/evaluator/fhir/repository/matcher/ResourceMatcherR4.java
@@ -19,9 +19,11 @@ import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.param.InternalCodingDt;
 
 public class ResourceMatcherR4 implements BaseResourceMatcher {
+  private final ModelResolver modelResolver = new R4FhirModelResolver();
+
   @Override
   public ModelResolver getModelResolver() {
-    return new R4FhirModelResolver();
+    return modelResolver;
   }
 
   @Override

--- a/evaluator.fhir/src/main/java/org/opencds/cqf/cql/evaluator/fhir/repository/matcher/ResourceMatcherR5.java
+++ b/evaluator.fhir/src/main/java/org/opencds/cqf/cql/evaluator/fhir/repository/matcher/ResourceMatcherR5.java
@@ -19,9 +19,11 @@ import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.param.InternalCodingDt;
 
 public class ResourceMatcherR5 implements BaseResourceMatcher {
+  private final ModelResolver modelResolver = new R5FhirModelResolver();
+
   @Override
   public ModelResolver getModelResolver() {
-    return new R5FhirModelResolver();
+    return modelResolver;
   }
 
   @Override


### PR DESCRIPTION
When using an in memory repository with search parameters, the resource matchers being used were instantiated a version specific ModelResolver on each match call.  This fix instantiates a single ModelResolver to be used for the life of the matcher.