### PR TITLE
Add support for transforming the value when setting initial on generated questionnaire items

### DIFF
--- a/evaluator.questionnaire/src/main/java/org/opencds/cqf/cql/evaluator/questionnaire/r4/ItemValueTransformer.java
+++ b/evaluator.questionnaire/src/main/java/org/opencds/cqf/cql/evaluator/questionnaire/r4/ItemValueTransformer.java
@@ -1,0 +1,16 @@
+package org.opencds.cqf.cql.evaluator.questionnaire.r4;
+
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Type;
+
+public class ItemValueTransformer {
+  private ItemValueTransformer() {}
+
+  public static Type transformValue(Type value) {
+    if (value instanceof CodeableConcept) {
+      return ((CodeableConcept) value).getCoding().get(0);
+    }
+
+    return value;
+  }
+}

--- a/evaluator.questionnaire/src/main/java/org/opencds/cqf/cql/evaluator/questionnaire/r4/QuestionnaireProcessor.java
+++ b/evaluator.questionnaire/src/main/java/org/opencds/cqf/cql/evaluator/questionnaire/r4/QuestionnaireProcessor.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.cql.evaluator.questionnaire.r4;
 
 import static org.opencds.cqf.cql.evaluator.fhir.util.r4.SearchHelper.searchRepositoryByCanonical;
+import static org.opencds.cqf.cql.evaluator.questionnaire.r4.ItemValueTransformer.transformValue;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -16,7 +17,6 @@ import org.hl7.fhir.r4.model.Base;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleType;
 import org.hl7.fhir.r4.model.CanonicalType;
-import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Enumerations.FHIRAllTypes;
 import org.hl7.fhir.r4.model.Expression;
 import org.hl7.fhir.r4.model.IdType;
@@ -154,12 +154,6 @@ public class QuestionnaireProcessor extends BaseQuestionnaireProcessor<Questionn
     return null;
   }
 
-  private Type transformInitial(IBase value) {
-    return ((Type) value).fhirType().equals("CodeableConcept")
-        ? ((CodeableConcept) value).getCodingFirstRep()
-        : (Type) value;
-  }
-
   private void getInitial(QuestionnaireItemComponent item, IBase populationContext) {
     var initialExpression = getInitialExpression(item);
     if (initialExpression != null) {
@@ -175,7 +169,7 @@ public class QuestionnaireProcessor extends BaseQuestionnaireProcessor<Questionn
             item.addExtension(Constants.QUESTIONNAIRE_RESPONSE_AUTHOR,
                 new Reference(Constants.CQL_ENGINE_DEVICE));
             item.addInitial(new Questionnaire.QuestionnaireItemInitialComponent()
-                .setValue(transformInitial(result)));
+                .setValue(transformValue((Type) result)));
           }
         }
       }
@@ -204,7 +198,7 @@ public class QuestionnaireProcessor extends BaseQuestionnaireProcessor<Questionn
             item.addExtension(Constants.QUESTIONNAIRE_RESPONSE_AUTHOR,
                 new Reference(Constants.CQL_ENGINE_DEVICE));
             item.addInitial(new Questionnaire.QuestionnaireItemInitialComponent()
-                .setValue(transformInitial(initialProperty.getValues().get(0))));
+                .setValue(transformValue((Type) initialProperty.getValues().get(0))));
           }
         }
       }

--- a/evaluator.questionnaire/src/main/java/org/opencds/cqf/cql/evaluator/questionnaire/r4/generator/nestedquestionnaireitem/ElementHasCqfExpression.java
+++ b/evaluator.questionnaire/src/main/java/org/opencds/cqf/cql/evaluator/questionnaire/r4/generator/nestedquestionnaireitem/ElementHasCqfExpression.java
@@ -1,39 +1,42 @@
 package org.opencds.cqf.cql.evaluator.questionnaire.r4.generator.nestedquestionnaireitem;
 
+import static org.opencds.cqf.cql.evaluator.questionnaire.r4.ItemValueTransformer.transformValue;
+
+import java.util.List;
+
 import org.hl7.fhir.instance.model.api.IAnyResource;
 import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseBundle;
+import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.r4.model.ElementDefinition;
 import org.hl7.fhir.r4.model.Expression;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.Type;
-import org.hl7.fhir.instance.model.api.IBaseBundle;
-import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.opencds.cqf.cql.evaluator.fhir.Constants;
 import org.opencds.cqf.cql.evaluator.library.LibraryEngine;
-import java.util.List;
 
-public class ElementHasCqfExtension {
+public class ElementHasCqfExpression {
   protected String patientId;
   protected IBaseBundle bundle;
   protected IBaseParameters parameters;
   protected LibraryEngine libraryEngine;
   protected String subjectType = "Patient";
 
-  public ElementHasCqfExtension(
+  public ElementHasCqfExpression(
       String thePatientId,
       IBaseParameters theParameters,
       IBaseBundle theBundle,
-      LibraryEngine theLibraryEngine
-  ) {
+      LibraryEngine theLibraryEngine) {
     patientId = thePatientId;
     parameters = theParameters;
     bundle = theBundle;
     libraryEngine = theLibraryEngine;
   }
 
-  public QuestionnaireItemComponent addProperties(ElementDefinition element, QuestionnaireItemComponent questionnaireItem) {
+  public QuestionnaireItemComponent addProperties(ElementDefinition element,
+      QuestionnaireItemComponent questionnaireItem) {
     final Expression expression = getExpression(element);
     final List<IBase> results = getExpressionResults(expression);
     results.forEach(result -> {
@@ -53,7 +56,7 @@ public class ElementHasCqfExtension {
   }
 
   void addTypeValue(IBase result, QuestionnaireItemComponent questionnaireItem) {
-    final Type type = (Type) result;
+    final Type type = transformValue((Type) result);
     questionnaireItem.addInitial().setValue(type);
   }
 
@@ -65,8 +68,7 @@ public class ElementHasCqfExtension {
         expression.getLanguage(),
         expression.getReference(),
         parameters,
-        this.bundle
-    );
+        this.bundle);
   }
 
   protected Expression getExpression(ElementDefinition element) {

--- a/evaluator.questionnaire/src/main/java/org/opencds/cqf/cql/evaluator/questionnaire/r4/generator/nestedquestionnaireitem/ElementHasDefaultValue.java
+++ b/evaluator.questionnaire/src/main/java/org/opencds/cqf/cql/evaluator/questionnaire/r4/generator/nestedquestionnaireitem/ElementHasDefaultValue.java
@@ -1,16 +1,17 @@
 package org.opencds.cqf.cql.evaluator.questionnaire.r4.generator.nestedquestionnaireitem;
 
+import static org.opencds.cqf.cql.evaluator.questionnaire.r4.ItemValueTransformer.transformValue;
+
 import org.hl7.fhir.r4.model.BooleanType;
-import org.hl7.fhir.r4.model.ElementDefinition;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.r4.model.Type;
 import org.opencds.cqf.cql.evaluator.fhir.Constants;
 
-public class ElementIsFixedOrHasPattern {
+public class ElementHasDefaultValue {
   public QuestionnaireItemComponent addProperties(
-      ElementDefinition element,
-      QuestionnaireItemComponent questionnaireItem
-  ) {
-    questionnaireItem.addInitial().setValue(element.getFixedOrPattern());
+      Type value,
+      QuestionnaireItemComponent questionnaireItem) {
+    questionnaireItem.addInitial().setValue(transformValue(value));
     questionnaireItem.addExtension(Constants.SDC_QUESTIONNAIRE_HIDDEN, new BooleanType(true));
     questionnaireItem.setReadOnly(true);
     return questionnaireItem;

--- a/evaluator.questionnaire/src/main/java/org/opencds/cqf/cql/evaluator/questionnaire/r4/generator/nestedquestionnaireitem/QuestionnaireTypeIsChoice.java
+++ b/evaluator.questionnaire/src/main/java/org/opencds/cqf/cql/evaluator/questionnaire/r4/generator/nestedquestionnaireitem/QuestionnaireTypeIsChoice.java
@@ -20,12 +20,12 @@ public class QuestionnaireTypeIsChoice {
   protected static final Logger logger = LoggerFactory.getLogger(QuestionnaireTypeIsChoice.class);
   protected Repository repository;
 
-  public static QuestionnaireTypeIsChoice of(Repository theRepository) {
-    return new QuestionnaireTypeIsChoice(theRepository);
+  public static QuestionnaireTypeIsChoice of(Repository repository) {
+    return new QuestionnaireTypeIsChoice(repository);
   }
 
-  QuestionnaireTypeIsChoice(Repository theRepository) {
-    repository = theRepository;
+  QuestionnaireTypeIsChoice(Repository repository) {
+    this.repository = repository;
   }
 
   public QuestionnaireItemComponent addProperties(

--- a/evaluator.questionnaire/src/main/java/org/opencds/cqf/cql/evaluator/questionnaire/r4/generator/questionnaireitem/QuestionnaireItemGenerator.java
+++ b/evaluator.questionnaire/src/main/java/org/opencds/cqf/cql/evaluator/questionnaire/r4/generator/questionnaireitem/QuestionnaireItemGenerator.java
@@ -1,5 +1,7 @@
 package org.opencds.cqf.cql.evaluator.questionnaire.r4.generator.questionnaireitem;
 
+import static org.opencds.cqf.cql.evaluator.fhir.util.r4.SearchHelper.searchRepositoryByCanonical;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,11 +20,10 @@ import org.opencds.cqf.fhir.api.Repository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.opencds.cqf.cql.evaluator.fhir.util.r4.SearchHelper.searchRepositoryByCanonical;
-
 public class QuestionnaireItemGenerator {
   protected static final Logger logger = LoggerFactory.getLogger(QuestionnaireItemGenerator.class);
-  protected static final String NO_PROFILE_ERROR = "No profile defined for input. Unable to generate item.";
+  protected static final String NO_PROFILE_ERROR =
+      "No profile defined for input. Unable to generate item.";
   protected static final String ITEM_CREATION_ERROR = "An error occurred during item creation: %s";
   protected static final String CHILD_LINK_ID_FORMAT = "%s.%s";
   protected Repository repository;
@@ -35,40 +36,39 @@ public class QuestionnaireItemGenerator {
       String patientId,
       IBaseParameters parameters,
       IBaseBundle bundle,
-      LibraryEngine libraryEngine
-  ) {
+      LibraryEngine libraryEngine) {
     QuestionnaireItemService questionnaireItemService = new QuestionnaireItemService();
-    NestedQuestionnaireItemService nestedQuestionnaireItemService = NestedQuestionnaireItemService.of(
-        repository,
-        patientId,
-        parameters,
-        bundle,
-        libraryEngine
-    );
-    return new QuestionnaireItemGenerator(repository, questionnaireItemService, nestedQuestionnaireItemService);
+    NestedQuestionnaireItemService nestedQuestionnaireItemService =
+        NestedQuestionnaireItemService.of(
+            repository,
+            patientId,
+            parameters,
+            bundle,
+            libraryEngine);
+    return new QuestionnaireItemGenerator(repository, questionnaireItemService,
+        nestedQuestionnaireItemService);
   }
 
   QuestionnaireItemGenerator(
-      Repository theRepository,
-      QuestionnaireItemService theQuestionnaireItemService,
-      NestedQuestionnaireItemService theNestedQuestionnaireItemService
-  ) {
-      repository = theRepository;
-      questionnaireItemService = theQuestionnaireItemService;
-      nestedQuestionnaireItemService = theNestedQuestionnaireItemService;
+      Repository repository,
+      QuestionnaireItemService questionnaireItemService,
+      NestedQuestionnaireItemService nestedQuestionnaireItemService) {
+    this.repository = repository;
+    this.questionnaireItemService = questionnaireItemService;
+    this.nestedQuestionnaireItemService = nestedQuestionnaireItemService;
   }
 
   public Questionnaire.QuestionnaireItemComponent generateItem(
       DataRequirement actionInput,
-      int itemCount
-  ) {
+      int itemCount) {
     if (!actionInput.hasProfile()) {
       throw new IllegalArgumentException(NO_PROFILE_ERROR);
     }
     final String linkId = String.valueOf(itemCount + 1);
     try {
       final StructureDefinition profile = (StructureDefinition) getProfileDefinition(actionInput);
-      this.questionnaireItem = questionnaireItemService.createQuestionnaireItem(actionInput, linkId, profile);
+      this.questionnaireItem =
+          questionnaireItemService.createQuestionnaireItem(actionInput, linkId, profile);
       processElements(profile);
     } catch (Exception ex) {
       final String message = String.format(ITEM_CREATION_ERROR, ex.getMessage());
@@ -78,9 +78,7 @@ public class QuestionnaireItemGenerator {
     return questionnaireItem;
   }
 
-  protected void processElements(
-      StructureDefinition profile
-  ) {
+  protected void processElements(StructureDefinition profile) {
     int childCount = questionnaireItem.getItem().size();
     for (ElementDefinition element : getElementsWithNonNullElementType(profile)) {
       childCount++;
@@ -91,15 +89,15 @@ public class QuestionnaireItemGenerator {
   protected void processElement(
       StructureDefinition profile,
       ElementDefinition element,
-      int childCount
-  ) {
-    final String childLinkId = String.format(CHILD_LINK_ID_FORMAT, questionnaireItem.getLinkId(), childCount);
+      int childCount) {
+    final String childLinkId =
+        String.format(CHILD_LINK_ID_FORMAT, questionnaireItem.getLinkId(), childCount);
     try {
-      final QuestionnaireItemComponent nestedQuestionnaireItem = nestedQuestionnaireItemService.getNestedQuestionnaireItem(
-          profile,
-          element,
-          childLinkId
-      );
+      final QuestionnaireItemComponent nestedQuestionnaireItem =
+          nestedQuestionnaireItemService.getNestedQuestionnaireItem(
+              profile,
+              element,
+              childLinkId);
       questionnaireItem.addItem(nestedQuestionnaireItem);
     } catch (Exception ex) {
       final String message = String.format(ITEM_CREATION_ERROR, ex.getMessage());
@@ -115,27 +113,15 @@ public class QuestionnaireItemGenerator {
         .collect(Collectors.toList());
   }
 
-  protected Questionnaire.QuestionnaireItemComponent createErrorItem(String linkId, String errorMessage) {
-    return new QuestionnaireItemComponent().setLinkId(linkId).setType(QuestionnaireItemType.DISPLAY).setText(errorMessage);
+  protected Questionnaire.QuestionnaireItemComponent createErrorItem(String linkId,
+      String errorMessage) {
+    return new QuestionnaireItemComponent().setLinkId(linkId).setType(QuestionnaireItemType.DISPLAY)
+        .setText(errorMessage);
   }
 
   protected String getElementType(ElementDefinition element) {
     return element.hasType() ? element.getType().get(0).getCode() : null;
-    // StructureDefinition profile) {
-    // if (elementType == null) {
-    // var snapshot = profile.getSnapshot().getElement().stream().filter(e ->
-    // e.getId().equals(element.getId())).collect(Collectors.toList());
-    // elementType = snapshot == null || snapshot.size() == 0 ? null : snapshot.get(0).hasType()
-    // ? snapshot.get(0).getType().get(0).getCode() : null;
-    // }
-    // return elementType;
   }
-
-
-
-//  protected StructureDefinition getProfileDefinition(DataRequirement actionInput) {
-//    return (StructureDefinition) searchRepositoryByCanonical(repository, actionInput.getProfile().get(0));
-//  }
 
   protected Resource getProfileDefinition(DataRequirement actionInput) {
     return searchRepositoryByCanonical(repository, actionInput.getProfile().get(0));

--- a/evaluator.questionnaire/src/test/java/org/opencds/cqf/cql/evaluator/questionnaire/r4/generator/nestedquestionnaireitem/ElementHasCqfExpressionTest.java
+++ b/evaluator.questionnaire/src/test/java/org/opencds/cqf/cql/evaluator/questionnaire/r4/generator/nestedquestionnaireitem/ElementHasCqfExpressionTest.java
@@ -1,15 +1,23 @@
 package org.opencds.cqf.cql.evaluator.questionnaire.r4.generator.nestedquestionnaireitem;
 
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.opencds.cqf.cql.evaluator.questionnaire.r4.helpers.TestingHelper.withQuestionnaireItemComponent;
+
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.ElementDefinition;
 import org.hl7.fhir.r4.model.Expression;
 import org.hl7.fhir.r4.model.Parameters;
-import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemInitialComponent;
-import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.Type;
@@ -24,15 +32,8 @@ import org.opencds.cqf.cql.evaluator.library.LibraryEngine;
 import org.opencds.cqf.cql.evaluator.questionnaire.r4.helpers.TestingHelper;
 import org.testng.Assert;
 
-import javax.annotation.Nonnull;
-import java.util.List;
-
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
-import static org.opencds.cqf.cql.evaluator.questionnaire.r4.helpers.TestingHelper.withQuestionnaireItemComponent;
-
 @ExtendWith(MockitoExtension.class)
-class ElementHasCqfExtensionTest {
+class ElementHasCqfExpressionTest {
   final static String TYPE_CODE = "typeCode";
   final static String PATH_VALUE = "pathValue";
   final static String PATIENT_ID = "patientId";
@@ -45,7 +46,7 @@ class ElementHasCqfExtensionTest {
   protected LibraryEngine libraryEngine;
   @InjectMocks
   @Spy
-  private ElementHasCqfExtension myFixture;
+  private ElementHasCqfExpression myFixture;
 
   @BeforeEach
   void setUp() {
@@ -69,8 +70,7 @@ class ElementHasCqfExtensionTest {
         EXPRESSION_LANGUAGE,
         EXPRESSION_REFERENCE,
         parameters,
-        bundle
-    );
+        bundle);
     // execute
     final List<IBase> actual = myFixture.getExpressionResults(expression);
     // validate
@@ -80,8 +80,7 @@ class ElementHasCqfExtensionTest {
         EXPRESSION_LANGUAGE,
         EXPRESSION_REFERENCE,
         parameters,
-        bundle
-    );
+        bundle);
     Assert.assertEquals(actual, expected);
   }
 
@@ -161,7 +160,7 @@ class ElementHasCqfExtensionTest {
     final Type type = actual.getValue();
     Assert.assertTrue(Reference.class.isAssignableFrom(type.getClass()));
     final Reference typeAsRef = (Reference) type;
-    final IBaseResource resource =  typeAsRef.getResource();
+    final IBaseResource resource = typeAsRef.getResource();
     Assert.assertEquals(resource, result);
   }
 
@@ -177,8 +176,7 @@ class ElementHasCqfExtensionTest {
     return List.of(
         withResourceValue(),
         withResourceValue(),
-        withResourceValue()
-    );
+        withResourceValue());
   }
 
   @Nonnull
@@ -193,14 +191,14 @@ class ElementHasCqfExtensionTest {
     return List.of(
         withTypeValue(),
         withTypeValue(),
-        withTypeValue()
-    );
+        withTypeValue());
   }
 
   @Nonnull
   Parameters withParameters() {
     return new Parameters();
   }
+
   @Nonnull
   Expression withExpression() {
     final Expression expression = new Expression();

--- a/evaluator.questionnaire/src/test/java/org/opencds/cqf/cql/evaluator/questionnaire/r4/generator/nestedquestionnaireitem/ElementHasDefaultValueTest.java
+++ b/evaluator.questionnaire/src/test/java/org/opencds/cqf/cql/evaluator/questionnaire/r4/generator/nestedquestionnaireitem/ElementHasDefaultValueTest.java
@@ -1,4 +1,8 @@
 package org.opencds.cqf.cql.evaluator.questionnaire.r4.generator.nestedquestionnaireitem;
+
+import static org.opencds.cqf.cql.evaluator.questionnaire.r4.helpers.TestingHelper.withElementDefinition;
+import static org.opencds.cqf.cql.evaluator.questionnaire.r4.helpers.TestingHelper.withQuestionnaireItemComponent;
+
 import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.ElementDefinition;
 import org.hl7.fhir.r4.model.Extension;
@@ -10,15 +14,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opencds.cqf.cql.evaluator.fhir.Constants;
 import org.testng.Assert;
 
-import static org.opencds.cqf.cql.evaluator.questionnaire.r4.helpers.TestingHelper.withElementDefinition;
-import static org.opencds.cqf.cql.evaluator.questionnaire.r4.helpers.TestingHelper.withQuestionnaireItemComponent;
-
 @ExtendWith(MockitoExtension.class)
-class ElementIsFixedOrHasPatternTest {
+class ElementHasDefaultValueTest {
   final static String TYPE_CODE = "typeCode";
   final static String PATH_VALUE = "pathValue";
   @InjectMocks
-  private ElementIsFixedOrHasPattern myFixture;
+  private ElementHasDefaultValue myFixture;
 
   @Test
   void addPropertiesShouldAddAllPropertiesToQuestionnaireItem() {
@@ -28,7 +29,8 @@ class ElementIsFixedOrHasPatternTest {
     elementDefinition.setFixed(booleanType);
     final QuestionnaireItemComponent questionnaireItem = withQuestionnaireItemComponent();
     // execute
-    final QuestionnaireItemComponent actual = myFixture.addProperties(elementDefinition, questionnaireItem);
+    final QuestionnaireItemComponent actual =
+        myFixture.addProperties(elementDefinition.getFixedOrPattern(), questionnaireItem);
     // validate
     Assert.assertEquals(actual.getInitial().size(), 1);
     Assert.assertEquals(actual.getInitial().get(0).getValue(), booleanType);


### PR DESCRIPTION
Questionnaire.initial.value[x] does not allow a CodeableConcept, only a Coding.  During Questionnaire item generation, when the result of an initial value is a CodeableConcept, we now transform it to a Coding.