### PR TITLE
Fix profile for $apply response

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/dstu3/PlanDefinitionProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/dstu3/PlanDefinitionProcessor.java
@@ -22,7 +22,6 @@ import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.Goal;
 import org.hl7.fhir.dstu3.model.IdType;
 import org.hl7.fhir.dstu3.model.Library;
-import org.hl7.fhir.dstu3.model.Meta;
 import org.hl7.fhir.dstu3.model.MetadataResource;
 import org.hl7.fhir.dstu3.model.OperationOutcome;
 import org.hl7.fhir.dstu3.model.Parameters;
@@ -439,8 +438,7 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
     }
 
     private IBaseResource resolveDefinition(
-            PlanDefinition planDefinition,
-            PlanDefinition.PlanDefinitionActionComponent action) {
+            PlanDefinition planDefinition, PlanDefinition.PlanDefinitionActionComponent action) {
         logger.debug("Resolving definition {}", action.getDefinition().getReference());
         var definition = new StringType(action.getDefinition().getReference());
         var resourceName = resolveResourceName(definition, planDefinition);

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/r4/PlanDefinitionProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/r4/PlanDefinitionProcessor.java
@@ -68,7 +68,7 @@ import org.opencds.cqf.fhir.utility.r4.SearchHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings({"unused", "squid:S107"})
+@SuppressWarnings({ "unused", "squid:S107" })
 public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDefinition> {
 
     private static final Logger logger = LoggerFactory.getLogger(PlanDefinitionProcessor.class);
@@ -101,11 +101,11 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
 
         var questionnaireResponses = ((Bundle) bundle)
                 .getEntry().stream()
-                        .filter(entry -> entry.getResource()
-                                .fhirType()
-                                .equals(Enumerations.FHIRAllTypes.QUESTIONNAIRERESPONSE.toCode()))
-                        .map(entry -> (QuestionnaireResponse) entry.getResource())
-                        .collect(Collectors.toList());
+                .filter(entry -> entry.getResource()
+                        .fhirType()
+                        .equals(Enumerations.FHIRAllTypes.QUESTIONNAIRERESPONSE.toCode()))
+                .map(entry -> (QuestionnaireResponse) entry.getResource())
+                .collect(Collectors.toList());
         if (questionnaireResponses != null && !questionnaireResponses.isEmpty()) {
             for (var questionnaireResponse : questionnaireResponses) {
                 try {
@@ -130,8 +130,7 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
         bundle.setType(BundleType.TRANSACTION);
         bundle.addEntry(PackageHelper.createEntry(thePlanDefinition, theIsPut));
         // The CPG IG specifies a main cql library for a PlanDefinition
-        var libraryCanonical =
-                thePlanDefinition.hasLibrary() ? thePlanDefinition.getLibrary().get(0) : null;
+        var libraryCanonical = thePlanDefinition.hasLibrary() ? thePlanDefinition.getLibrary().get(0) : null;
         if (libraryCanonical != null) {
             var library = (Library) SearchHelper.searchRepositoryByCanonical(repository, libraryCanonical);
             if (library != null) {
@@ -161,9 +160,9 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
         requireNonNull(basePlanDefinition, "Couldn't find PlanDefinition " + theId);
 
         return castOrThrow(
-                        basePlanDefinition,
-                        PlanDefinition.class,
-                        "The planDefinition passed in was not a valid instance of PlanDefinition.class")
+                basePlanDefinition,
+                PlanDefinition.class,
+                "The planDefinition passed in was not a valid instance of PlanDefinition.class")
                 .orElse(null);
     }
 
@@ -178,12 +177,12 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
 
         this.questionnaire = new Questionnaire();
         this.questionnaire.setId(new IdType(FHIRAllTypes.QUESTIONNAIRE.toCode(), planDefinition.getIdPart()));
-        this.questionnaireItemGenerator =
-                QuestionnaireItemGenerator.of(repository, subjectId, parameters, bundle, libraryEngine);
+        this.questionnaireItemGenerator = QuestionnaireItemGenerator.of(repository, subjectId, parameters, bundle,
+                libraryEngine);
         this.inputParameterResolver = new InputParameterResolver(
                 subjectId, encounterId, practitionerId, parameters, useServerData, bundle, repository);
-        this.extensionResolver =
-                new ExtensionResolver(subjectId, inputParameterResolver.getParameters(), bundle, libraryEngine);
+        this.extensionResolver = new ExtensionResolver(subjectId, inputParameterResolver.getParameters(), bundle,
+                libraryEngine);
 
         return planDefinition;
     }
@@ -202,7 +201,7 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
                 .setSubject(new Reference(subjectId));
         requestGroup.setId(new IdType(
                 requestGroup.fhirType(), planDefinition.getIdElement().getIdPart()));
-        requestGroup.setMeta(new Meta().addProfile(Constants.CPG_STRATEGY));
+        // requestGroup.setMeta(new Meta().addProfile(Constants.CPG_STRATEGY));
         if (encounterId != null) {
             requestGroup.setEncounter(new Reference(encounterId));
         }
@@ -224,9 +223,9 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
         }
 
         var defaultLibraryUrl = planDefinition.getLibrary() == null
-                        || planDefinition.getLibrary().isEmpty()
-                ? null
-                : planDefinition.getLibrary().get(0).getValue();
+                || planDefinition.getLibrary().isEmpty()
+                        ? null
+                        : planDefinition.getLibrary().get(0).getValue();
         extensionResolver.resolveExtensions(requestGroup.getExtension(), defaultLibraryUrl);
 
         for (int i = 0; i < planDefinition.getGoal().size(); i++) {
@@ -240,7 +239,8 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
                         .setUrl(Constants.PERTAINS_TO_GOAL)
                         .setValue(new Reference(goal.getIdElement()));
             }
-            // Always add goals to the resource list so they can be added to the CarePlan if needed
+            // Always add goals to the resource list so they can be added to the CarePlan if
+            // needed
             requestResources.add(goal);
         }
 
@@ -386,7 +386,8 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
             // TODO: Figure out why this was here and what it was trying to do
             // if (action.hasRelatedAction()) {
             // for (var relatedActionComponent : action.getRelatedAction()) {
-            // if (relatedActionComponent.getRelationship().equals(ActionRelationshipType.AFTER)
+            // if
+            // (relatedActionComponent.getRelationship().equals(ActionRelationshipType.AFTER)
             // && metConditions.containsKey(relatedActionComponent.getActionId())) {
             // metConditions.put(action.getId(), action);
             // resolveDefinition(planDefinition, requestGroup, action);
@@ -405,7 +406,7 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
             }
             IBaseResource resource = null;
             if (action.hasDefinitionCanonicalType()) {
-                resource = resolveDefinition(planDefinition, requestGroup, action);
+                resource = resolveDefinition(planDefinition, action);
                 if (resource != null) {
                     applyAction(requestGroup, resource, action);
                     requestAction.setResource(new Reference(resource.getIdElement()));
@@ -470,7 +471,6 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
 
     private IBaseResource resolveDefinition(
             PlanDefinition planDefinition,
-            RequestGroup requestGroup,
             PlanDefinition.PlanDefinitionActionComponent action) {
         logger.debug(
                 "Resolving definition {}", action.getDefinitionCanonicalType().getValue());
@@ -478,7 +478,7 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
         var resourceName = resolveResourceName(definition, planDefinition);
         switch (FHIRAllTypes.fromCode(requireNonNull(resourceName))) {
             case PLANDEFINITION:
-                return applyNestedPlanDefinition(requestGroup, definition);
+                return applyNestedPlanDefinition(planDefinition, definition);
             case ACTIVITYDEFINITION:
                 return applyActivityDefinition(planDefinition, definition);
             case QUESTIONNAIRE:
@@ -512,10 +512,9 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
         IBaseResource result = null;
         try {
             var referenceToContained = definition.getValue().startsWith("#");
-            var activityDefinition = (ActivityDefinition)
-                    (referenceToContained
-                            ? resolveContained(planDefinition, definition.getValue())
-                            : SearchHelper.searchRepositoryByCanonical(repository, definition));
+            var activityDefinition = (ActivityDefinition) (referenceToContained
+                    ? resolveContained(planDefinition, definition.getValue())
+                    : SearchHelper.searchRepositoryByCanonical(repository, definition));
             result = this.activityDefinitionProcessor.apply(
                     activityDefinition,
                     subjectId,
@@ -548,15 +547,15 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
         return result;
     }
 
-    private IBaseResource applyNestedPlanDefinition(RequestGroup requestGroup, CanonicalType definition) {
+    private IBaseResource applyNestedPlanDefinition(PlanDefinition planDefinition, CanonicalType definition) {
         RequestGroup result = null;
         try {
-            var planDefinition = (PlanDefinition) SearchHelper.searchRepositoryByCanonical(repository, definition);
-            result = (RequestGroup) applyPlanDefinition(planDefinition);
-
-            for (var c : result.getInstantiatesCanonical()) {
-                requestGroup.addInstantiatesCanonical(c.getValueAsString());
-            }
+            var referenceToContained = definition.getValue().startsWith("#");
+            var nextPlanDefinition = (PlanDefinition)
+                    (referenceToContained
+                            ? resolveContained(planDefinition, definition.getValue())
+                            : SearchHelper.searchRepositoryByCanonical(repository, definition));
+            result = (RequestGroup) applyPlanDefinition(nextPlanDefinition);
         } catch (Exception e) {
             var message = String.format(
                     "ERROR: PlanDefinition %s could not be applied and threw exception %s",
@@ -576,7 +575,8 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
     }
 
     /*
-     * offset -> Duration timing -> Timing ( just our use case for connectathon period periodUnit
+     * offset -> Duration timing -> Timing ( just our use case for connectathon
+     * period periodUnit
      * frequency count ) use task code
      */
     private void resolveTask(
@@ -636,12 +636,12 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
     private void resolvePrepopulateAction(
             PlanDefinition.PlanDefinitionActionComponent action, RequestGroup requestGroup, Task task) {
         if (action.hasExtension(Constants.SDC_QUESTIONNAIRE_PREPOPULATE)) {
-            var questionnaireBundles =
-                    getQuestionnairePackage(action.getExtensionByUrl(Constants.SDC_QUESTIONNAIRE_PREPOPULATE));
+            var questionnaireBundles = getQuestionnairePackage(
+                    action.getExtensionByUrl(Constants.SDC_QUESTIONNAIRE_PREPOPULATE));
             for (var questionnaireBundle : questionnaireBundles) {
-                var toPopulate =
-                        (Questionnaire) questionnaireBundle.getEntryFirstRep().getResource();
-                // Bundle should contain a Questionnaire and supporting Library and ValueSet resources
+                var toPopulate = (Questionnaire) questionnaireBundle.getEntryFirstRep().getResource();
+                // Bundle should contain a Questionnaire and supporting Library and ValueSet
+                // resources
                 var libraries = questionnaireBundle.getEntry().stream()
                         .filter(e -> e.hasResource()
                                 && (e.getResource().fhirType().equals(Enumerations.FHIRAllTypes.LIBRARY.toCode())))
@@ -652,8 +652,8 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
                                 && (e.getResource().fhirType().equals(Enumerations.FHIRAllTypes.VALUESET.toCode())))
                         .map(e -> (ValueSet) e.getResource())
                         .collect(Collectors.toList());
-                var additionalData =
-                        bundle == null ? new Bundle().setType(BundleType.COLLECTION) : ((Bundle) bundle).copy();
+                var additionalData = bundle == null ? new Bundle().setType(BundleType.COLLECTION)
+                        : ((Bundle) bundle).copy();
                 libraries.forEach(
                         library -> additionalData.addEntry(new Bundle.BundleEntryComponent().setResource(library)));
                 valueSets.forEach(
@@ -675,24 +675,25 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
 
     private List<Bundle> getQuestionnairePackage(Extension prepopulateExtension) {
         Bundle bundle = null;
-        // PlanDef action should provide endpoint for $questionnaire-for-order operation as well as
+        // PlanDef action should provide endpoint for $questionnaire-for-order operation
+        // as well as
         // the order id to pass
-        var parameterExtension =
-                prepopulateExtension.getExtensionByUrl(Constants.SDC_QUESTIONNAIRE_PREPOPULATE_PARAMETER);
+        var parameterExtension = prepopulateExtension
+                .getExtensionByUrl(Constants.SDC_QUESTIONNAIRE_PREPOPULATE_PARAMETER);
         if (parameterExtension == null) {
             throw new IllegalArgumentException(String.format(
                     "Required extension for %s not found.", Constants.SDC_QUESTIONNAIRE_PREPOPULATE_PARAMETER));
         }
         var parameterName = parameterExtension.getValue().toString();
-        var prepopulateParameter =
-                this.parameters != null ? ((Parameters) this.parameters).getParameter(parameterName) : null;
+        var prepopulateParameter = this.parameters != null ? ((Parameters) this.parameters).getParameter(parameterName)
+                : null;
         if (prepopulateParameter == null) {
             throw new IllegalArgumentException(String.format("Parameter not found: %s ", parameterName));
         }
         var orderId = prepopulateParameter.toString();
 
-        var questionnaireExtension =
-                prepopulateExtension.getExtensionByUrl(Constants.SDC_QUESTIONNAIRE_LOOKUP_QUESTIONNAIRE);
+        var questionnaireExtension = prepopulateExtension
+                .getExtensionByUrl(Constants.SDC_QUESTIONNAIRE_LOOKUP_QUESTIONNAIRE);
         if (questionnaireExtension == null) {
             throw new IllegalArgumentException(String.format(
                     "Required extension for %s not found.", Constants.SDC_QUESTIONNAIRE_LOOKUP_QUESTIONNAIRE));
@@ -705,10 +706,11 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
                 bundle = new Bundle().addEntry(new Bundle.BundleEntryComponent().setResource(questionnaire));
             }
         } else if (questionnaireExtension.getValue().hasType(FHIRAllTypes.URL.toCode())) {
-            // Assuming package operation endpoint if the extension is using valueUrl instead of
+            // Assuming package operation endpoint if the extension is using valueUrl
+            // instead of
             // valueCanonical
-            bundle =
-                    callQuestionnairePackageOperation(((UrlType) questionnaireExtension.getValue()).getValueAsString());
+            bundle = callQuestionnairePackageOperation(
+                    ((UrlType) questionnaireExtension.getValue()).getValueAsString());
         }
 
         if (bundle == null) {
@@ -734,7 +736,8 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
         IGenericClient client = Clients.forUrl(repository.fhirContext(), baseUrl);
         // Clients.registerBasicAuth(client, user, password);
         try {
-            // TODO: This is not currently in use, but if it ever is we will need to determine how the
+            // TODO: This is not currently in use, but if it ever is we will need to
+            // determine how the
             // order and coverage resources are passed in
             Type order = null;
             Type coverage = null;

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/r4/PlanDefinitionProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/r4/PlanDefinitionProcessor.java
@@ -30,7 +30,6 @@ import org.hl7.fhir.r4.model.Goal;
 import org.hl7.fhir.r4.model.Goal.GoalLifecycleStatus;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Library;
-import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.MetadataResource;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Parameters;
@@ -68,7 +67,7 @@ import org.opencds.cqf.fhir.utility.r4.SearchHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings({ "unused", "squid:S107" })
+@SuppressWarnings({"unused", "squid:S107"})
 public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDefinition> {
 
     private static final Logger logger = LoggerFactory.getLogger(PlanDefinitionProcessor.class);
@@ -101,11 +100,11 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
 
         var questionnaireResponses = ((Bundle) bundle)
                 .getEntry().stream()
-                .filter(entry -> entry.getResource()
-                        .fhirType()
-                        .equals(Enumerations.FHIRAllTypes.QUESTIONNAIRERESPONSE.toCode()))
-                .map(entry -> (QuestionnaireResponse) entry.getResource())
-                .collect(Collectors.toList());
+                        .filter(entry -> entry.getResource()
+                                .fhirType()
+                                .equals(Enumerations.FHIRAllTypes.QUESTIONNAIRERESPONSE.toCode()))
+                        .map(entry -> (QuestionnaireResponse) entry.getResource())
+                        .collect(Collectors.toList());
         if (questionnaireResponses != null && !questionnaireResponses.isEmpty()) {
             for (var questionnaireResponse : questionnaireResponses) {
                 try {
@@ -130,7 +129,8 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
         bundle.setType(BundleType.TRANSACTION);
         bundle.addEntry(PackageHelper.createEntry(thePlanDefinition, theIsPut));
         // The CPG IG specifies a main cql library for a PlanDefinition
-        var libraryCanonical = thePlanDefinition.hasLibrary() ? thePlanDefinition.getLibrary().get(0) : null;
+        var libraryCanonical =
+                thePlanDefinition.hasLibrary() ? thePlanDefinition.getLibrary().get(0) : null;
         if (libraryCanonical != null) {
             var library = (Library) SearchHelper.searchRepositoryByCanonical(repository, libraryCanonical);
             if (library != null) {
@@ -160,9 +160,9 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
         requireNonNull(basePlanDefinition, "Couldn't find PlanDefinition " + theId);
 
         return castOrThrow(
-                basePlanDefinition,
-                PlanDefinition.class,
-                "The planDefinition passed in was not a valid instance of PlanDefinition.class")
+                        basePlanDefinition,
+                        PlanDefinition.class,
+                        "The planDefinition passed in was not a valid instance of PlanDefinition.class")
                 .orElse(null);
     }
 
@@ -177,12 +177,12 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
 
         this.questionnaire = new Questionnaire();
         this.questionnaire.setId(new IdType(FHIRAllTypes.QUESTIONNAIRE.toCode(), planDefinition.getIdPart()));
-        this.questionnaireItemGenerator = QuestionnaireItemGenerator.of(repository, subjectId, parameters, bundle,
-                libraryEngine);
+        this.questionnaireItemGenerator =
+                QuestionnaireItemGenerator.of(repository, subjectId, parameters, bundle, libraryEngine);
         this.inputParameterResolver = new InputParameterResolver(
                 subjectId, encounterId, practitionerId, parameters, useServerData, bundle, repository);
-        this.extensionResolver = new ExtensionResolver(subjectId, inputParameterResolver.getParameters(), bundle,
-                libraryEngine);
+        this.extensionResolver =
+                new ExtensionResolver(subjectId, inputParameterResolver.getParameters(), bundle, libraryEngine);
 
         return planDefinition;
     }
@@ -223,9 +223,9 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
         }
 
         var defaultLibraryUrl = planDefinition.getLibrary() == null
-                || planDefinition.getLibrary().isEmpty()
-                        ? null
-                        : planDefinition.getLibrary().get(0).getValue();
+                        || planDefinition.getLibrary().isEmpty()
+                ? null
+                : planDefinition.getLibrary().get(0).getValue();
         extensionResolver.resolveExtensions(requestGroup.getExtension(), defaultLibraryUrl);
 
         for (int i = 0; i < planDefinition.getGoal().size(); i++) {
@@ -470,8 +470,7 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
     }
 
     private IBaseResource resolveDefinition(
-            PlanDefinition planDefinition,
-            PlanDefinition.PlanDefinitionActionComponent action) {
+            PlanDefinition planDefinition, PlanDefinition.PlanDefinitionActionComponent action) {
         logger.debug(
                 "Resolving definition {}", action.getDefinitionCanonicalType().getValue());
         var definition = action.getDefinitionCanonicalType();
@@ -512,9 +511,10 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
         IBaseResource result = null;
         try {
             var referenceToContained = definition.getValue().startsWith("#");
-            var activityDefinition = (ActivityDefinition) (referenceToContained
-                    ? resolveContained(planDefinition, definition.getValue())
-                    : SearchHelper.searchRepositoryByCanonical(repository, definition));
+            var activityDefinition = (ActivityDefinition)
+                    (referenceToContained
+                            ? resolveContained(planDefinition, definition.getValue())
+                            : SearchHelper.searchRepositoryByCanonical(repository, definition));
             result = this.activityDefinitionProcessor.apply(
                     activityDefinition,
                     subjectId,
@@ -636,10 +636,11 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
     private void resolvePrepopulateAction(
             PlanDefinition.PlanDefinitionActionComponent action, RequestGroup requestGroup, Task task) {
         if (action.hasExtension(Constants.SDC_QUESTIONNAIRE_PREPOPULATE)) {
-            var questionnaireBundles = getQuestionnairePackage(
-                    action.getExtensionByUrl(Constants.SDC_QUESTIONNAIRE_PREPOPULATE));
+            var questionnaireBundles =
+                    getQuestionnairePackage(action.getExtensionByUrl(Constants.SDC_QUESTIONNAIRE_PREPOPULATE));
             for (var questionnaireBundle : questionnaireBundles) {
-                var toPopulate = (Questionnaire) questionnaireBundle.getEntryFirstRep().getResource();
+                var toPopulate =
+                        (Questionnaire) questionnaireBundle.getEntryFirstRep().getResource();
                 // Bundle should contain a Questionnaire and supporting Library and ValueSet
                 // resources
                 var libraries = questionnaireBundle.getEntry().stream()
@@ -652,8 +653,8 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
                                 && (e.getResource().fhirType().equals(Enumerations.FHIRAllTypes.VALUESET.toCode())))
                         .map(e -> (ValueSet) e.getResource())
                         .collect(Collectors.toList());
-                var additionalData = bundle == null ? new Bundle().setType(BundleType.COLLECTION)
-                        : ((Bundle) bundle).copy();
+                var additionalData =
+                        bundle == null ? new Bundle().setType(BundleType.COLLECTION) : ((Bundle) bundle).copy();
                 libraries.forEach(
                         library -> additionalData.addEntry(new Bundle.BundleEntryComponent().setResource(library)));
                 valueSets.forEach(
@@ -678,22 +679,22 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
         // PlanDef action should provide endpoint for $questionnaire-for-order operation
         // as well as
         // the order id to pass
-        var parameterExtension = prepopulateExtension
-                .getExtensionByUrl(Constants.SDC_QUESTIONNAIRE_PREPOPULATE_PARAMETER);
+        var parameterExtension =
+                prepopulateExtension.getExtensionByUrl(Constants.SDC_QUESTIONNAIRE_PREPOPULATE_PARAMETER);
         if (parameterExtension == null) {
             throw new IllegalArgumentException(String.format(
                     "Required extension for %s not found.", Constants.SDC_QUESTIONNAIRE_PREPOPULATE_PARAMETER));
         }
         var parameterName = parameterExtension.getValue().toString();
-        var prepopulateParameter = this.parameters != null ? ((Parameters) this.parameters).getParameter(parameterName)
-                : null;
+        var prepopulateParameter =
+                this.parameters != null ? ((Parameters) this.parameters).getParameter(parameterName) : null;
         if (prepopulateParameter == null) {
             throw new IllegalArgumentException(String.format("Parameter not found: %s ", parameterName));
         }
         var orderId = prepopulateParameter.toString();
 
-        var questionnaireExtension = prepopulateExtension
-                .getExtensionByUrl(Constants.SDC_QUESTIONNAIRE_LOOKUP_QUESTIONNAIRE);
+        var questionnaireExtension =
+                prepopulateExtension.getExtensionByUrl(Constants.SDC_QUESTIONNAIRE_LOOKUP_QUESTIONNAIRE);
         if (questionnaireExtension == null) {
             throw new IllegalArgumentException(String.format(
                     "Required extension for %s not found.", Constants.SDC_QUESTIONNAIRE_LOOKUP_QUESTIONNAIRE));
@@ -709,8 +710,8 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
             // Assuming package operation endpoint if the extension is using valueUrl
             // instead of
             // valueCanonical
-            bundle = callQuestionnairePackageOperation(
-                    ((UrlType) questionnaireExtension.getValue()).getValueAsString());
+            bundle =
+                    callQuestionnairePackageOperation(((UrlType) questionnaireExtension.getValue()).getValueAsString());
         }
 
         if (bundle == null) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/r5/PlanDefinitionProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/r5/PlanDefinitionProcessor.java
@@ -37,7 +37,6 @@ import org.hl7.fhir.r5.model.Goal;
 import org.hl7.fhir.r5.model.Goal.GoalLifecycleStatus;
 import org.hl7.fhir.r5.model.IdType;
 import org.hl7.fhir.r5.model.Library;
-import org.hl7.fhir.r5.model.Meta;
 import org.hl7.fhir.r5.model.MetadataResource;
 import org.hl7.fhir.r5.model.OperationOutcome;
 import org.hl7.fhir.r5.model.Parameters;
@@ -417,8 +416,7 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
     }
 
     private IBaseResource resolveDefinition(
-            PlanDefinition planDefinition,
-            PlanDefinition.PlanDefinitionActionComponent action) {
+            PlanDefinition planDefinition, PlanDefinition.PlanDefinitionActionComponent action) {
         logger.debug(
                 "Resolving definition {}", action.getDefinitionCanonicalType().getValue());
         var definition = action.getDefinitionCanonicalType();

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/r5/PlanDefinitionProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/r5/PlanDefinitionProcessor.java
@@ -205,7 +205,7 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
                 .setSubject(new Reference(subjectId));
         requestOrchestration.setId(new IdType(
                 requestOrchestration.fhirType(), planDefinition.getIdElement().getIdPart()));
-        requestOrchestration.setMeta(new Meta().addProfile(Constants.CPG_STRATEGY));
+        // requestOrchestration.setMeta(new Meta().addProfile(Constants.CPG_STRATEGY));
         if (encounterId != null) {
             requestOrchestration.setEncounter(new Reference(encounterId));
         }
@@ -356,7 +356,7 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
             }
             IBaseResource resource = null;
             if (action.hasDefinitionCanonicalType()) {
-                resource = resolveDefinition(planDefinition, requestOrchestration, action);
+                resource = resolveDefinition(planDefinition, action);
                 if (resource != null) {
                     applyAction(requestOrchestration, resource, action);
                     requestAction.setResource(new Reference(resource.getIdElement()));
@@ -418,7 +418,6 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
 
     private IBaseResource resolveDefinition(
             PlanDefinition planDefinition,
-            RequestOrchestration requestOrchestration,
             PlanDefinition.PlanDefinitionActionComponent action) {
         logger.debug(
                 "Resolving definition {}", action.getDefinitionCanonicalType().getValue());
@@ -426,7 +425,7 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
         var resourceName = resolveResourceName(definition, planDefinition);
         switch (FHIRTypes.fromCode(requireNonNull(resourceName))) {
             case PLANDEFINITION:
-                return applyNestedPlanDefinition(requestOrchestration, definition);
+                return applyNestedPlanDefinition(planDefinition, definition);
             case ACTIVITYDEFINITION:
                 return applyActivityDefinition(planDefinition, definition);
             case QUESTIONNAIRE:
@@ -496,16 +495,15 @@ public class PlanDefinitionProcessor extends BasePlanDefinitionProcessor<PlanDef
         return result;
     }
 
-    private IBaseResource applyNestedPlanDefinition(
-            RequestOrchestration requestOrchestration, CanonicalType definition) {
+    private IBaseResource applyNestedPlanDefinition(PlanDefinition planDefinition, CanonicalType definition) {
         RequestOrchestration result = null;
         try {
-            var planDefinition = (PlanDefinition) SearchHelper.searchRepositoryByCanonical(repository, definition);
-            result = (RequestOrchestration) applyPlanDefinition(planDefinition);
-
-            for (var c : result.getInstantiatesCanonical()) {
-                requestOrchestration.addInstantiatesCanonical(c.getValueAsString());
-            }
+            var referenceToContained = definition.getValue().startsWith("#");
+            var nextPlanDefinition = (PlanDefinition)
+                    (referenceToContained
+                            ? resolveContained(planDefinition, definition.getValue())
+                            : SearchHelper.searchRepositoryByCanonical(repository, definition));
+            result = (RequestOrchestration) applyPlanDefinition(nextPlanDefinition);
         } catch (Exception e) {
             var message = String.format(
                     "ERROR: PlanDefinition %s could not be applied and threw exception %s",

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/dstu3/QuestionnaireResponseProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/dstu3/QuestionnaireResponseProcessor.java
@@ -3,6 +3,7 @@ package org.opencds.cqf.fhir.cr.questionnaireresponse.dstu3;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,10 +14,12 @@ import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.DateTimeType;
 import org.hl7.fhir.dstu3.model.DateType;
+import org.hl7.fhir.dstu3.model.DomainResource;
 import org.hl7.fhir.dstu3.model.Enumerations.FHIRAllTypes;
 import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.IdType;
 import org.hl7.fhir.dstu3.model.InstantType;
+import org.hl7.fhir.dstu3.model.Meta;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Property;
 import org.hl7.fhir.dstu3.model.Questionnaire;
@@ -53,9 +56,9 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         }
 
         return castOrThrow(
-                        baseQuestionnaireResponse,
-                        QuestionnaireResponse.class,
-                        "The QuestionnaireResponse passed to repository was not a valid instance of QuestionnaireResponse.class")
+                baseQuestionnaireResponse,
+                QuestionnaireResponse.class,
+                "The QuestionnaireResponse passed to repository was not a valid instance of QuestionnaireResponse.class")
                 .orElse(null);
     }
 
@@ -84,8 +87,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         patientId = questionnaireResponse.getSubject().getId();
         libraryUrl = questionnaireResponse.hasExtension(Constants.CQF_LIBRARY)
                 ? ((StringType) questionnaireResponse
-                                .getExtensionByUrl(Constants.CQF_LIBRARY)
-                                .getValue())
+                        .getExtensionByUrl(Constants.CQF_LIBRARY)
+                        .getValue())
                         .getValue()
                 : null;
     }
@@ -133,8 +136,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         var subjectItems = item.getItem().stream()
                 .filter(child -> child.hasExtension(Constants.SDC_QUESTIONNAIRE_RESPONSE_IS_SUBJECT))
                 .collect(Collectors.toList());
-        var groupSubject =
-                !subjectItems.isEmpty() ? subjectItems.get(0).getAnswer().get(0).getValueReference() : subject.copy();
+        var groupSubject = !subjectItems.isEmpty() ? subjectItems.get(0).getAnswer().get(0).getValueReference()
+                : subject.copy();
         if (item.hasDefinition()) {
             processDefinitionItem(item, questionnaireResponse, resources, groupSubject);
         } else {
@@ -160,6 +163,34 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         return property;
     }
 
+    private Property getAuthorProperty(Resource resource) {
+        var property = resource.getNamedProperty("recorder");
+        if (property == null && resource.fhirType().equals(FHIRAllTypes.OBSERVATION.toCode())) {
+            property = resource.getNamedProperty("performer");
+        }
+
+        return property;
+    }
+
+    private List<Property> getDateProperties(Resource resource) {
+        List<Property> results = new ArrayList<>();
+        results.add(resource.getNamedProperty("onset"));
+        results.add(resource.getNamedProperty("issued"));
+        results.add(resource.getNamedProperty("effective"));
+        results.add(resource.getNamedProperty("recordDate"));
+
+        return results.stream().filter(p -> p != null).collect(Collectors.toList());
+    }
+
+    private void resolveMeta(DomainResource resource, String definition) {
+        var meta = new Meta();
+        // Consider setting source and lastUpdated here?
+        if (definition != null && !definition.isEmpty()) {
+            meta.addProfile(definition.split("#")[0]);
+            resource.setMeta(meta);
+        }
+    }
+
     private String getDefinitionType(String definition) {
         return definition.split("#")[1];
     }
@@ -174,10 +205,33 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
 
         var resourceType = getDefinitionType(item.getDefinition());
         var resource = (Resource) newValue(resourceType);
-        resource.setId(new IdType(resourceType, getExtractId(questionnaireResponse) + "." + item.getLinkId()));
+        resource.setId(new IdType(resourceType, getExtractId(questionnaireResponse) + "-" + item.getLinkId()));
+        resolveMeta((DomainResource) resource, item.getDefinition());
         var subjectProperty = getSubjectProperty(resource);
         if (subjectProperty != null) {
             resource.setProperty(subjectProperty.getName(), subject);
+        }
+        var authorProperty = getAuthorProperty(resource);
+        if (authorProperty != null && questionnaireResponse.hasAuthor()) {
+            resource.setProperty(authorProperty.getName(), questionnaireResponse.getAuthor());
+        }
+        var dateProperties = getDateProperties(resource);
+        if (dateProperties != null && !dateProperties.isEmpty() && questionnaireResponse.hasAuthored()) {
+            dateProperties.forEach(p -> {
+                try {
+                    var propertyDef = fhirContext().getElementDefinition(
+                            p.getTypeCode().contains("|") ? p.getTypeCode().split("\\|")[0] : p.getTypeCode());
+                    if (propertyDef != null) {
+                        modelResolver.setValue(resource, p.getName(), propertyDef.getImplementingClass()
+                                .getConstructor(Date.class).newInstance(questionnaireResponse.getAuthored()));
+                    }
+                } catch (Exception ex) {
+                    var message = String.format(
+                            "Error encountered attempting to set property (%s) on resource type (%s): %s",
+                            p.getName(), resource.fhirType(), ex.getMessage());
+                    logger.error(message);
+                }
+            });
         }
         item.getItem().forEach(childItem -> {
             if (childItem.hasDefinition()) {
@@ -185,15 +239,9 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
                 var path = definition[1];
                 // First element is always the resource type, so it can be ignored
                 path = path.replace(resourceType + ".", "");
-                // var property = modelResolver.resolvePath(resource, path);
                 var answerValue = childItem.getAnswerFirstRep().getValue();
-                // transformAnswerValue(childItem.getAnswerFirstRep().getValue(), "");
                 if (answerValue != null) {
-                    // if (path.contains(".")) {
-                    // nestedValueResolver.setNestedValue(resource, path, answerValue);
-                    // } else {
                     modelResolver.setValue(resource, path, answerValue);
-                    // }
                 }
             }
         });
@@ -262,8 +310,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         // obs.setFocus();
         // obs.setEncounter(questionnaireResponse.getEncounter());
         var authoredDate = new DateTimeType((questionnaireResponse.hasAuthored()
-                        ? questionnaireResponse.getAuthored().toInstant()
-                        : Instant.now())
+                ? questionnaireResponse.getAuthored().toInstant()
+                : Instant.now())
                 .toString());
         obs.setEffective(authoredDate);
         obs.setIssuedElement(new InstantType(authoredDate));
@@ -301,7 +349,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
     // String url = mySdcProperties.getExtract().getEndpoint();
     // if (null == url || url.length() < 1) {
     // throw new IllegalArgumentException(
-    // "Unable to transmit observation bundle. No observation.endpoint defined in sdc properties.");
+    // "Unable to transmit observation bundle. No observation.endpoint defined in
+    // sdc properties.");
     // }
     // String user = mySdcProperties.getExtract().getUsername();
     // String password = mySdcProperties.getExtract().getPassword();

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/dstu3/QuestionnaireResponseProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/dstu3/QuestionnaireResponseProcessor.java
@@ -56,9 +56,9 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         }
 
         return castOrThrow(
-                baseQuestionnaireResponse,
-                QuestionnaireResponse.class,
-                "The QuestionnaireResponse passed to repository was not a valid instance of QuestionnaireResponse.class")
+                        baseQuestionnaireResponse,
+                        QuestionnaireResponse.class,
+                        "The QuestionnaireResponse passed to repository was not a valid instance of QuestionnaireResponse.class")
                 .orElse(null);
     }
 
@@ -87,8 +87,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         patientId = questionnaireResponse.getSubject().getId();
         libraryUrl = questionnaireResponse.hasExtension(Constants.CQF_LIBRARY)
                 ? ((StringType) questionnaireResponse
-                        .getExtensionByUrl(Constants.CQF_LIBRARY)
-                        .getValue())
+                                .getExtensionByUrl(Constants.CQF_LIBRARY)
+                                .getValue())
                         .getValue()
                 : null;
     }
@@ -136,8 +136,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         var subjectItems = item.getItem().stream()
                 .filter(child -> child.hasExtension(Constants.SDC_QUESTIONNAIRE_RESPONSE_IS_SUBJECT))
                 .collect(Collectors.toList());
-        var groupSubject = !subjectItems.isEmpty() ? subjectItems.get(0).getAnswer().get(0).getValueReference()
-                : subject.copy();
+        var groupSubject =
+                !subjectItems.isEmpty() ? subjectItems.get(0).getAnswer().get(0).getValueReference() : subject.copy();
         if (item.hasDefinition()) {
             processDefinitionItem(item, questionnaireResponse, resources, groupSubject);
         } else {
@@ -219,11 +219,19 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         if (dateProperties != null && !dateProperties.isEmpty() && questionnaireResponse.hasAuthored()) {
             dateProperties.forEach(p -> {
                 try {
-                    var propertyDef = fhirContext().getElementDefinition(
-                            p.getTypeCode().contains("|") ? p.getTypeCode().split("\\|")[0] : p.getTypeCode());
+                    var propertyDef = fhirContext()
+                            .getElementDefinition(
+                                    p.getTypeCode().contains("|")
+                                            ? p.getTypeCode().split("\\|")[0]
+                                            : p.getTypeCode());
                     if (propertyDef != null) {
-                        modelResolver.setValue(resource, p.getName(), propertyDef.getImplementingClass()
-                                .getConstructor(Date.class).newInstance(questionnaireResponse.getAuthored()));
+                        modelResolver.setValue(
+                                resource,
+                                p.getName(),
+                                propertyDef
+                                        .getImplementingClass()
+                                        .getConstructor(Date.class)
+                                        .newInstance(questionnaireResponse.getAuthored()));
                     }
                 } catch (Exception ex) {
                     var message = String.format(
@@ -310,8 +318,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         // obs.setFocus();
         // obs.setEncounter(questionnaireResponse.getEncounter());
         var authoredDate = new DateTimeType((questionnaireResponse.hasAuthored()
-                ? questionnaireResponse.getAuthored().toInstant()
-                : Instant.now())
+                        ? questionnaireResponse.getAuthored().toInstant()
+                        : Instant.now())
                 .toString());
         obs.setEffective(authoredDate);
         obs.setIssuedElement(new InstantType(authoredDate));

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/r4/QuestionnaireResponseProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/r4/QuestionnaireResponseProcessor.java
@@ -3,6 +3,7 @@ package org.opencds.cqf.fhir.cr.questionnaireresponse.r4;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,11 +19,13 @@ import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.DateType;
+import org.hl7.fhir.r4.model.DomainResource;
 import org.hl7.fhir.r4.model.Enumerations.FHIRAllTypes;
 import org.hl7.fhir.r4.model.Expression;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.InstantType;
+import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Property;
 import org.hl7.fhir.r4.model.Questionnaire;
@@ -57,9 +60,9 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         }
 
         return castOrThrow(
-                        baseQuestionnaireResponse,
-                        QuestionnaireResponse.class,
-                        "The QuestionnaireResponse passed to repository was not a valid instance of QuestionnaireResponse.class")
+                baseQuestionnaireResponse,
+                QuestionnaireResponse.class,
+                "The QuestionnaireResponse passed to repository was not a valid instance of QuestionnaireResponse.class")
                 .orElse(null);
     }
 
@@ -88,8 +91,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         patientId = questionnaireResponse.getSubject().getId();
         libraryUrl = questionnaireResponse.hasExtension(Constants.CQF_LIBRARY)
                 ? ((CanonicalType) questionnaireResponse
-                                .getExtensionByUrl(Constants.CQF_LIBRARY)
-                                .getValue())
+                        .getExtensionByUrl(Constants.CQF_LIBRARY)
+                        .getValue())
                         .getValue()
                 : null;
     }
@@ -137,8 +140,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         var subjectItems = item.getItem().stream()
                 .filter(child -> child.hasExtension(Constants.SDC_QUESTIONNAIRE_RESPONSE_IS_SUBJECT))
                 .collect(Collectors.toList());
-        var groupSubject =
-                !subjectItems.isEmpty() ? subjectItems.get(0).getAnswer().get(0).getValueReference() : subject.copy();
+        var groupSubject = !subjectItems.isEmpty() ? subjectItems.get(0).getAnswer().get(0).getValueReference()
+                : subject.copy();
         if (item.hasDefinition()) {
             processDefinitionItem(item, questionnaireResponse, resources, groupSubject);
         } else {
@@ -162,6 +165,34 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         }
 
         return property;
+    }
+
+    private Property getAuthorProperty(Resource resource) {
+        var property = resource.getNamedProperty("recorder");
+        if (property == null && resource.fhirType().equals(FHIRAllTypes.OBSERVATION.toCode())) {
+            property = resource.getNamedProperty("performer");
+        }
+
+        return property;
+    }
+
+    private List<Property> getDateProperties(Resource resource) {
+        List<Property> results = new ArrayList<>();
+        results.add(resource.getNamedProperty("onset"));
+        results.add(resource.getNamedProperty("issued"));
+        results.add(resource.getNamedProperty("effective"));
+        results.add(resource.getNamedProperty("recordDate"));
+
+        return results.stream().filter(p -> p != null).collect(Collectors.toList());
+    }
+
+    private void resolveMeta(DomainResource resource, String definition) {
+        var meta = new Meta();
+        // Consider setting source and lastUpdated here?
+        if (definition != null && !definition.isEmpty()) {
+            meta.addProfile(definition.split("#")[0]);
+            resource.setMeta(meta);
+        }
     }
 
     private List<IBase> getExpressionResult(Expression expression, String itemLinkId) {
@@ -210,10 +241,33 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
 
         var resourceType = getDefinitionType(item.getDefinition());
         var resource = (Resource) newValue(resourceType);
-        resource.setId(new IdType(resourceType, getExtractId(questionnaireResponse) + "." + item.getLinkId()));
+        resource.setId(new IdType(resourceType, getExtractId(questionnaireResponse) + "-" + item.getLinkId()));
+        resolveMeta((DomainResource) resource, item.getDefinition());
         var subjectProperty = getSubjectProperty(resource);
         if (subjectProperty != null) {
             resource.setProperty(subjectProperty.getName(), subject);
+        }
+        var authorProperty = getAuthorProperty(resource);
+        if (authorProperty != null && questionnaireResponse.hasAuthor()) {
+            resource.setProperty(authorProperty.getName(), questionnaireResponse.getAuthor());
+        }
+        var dateProperties = getDateProperties(resource);
+        if (dateProperties != null && !dateProperties.isEmpty() && questionnaireResponse.hasAuthored()) {
+            dateProperties.forEach(p -> {
+                try {
+                    var propertyDef = fhirContext().getElementDefinition(
+                            p.getTypeCode().contains("|") ? p.getTypeCode().split("\\|")[0] : p.getTypeCode());
+                    if (propertyDef != null) {
+                        modelResolver.setValue(resource, p.getName(), propertyDef.getImplementingClass()
+                                .getConstructor(Date.class).newInstance(questionnaireResponse.getAuthored()));
+                    }
+                } catch (Exception ex) {
+                    var message = String.format(
+                            "Error encountered attempting to set property (%s) on resource type (%s): %s",
+                            p.getName(), resource.fhirType(), ex.getMessage());
+                    logger.error(message);
+                }
+            });
         }
         item.getItem().forEach(childItem -> {
             if (childItem.hasDefinition()) {
@@ -223,11 +277,7 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
                 path = path.replace(resourceType + ".", "");
                 var answerValue = childItem.getAnswerFirstRep().getValue();
                 if (answerValue != null) {
-                    // if (path.contains(".")) {
-                    // nestedValueResolver.setNestedValue(resource, path, answerValue);
-                    // } else {
                     modelResolver.setValue(resource, path, answerValue);
-                    // }
                 }
             }
         });
@@ -296,8 +346,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         // obs.setFocus();
         obs.setEncounter(questionnaireResponse.getEncounter());
         var authoredDate = new DateTimeType((questionnaireResponse.hasAuthored()
-                        ? questionnaireResponse.getAuthored().toInstant()
-                        : Instant.now())
+                ? questionnaireResponse.getAuthored().toInstant()
+                : Instant.now())
                 .toString());
         obs.setEffective(authoredDate);
         obs.setIssuedElement(new InstantType(authoredDate));
@@ -331,7 +381,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
     // String url = mySdcProperties.getExtract().getEndpoint();
     // if (null == url || url.length() < 1) {
     // throw new IllegalArgumentException(
-    // "Unable to transmit observation bundle. No observation.endpoint defined in sdc properties.");
+    // "Unable to transmit observation bundle. No observation.endpoint defined in
+    // sdc properties.");
     // }
     // String user = mySdcProperties.getExtract().getUsername();
     // String password = mySdcProperties.getExtract().getPassword();

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/r4/QuestionnaireResponseProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/r4/QuestionnaireResponseProcessor.java
@@ -60,9 +60,9 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         }
 
         return castOrThrow(
-                baseQuestionnaireResponse,
-                QuestionnaireResponse.class,
-                "The QuestionnaireResponse passed to repository was not a valid instance of QuestionnaireResponse.class")
+                        baseQuestionnaireResponse,
+                        QuestionnaireResponse.class,
+                        "The QuestionnaireResponse passed to repository was not a valid instance of QuestionnaireResponse.class")
                 .orElse(null);
     }
 
@@ -91,8 +91,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         patientId = questionnaireResponse.getSubject().getId();
         libraryUrl = questionnaireResponse.hasExtension(Constants.CQF_LIBRARY)
                 ? ((CanonicalType) questionnaireResponse
-                        .getExtensionByUrl(Constants.CQF_LIBRARY)
-                        .getValue())
+                                .getExtensionByUrl(Constants.CQF_LIBRARY)
+                                .getValue())
                         .getValue()
                 : null;
     }
@@ -140,8 +140,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         var subjectItems = item.getItem().stream()
                 .filter(child -> child.hasExtension(Constants.SDC_QUESTIONNAIRE_RESPONSE_IS_SUBJECT))
                 .collect(Collectors.toList());
-        var groupSubject = !subjectItems.isEmpty() ? subjectItems.get(0).getAnswer().get(0).getValueReference()
-                : subject.copy();
+        var groupSubject =
+                !subjectItems.isEmpty() ? subjectItems.get(0).getAnswer().get(0).getValueReference() : subject.copy();
         if (item.hasDefinition()) {
             processDefinitionItem(item, questionnaireResponse, resources, groupSubject);
         } else {
@@ -255,11 +255,19 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         if (dateProperties != null && !dateProperties.isEmpty() && questionnaireResponse.hasAuthored()) {
             dateProperties.forEach(p -> {
                 try {
-                    var propertyDef = fhirContext().getElementDefinition(
-                            p.getTypeCode().contains("|") ? p.getTypeCode().split("\\|")[0] : p.getTypeCode());
+                    var propertyDef = fhirContext()
+                            .getElementDefinition(
+                                    p.getTypeCode().contains("|")
+                                            ? p.getTypeCode().split("\\|")[0]
+                                            : p.getTypeCode());
                     if (propertyDef != null) {
-                        modelResolver.setValue(resource, p.getName(), propertyDef.getImplementingClass()
-                                .getConstructor(Date.class).newInstance(questionnaireResponse.getAuthored()));
+                        modelResolver.setValue(
+                                resource,
+                                p.getName(),
+                                propertyDef
+                                        .getImplementingClass()
+                                        .getConstructor(Date.class)
+                                        .newInstance(questionnaireResponse.getAuthored()));
                     }
                 } catch (Exception ex) {
                     var message = String.format(
@@ -346,8 +354,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         // obs.setFocus();
         obs.setEncounter(questionnaireResponse.getEncounter());
         var authoredDate = new DateTimeType((questionnaireResponse.hasAuthored()
-                ? questionnaireResponse.getAuthored().toInstant()
-                : Instant.now())
+                        ? questionnaireResponse.getAuthored().toInstant()
+                        : Instant.now())
                 .toString());
         obs.setEffective(authoredDate);
         obs.setIssuedElement(new InstantType(authoredDate));

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/r5/QuestionnaireResponseProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/r5/QuestionnaireResponseProcessor.java
@@ -3,6 +3,7 @@ package org.opencds.cqf.fhir.cr.questionnaireresponse.r5;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,12 +19,14 @@ import org.hl7.fhir.r5.model.CodeableConcept;
 import org.hl7.fhir.r5.model.Coding;
 import org.hl7.fhir.r5.model.DateTimeType;
 import org.hl7.fhir.r5.model.DateType;
+import org.hl7.fhir.r5.model.DomainResource;
 import org.hl7.fhir.r5.model.Enumerations.FHIRTypes;
 import org.hl7.fhir.r5.model.Enumerations.ObservationStatus;
 import org.hl7.fhir.r5.model.Expression;
 import org.hl7.fhir.r5.model.Extension;
 import org.hl7.fhir.r5.model.IdType;
 import org.hl7.fhir.r5.model.InstantType;
+import org.hl7.fhir.r5.model.Meta;
 import org.hl7.fhir.r5.model.Observation;
 import org.hl7.fhir.r5.model.Property;
 import org.hl7.fhir.r5.model.Questionnaire;
@@ -58,9 +61,9 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         }
 
         return castOrThrow(
-                        baseQuestionnaireResponse,
-                        QuestionnaireResponse.class,
-                        "The QuestionnaireResponse passed to repository was not a valid instance of QuestionnaireResponse.class")
+                baseQuestionnaireResponse,
+                QuestionnaireResponse.class,
+                "The QuestionnaireResponse passed to repository was not a valid instance of QuestionnaireResponse.class")
                 .orElse(null);
     }
 
@@ -89,8 +92,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         patientId = questionnaireResponse.getSubject().getId();
         libraryUrl = questionnaireResponse.hasExtension(Constants.CQF_LIBRARY)
                 ? ((CanonicalType) questionnaireResponse
-                                .getExtensionByUrl(Constants.CQF_LIBRARY)
-                                .getValue())
+                        .getExtensionByUrl(Constants.CQF_LIBRARY)
+                        .getValue())
                         .getValue()
                 : null;
     }
@@ -138,8 +141,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         var subjectItems = item.getItem().stream()
                 .filter(child -> child.hasExtension(Constants.SDC_QUESTIONNAIRE_RESPONSE_IS_SUBJECT))
                 .collect(Collectors.toList());
-        var groupSubject =
-                !subjectItems.isEmpty() ? subjectItems.get(0).getAnswer().get(0).getValueReference() : subject.copy();
+        var groupSubject = !subjectItems.isEmpty() ? subjectItems.get(0).getAnswer().get(0).getValueReference()
+                : subject.copy();
         if (item.hasDefinition()) {
             processDefinitionItem(item, questionnaireResponse, resources, groupSubject);
         } else {
@@ -163,6 +166,34 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         }
 
         return property;
+    }
+
+    private Property getAuthorProperty(Resource resource) {
+        var property = resource.getNamedProperty("recorder");
+        if (property == null && resource.fhirType().equals(FHIRTypes.OBSERVATION.toCode())) {
+            property = resource.getNamedProperty("performer");
+        }
+
+        return property;
+    }
+
+    private List<Property> getDateProperties(Resource resource) {
+        List<Property> results = new ArrayList<>();
+        results.add(resource.getNamedProperty("onset"));
+        results.add(resource.getNamedProperty("issued"));
+        results.add(resource.getNamedProperty("effective"));
+        results.add(resource.getNamedProperty("recordDate"));
+
+        return results.stream().filter(p -> p != null).collect(Collectors.toList());
+    }
+
+    private void resolveMeta(DomainResource resource, String definition) {
+        var meta = new Meta();
+        // Consider setting source and lastUpdated here?
+        if (definition != null && !definition.isEmpty()) {
+            meta.addProfile(definition.split("#")[0]);
+            resource.setMeta(meta);
+        }
     }
 
     private List<IBase> getExpressionResult(Expression expression, String itemLinkId) {
@@ -207,10 +238,33 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
 
         var resourceType = getDefinitionType(item.getDefinition());
         var resource = (Resource) newValue(resourceType);
-        resource.setId(new IdType(resourceType, getExtractId(questionnaireResponse) + "." + item.getLinkId()));
+        resource.setId(new IdType(resourceType, getExtractId(questionnaireResponse) + "-" + item.getLinkId()));
+        resolveMeta((DomainResource) resource, item.getDefinition());
         var subjectProperty = getSubjectProperty(resource);
         if (subjectProperty != null) {
             resource.setProperty(subjectProperty.getName(), subject);
+        }
+        var authorProperty = getAuthorProperty(resource);
+        if (authorProperty != null && questionnaireResponse.hasAuthor()) {
+            resource.setProperty(authorProperty.getName(), questionnaireResponse.getAuthor());
+        }
+        var dateProperties = getDateProperties(resource);
+        if (dateProperties != null && !dateProperties.isEmpty() && questionnaireResponse.hasAuthored()) {
+            dateProperties.forEach(p -> {
+                try {
+                    var propertyDef = fhirContext().getElementDefinition(
+                            p.getTypeCode().contains("|") ? p.getTypeCode().split("\\|")[0] : p.getTypeCode());
+                    if (propertyDef != null) {
+                        modelResolver.setValue(resource, p.getName(), propertyDef.getImplementingClass()
+                                .getConstructor(Date.class).newInstance(questionnaireResponse.getAuthored()));
+                    }
+                } catch (Exception ex) {
+                    var message = String.format(
+                            "Error encountered attempting to set property (%s) on resource type (%s): %s",
+                            p.getName(), resource.fhirType(), ex.getMessage());
+                    logger.error(message);
+                }
+            });
         }
         item.getItem().forEach(childItem -> {
             if (childItem.hasDefinition()) {
@@ -220,11 +274,7 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
                 path = path.replace(resourceType + ".", "");
                 var answerValue = childItem.getAnswerFirstRep().getValue();
                 if (answerValue != null) {
-                    // if (path.contains(".")) {
-                    // nestedValueResolver.setNestedValue(resource, path, answerValue);
-                    // } else {
                     modelResolver.setValue(resource, path, answerValue);
-                    // }
                 }
             }
         });
@@ -293,8 +343,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         // obs.setFocus();
         obs.setEncounter(questionnaireResponse.getEncounter());
         var authoredDate = new DateTimeType((questionnaireResponse.hasAuthored()
-                        ? questionnaireResponse.getAuthored().toInstant()
-                        : Instant.now())
+                ? questionnaireResponse.getAuthored().toInstant()
+                : Instant.now())
                 .toString());
         obs.setEffective(authoredDate);
         obs.setIssuedElement(new InstantType(authoredDate));
@@ -328,7 +378,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
     // String url = mySdcProperties.getExtract().getEndpoint();
     // if (null == url || url.length() < 1) {
     // throw new IllegalArgumentException(
-    // "Unable to transmit observation bundle. No observation.endpoint defined in sdc properties.");
+    // "Unable to transmit observation bundle. No observation.endpoint defined in
+    // sdc properties.");
     // }
     // String user = mySdcProperties.getExtract().getUsername();
     // String password = mySdcProperties.getExtract().getPassword();

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/r5/QuestionnaireResponseProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/r5/QuestionnaireResponseProcessor.java
@@ -61,9 +61,9 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         }
 
         return castOrThrow(
-                baseQuestionnaireResponse,
-                QuestionnaireResponse.class,
-                "The QuestionnaireResponse passed to repository was not a valid instance of QuestionnaireResponse.class")
+                        baseQuestionnaireResponse,
+                        QuestionnaireResponse.class,
+                        "The QuestionnaireResponse passed to repository was not a valid instance of QuestionnaireResponse.class")
                 .orElse(null);
     }
 
@@ -92,8 +92,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         patientId = questionnaireResponse.getSubject().getId();
         libraryUrl = questionnaireResponse.hasExtension(Constants.CQF_LIBRARY)
                 ? ((CanonicalType) questionnaireResponse
-                        .getExtensionByUrl(Constants.CQF_LIBRARY)
-                        .getValue())
+                                .getExtensionByUrl(Constants.CQF_LIBRARY)
+                                .getValue())
                         .getValue()
                 : null;
     }
@@ -141,8 +141,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         var subjectItems = item.getItem().stream()
                 .filter(child -> child.hasExtension(Constants.SDC_QUESTIONNAIRE_RESPONSE_IS_SUBJECT))
                 .collect(Collectors.toList());
-        var groupSubject = !subjectItems.isEmpty() ? subjectItems.get(0).getAnswer().get(0).getValueReference()
-                : subject.copy();
+        var groupSubject =
+                !subjectItems.isEmpty() ? subjectItems.get(0).getAnswer().get(0).getValueReference() : subject.copy();
         if (item.hasDefinition()) {
             processDefinitionItem(item, questionnaireResponse, resources, groupSubject);
         } else {
@@ -252,11 +252,19 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         if (dateProperties != null && !dateProperties.isEmpty() && questionnaireResponse.hasAuthored()) {
             dateProperties.forEach(p -> {
                 try {
-                    var propertyDef = fhirContext().getElementDefinition(
-                            p.getTypeCode().contains("|") ? p.getTypeCode().split("\\|")[0] : p.getTypeCode());
+                    var propertyDef = fhirContext()
+                            .getElementDefinition(
+                                    p.getTypeCode().contains("|")
+                                            ? p.getTypeCode().split("\\|")[0]
+                                            : p.getTypeCode());
                     if (propertyDef != null) {
-                        modelResolver.setValue(resource, p.getName(), propertyDef.getImplementingClass()
-                                .getConstructor(Date.class).newInstance(questionnaireResponse.getAuthored()));
+                        modelResolver.setValue(
+                                resource,
+                                p.getName(),
+                                propertyDef
+                                        .getImplementingClass()
+                                        .getConstructor(Date.class)
+                                        .newInstance(questionnaireResponse.getAuthored()));
                     }
                 } catch (Exception ex) {
                     var message = String.format(
@@ -343,8 +351,8 @@ public class QuestionnaireResponseProcessor extends BaseQuestionnaireResponsePro
         // obs.setFocus();
         obs.setEncounter(questionnaireResponse.getEncounter());
         var authoredDate = new DateTimeType((questionnaireResponse.hasAuthored()
-                ? questionnaireResponse.getAuthored().toInstant()
-                : Instant.now())
+                        ? questionnaireResponse.getAuthored().toInstant()
+                        : Instant.now())
                 .toString());
         obs.setEffective(authoredDate);
         obs.setIssuedElement(new InstantType(authoredDate));

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaireresponse/r4/QuestionnaireResponseProcessorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaireresponse/r4/QuestionnaireResponseProcessorTests.java
@@ -34,7 +34,7 @@ public class QuestionnaireResponseProcessorTests {
     @Test
     void testDefinitionBasedExtraction() {
         TestQuestionnaireResponse.Assert.that(
-                new IdType("QuestionnaireResponse", "OutpatientPriorAuthorizationRequest-OPA-Patient1"))
+                        new IdType("QuestionnaireResponse", "OutpatientPriorAuthorizationRequest-OPA-Patient1"))
                 .withExpectedBundleId(new IdType("Bundle", "extract-OutpatientPriorAuthorizationRequest-OPA-Patient1"))
                 .extract()
                 .hasEntry(2);
@@ -43,7 +43,7 @@ public class QuestionnaireResponseProcessorTests {
     @Test
     void testNestedDefinitionBaseExtraction() {
         TestQuestionnaireResponse.Assert.that(
-                new IdType("QuestionnaireResponse", "cc-screening-pathway-definition-answers"))
+                        new IdType("QuestionnaireResponse", "cc-screening-pathway-definition-answers"))
                 .withExpectedBundleId(new IdType("Bundle", "extract-cc-screening-pathway-definition-answers"))
                 .extract()
                 .hasEntry(3);

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaireresponse/r4/QuestionnaireResponseProcessorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaireresponse/r4/QuestionnaireResponseProcessorTests.java
@@ -34,7 +34,7 @@ public class QuestionnaireResponseProcessorTests {
     @Test
     void testDefinitionBasedExtraction() {
         TestQuestionnaireResponse.Assert.that(
-                        new IdType("QuestionnaireResponse", "OutpatientPriorAuthorizationRequest-OPA-Patient1"))
+                new IdType("QuestionnaireResponse", "OutpatientPriorAuthorizationRequest-OPA-Patient1"))
                 .withExpectedBundleId(new IdType("Bundle", "extract-OutpatientPriorAuthorizationRequest-OPA-Patient1"))
                 .extract()
                 .hasEntry(2);
@@ -43,7 +43,7 @@ public class QuestionnaireResponseProcessorTests {
     @Test
     void testNestedDefinitionBaseExtraction() {
         TestQuestionnaireResponse.Assert.that(
-                        new IdType("QuestionnaireResponse", "cc-screening-pathway-definition-answers"))
+                new IdType("QuestionnaireResponse", "cc-screening-pathway-definition-answers"))
                 .withExpectedBundleId(new IdType("Bundle", "extract-cc-screening-pathway-definition-answers"))
                 .extract()
                 .hasEntry(3);

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/dstu3/child-routine-visit/child_routine_visit_careplan.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/dstu3/child-routine-visit/child_routine_visit_careplan.json
@@ -5,11 +5,6 @@
     {
       "resourceType": "RequestGroup",
       "id": "ChildRoutineVisit-PlanDefinition-1.0.0",
-      "meta": {
-        "profile": [
-          "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-        ]
-      },
       "definition": [
         {
           "reference": "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/ChildRoutineVisit-PlanDefinition-1.0.0"

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/dstu3/extract-questionnaireresponse/careplan.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/dstu3/extract-questionnaireresponse/careplan.json
@@ -5,11 +5,6 @@
     {
       "resourceType": "RequestGroup",
       "id": "prepopulate",
-      "meta": {
-        "profile": [
-          "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-        ]
-      },
       "definition": [
         {
           "reference": "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/prepopulate|1.0.0"

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/dstu3/hello-world/hello-world-careplan.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/dstu3/hello-world/hello-world-careplan.json
@@ -5,11 +5,6 @@
     {
       "resourceType": "RequestGroup",
       "id": "hello-world-patient-view",
-      "meta": {
-        "profile": [
-          "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-        ]
-      },
       "definition": [
         {
           "reference": "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/hello-world-patient-view|1.0.0"

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/anc-dak/output-careplan.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/anc-dak/output-careplan.json
@@ -5,11 +5,6 @@
     {
       "resourceType": "RequestGroup",
       "id": "ANCDT17",
-      "meta": {
-        "profile": [
-          "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-        ]
-      },
       "instantiatesCanonical": [
         "http://fhir.org/guides/who/anc-cds/PlanDefinition/ANCDT17"
       ],

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/anc-dak/tests/Bundle-ANCDT17.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/anc-dak/tests/Bundle-ANCDT17.json
@@ -7,11 +7,6 @@
       "resource": {
         "resourceType": "RequestGroup",
         "id": "ANCDT17",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-          ]
-        },
         "instantiatesCanonical": [
           "http://fhir.org/guides/who/anc-cds/PlanDefinition/ANCDT17"
         ],

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/anc-dak/tests/CarePlan-ANCDT17.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/anc-dak/tests/CarePlan-ANCDT17.json
@@ -5,11 +5,6 @@
     {
       "resourceType": "RequestGroup",
       "id": "ANCDT17",
-      "meta": {
-        "profile": [
-          "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-        ]
-      },
       "instantiatesCanonical": [
         "http://fhir.org/guides/who/anc-cds/PlanDefinition/ANCDT17"
       ],

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/anc-visit/anc_visit_bundle.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/anc-visit/anc_visit_bundle.json
@@ -7,11 +7,6 @@
       "resource": {
         "resourceType": "RequestGroup",
         "id": "AncVisit-PlanDefinition",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-          ]
-        },
         "extension": [
           {
             "url": "http://hl7.org/fhir/StructureDefinition/resource-pertainsToGoal",

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/anc-visit/anc_visit_careplan.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/anc-visit/anc_visit_careplan.json
@@ -5,11 +5,6 @@
     {
       "resourceType": "RequestGroup",
       "id": "AncVisit-PlanDefinition",
-      "meta": {
-        "profile": [
-          "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-        ]
-      },
       "instantiatesCanonical": [
         "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/AncVisit-PlanDefinition"
       ],

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/cds-hooks-multiple-actions/cds_hooks_multiple_actions_bundle.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/cds-hooks-multiple-actions/cds_hooks_multiple_actions_bundle.json
@@ -7,11 +7,6 @@
       "resource": {
         "resourceType": "RequestGroup",
         "id": "CdsHooksMultipleActions-PlanDefinition-1.0.0",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-          ]
-        },
         "instantiatesCanonical": [
           "http://example.com/PlanDefinition/CdsHooksMultipleActions-PlanDefinition-1.0.0"
         ],

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/cds-hooks-multiple-actions/cds_hooks_multiple_actions_careplan.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/cds-hooks-multiple-actions/cds_hooks_multiple_actions_careplan.json
@@ -5,11 +5,6 @@
     {
       "resourceType": "RequestGroup",
       "id": "CdsHooksMultipleActions-PlanDefinition-1.0.0",
-      "meta": {
-        "profile": [
-          "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-        ]
-      },
       "instantiatesCanonical": [
         "http://example.com/PlanDefinition/CdsHooksMultipleActions-PlanDefinition-1.0.0"
       ],

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/child-routine-visit/child_routine_visit_bundle.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/child-routine-visit/child_routine_visit_bundle.json
@@ -7,11 +7,6 @@
       "resource": {
         "resourceType": "RequestGroup",
         "id": "ChildRoutineVisit-PlanDefinition-1.0.0",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-          ]
-        },
         "extension": [
           {
             "url": "http://hl7.org/fhir/StructureDefinition/resource-pertainsToGoal",

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/child-routine-visit/child_routine_visit_careplan.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/child-routine-visit/child_routine_visit_careplan.json
@@ -5,11 +5,6 @@
     {
       "resourceType": "RequestGroup",
       "id": "ChildRoutineVisit-PlanDefinition-1.0.0",
-      "meta": {
-        "profile": [
-          "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-        ]
-      },
       "instantiatesCanonical": [
         "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/ChildRoutineVisit-PlanDefinition-1.0.0"
       ],

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/opioid-Rec10-patient-view/tests/Bundle-opioidcds-10-patient-view.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/opioid-Rec10-patient-view/tests/Bundle-opioidcds-10-patient-view.json
@@ -7,11 +7,6 @@
       "resource": {
         "resourceType": "RequestGroup",
         "id": "opioidcds-10-patient-view",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-          ]
-        },
         "contained": [
           {
             "resourceType": "OperationOutcome",

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/opioid-Rec10-patient-view/tests/CarePlan-opioidcds-10-patient-view.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/opioid-Rec10-patient-view/tests/CarePlan-opioidcds-10-patient-view.json
@@ -5,11 +5,6 @@
     {
       "resourceType": "RequestGroup",
       "id": "opioidcds-10-patient-view",
-      "meta": {
-        "profile": [
-          "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-        ]
-      },
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-messages",

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/tests/Bundle-generate-questionnaire.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/tests/Bundle-generate-questionnaire.json
@@ -7,14 +7,8 @@
       "resource": {
         "resourceType": "RequestGroup",
         "id": "generate-questionnaire",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-          ]
-        },
         "instantiatesCanonical": [
-          "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/generate-questionnaire|1.0.0",
-          "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/route-one|1.0.0"
+          "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/generate-questionnaire|1.0.0"
         ],
         "status": "draft",
         "intent": "proposal",
@@ -44,11 +38,6 @@
       "resource": {
         "resourceType": "RequestGroup",
         "id": "route-one",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-          ]
-        },
         "instantiatesCanonical": [
           "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/route-one|1.0.0"
         ],

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/tests/Bundle-hello-world-patient-view.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/tests/Bundle-hello-world-patient-view.json
@@ -7,11 +7,6 @@
       "resource": {
         "resourceType": "RequestGroup",
         "id": "hello-world-patient-view",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-          ]
-        },
         "instantiatesCanonical": [
           "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/hello-world-patient-view|1.0.0"
         ],

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/tests/Bundle-prepopulate.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/tests/Bundle-prepopulate.json
@@ -7,11 +7,6 @@
       "resource": {
         "resourceType": "RequestGroup",
         "id": "prepopulate",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-          ]
-        },
         "instantiatesCanonical": [
           "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/prepopulate|1.0.0"
         ],

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/tests/CarePlan-generate-questionnaire.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/tests/CarePlan-generate-questionnaire.json
@@ -5,14 +5,8 @@
     {
       "resourceType": "RequestGroup",
       "id": "generate-questionnaire",
-      "meta": {
-        "profile": [
-          "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-        ]
-      },
       "instantiatesCanonical": [
-        "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/generate-questionnaire|1.0.0",
-        "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/route-one|1.0.0"
+        "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/generate-questionnaire|1.0.0"
       ],
       "status": "draft",
       "intent": "proposal",
@@ -439,11 +433,6 @@
     {
       "resourceType": "RequestGroup",
       "id": "route-one",
-      "meta": {
-        "profile": [
-          "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-        ]
-      },
       "instantiatesCanonical": [
         "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/route-one|1.0.0"
       ],
@@ -469,8 +458,7 @@
     }
   ],
   "instantiatesCanonical": [
-    "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/generate-questionnaire|1.0.0",
-    "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/route-one|1.0.0"
+    "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/generate-questionnaire|1.0.0"
   ],
   "status": "draft",
   "intent": "proposal",

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/tests/CarePlan-hello-world-patient-view.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/tests/CarePlan-hello-world-patient-view.json
@@ -5,11 +5,6 @@
     {
       "resourceType": "RequestGroup",
       "id": "hello-world-patient-view",
-      "meta": {
-        "profile": [
-          "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-        ]
-      },
       "instantiatesCanonical": [
         "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/hello-world-patient-view|1.0.0"
       ],

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/tests/CarePlan-prepopulate.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r4/tests/CarePlan-prepopulate.json
@@ -5,11 +5,6 @@
     {
       "resourceType": "RequestGroup",
       "id": "prepopulate",
-      "meta": {
-        "profile": [
-          "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-        ]
-      },
       "instantiatesCanonical": [
         "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/prepopulate|1.0.0"
       ],

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r5/child-routine-visit/child_routine_visit_bundle.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r5/child-routine-visit/child_routine_visit_bundle.json
@@ -7,11 +7,6 @@
       "resource": {
         "resourceType": "RequestOrchestration",
         "id": "ChildRoutineVisit-PlanDefinition-1.0.0",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-          ]
-        },
         "extension": [
           {
             "url": "http://hl7.org/fhir/StructureDefinition/resource-pertainsToGoal",

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r5/extract-questionnaireresponse/bundle.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r5/extract-questionnaireresponse/bundle.json
@@ -7,11 +7,6 @@
       "resource": {
         "resourceType": "RequestOrchestration",
         "id": "prepopulate",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-          ]
-        },
         "instantiatesCanonical": [
           "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/prepopulate|1.0.0"
         ],

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r5/hello-world/hello-world-bundle.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r5/hello-world/hello-world-bundle.json
@@ -7,11 +7,6 @@
       "resource": {
         "resourceType": "RequestOrchestration",
         "id": "hello-world-patient-view",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-strategy"
-          ]
-        },
         "contained": [
           {
             "resourceType": "OperationOutcome",

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r5/tests/Bundle-generate-questionnaire.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/plandefinition/r5/tests/Bundle-generate-questionnaire.json
@@ -8,8 +8,7 @@
         "resourceType": "RequestOrchestration",
         "id": "generate-questionnaire",
         "instantiatesCanonical": [
-          "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/generate-questionnaire",
-          "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/route-one"
+          "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/generate-questionnaire"
         ],
         "status": "draft",
         "intent": "proposal",

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/questionnaireresponse/dstu3/tests/Bundle-OutpatientPriorAuthorizationRequest.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/questionnaireresponse/dstu3/tests/Bundle-OutpatientPriorAuthorizationRequest.json
@@ -6,18 +6,28 @@
     {
       "resource": {
         "resourceType": "Organization",
-        "id": "extract-OutpatientPriorAuthorizationRequest.1",
+        "id": "extract-OutpatientPriorAuthorizationRequest-1",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/Organization"
+          ]
+        },
         "name": "Test Facility"
       },
       "request": {
         "method": "PUT",
-        "url": "Organization/extract-OutpatientPriorAuthorizationRequest.1"
+        "url": "Organization/extract-OutpatientPriorAuthorizationRequest-1"
       }
     },
     {
       "resource": {
         "resourceType": "Patient",
-        "id": "extract-OutpatientPriorAuthorizationRequest.2",
+        "id": "extract-OutpatientPriorAuthorizationRequest-2",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/Patient"
+          ]
+        },
         "identifier": [
           {
             "system": "http://hl7.org/fhir/sid/us-medicare",
@@ -32,12 +42,12 @@
             ]
           }
         ],
-        "birthDate": "1950-01-01",
-        "gender": "male"
+        "gender": "male",
+        "birthDate": "1950-01-01"
       },
       "request": {
         "method": "PUT",
-        "url": "Patient/extract-OutpatientPriorAuthorizationRequest.2"
+        "url": "Patient/extract-OutpatientPriorAuthorizationRequest-2"
       }
     }
   ]

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/questionnaireresponse/r4/tests/Bundle-extract-OutpatientPriorAuthorizationRequest.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/questionnaireresponse/r4/tests/Bundle-extract-OutpatientPriorAuthorizationRequest.json
@@ -6,18 +6,18 @@
     {
       "resource": {
         "resourceType": "Organization",
-        "id": "extract-OutpatientPriorAuthorizationRequest.1",
+        "id": "extract-OutpatientPriorAuthorizationRequest-1",
         "name": "Test Facility"
       },
       "request": {
         "method": "PUT",
-        "url": "Organization/extract-OutpatientPriorAuthorizationRequest.1"
+        "url": "Organization/extract-OutpatientPriorAuthorizationRequest-1"
       }
     },
     {
       "resource": {
         "resourceType": "Patient",
-        "id": "extract-OutpatientPriorAuthorizationRequest.2",
+        "id": "extract-OutpatientPriorAuthorizationRequest-2",
         "identifier": [
           {
             "system": "http://hl7.org/fhir/sid/us-medicare",
@@ -37,7 +37,7 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Patient/extract-OutpatientPriorAuthorizationRequest.2"
+        "url": "Patient/extract-OutpatientPriorAuthorizationRequest-2"
       }
     }
   ]

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/questionnaireresponse/r4/tests/QuestionnaireResponse-cc-screening-pathway-definition-answers.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/questionnaireresponse/r4/tests/QuestionnaireResponse-cc-screening-pathway-definition-answers.json
@@ -3,7 +3,13 @@
   "id": "cc-screening-pathway-definition-answers",
   "questionnaire": "http://example.org/sdh/demo/Questionnaire/cc-screening-pathway-definition",
   "status": "completed",
+  "subject": {
+    "reference": "Patient/coverage-concern"
+  },
   "authored": "2023-08-24",
+  "author": {
+    "reference": "Practitioner/practitioner1"
+  },
   "item": [
     {
       "linkId": "1",

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/questionnaireresponse/r5/tests/Bundle-OutpatientPriorAuthorizationRequest.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/questionnaireresponse/r5/tests/Bundle-OutpatientPriorAuthorizationRequest.json
@@ -6,18 +6,28 @@
     {
       "resource": {
         "resourceType": "Organization",
-        "id": "extract-OutpatientPriorAuthorizationRequest.1",
+        "id": "extract-OutpatientPriorAuthorizationRequest-1",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/Organization"
+          ]
+        },
         "name": "Test Facility"
       },
       "request": {
         "method": "PUT",
-        "url": "Organization/extract-OutpatientPriorAuthorizationRequest.1"
+        "url": "Organization/extract-OutpatientPriorAuthorizationRequest-1"
       }
     },
     {
       "resource": {
         "resourceType": "Patient",
-        "id": "extract-OutpatientPriorAuthorizationRequest.2",
+        "id": "extract-OutpatientPriorAuthorizationRequest-2",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/Patient"
+          ]
+        },
         "identifier": [
           {
             "system": "http://hl7.org/fhir/sid/us-medicare",
@@ -32,12 +42,12 @@
             ]
           }
         ],
-        "birthDate": "1950-01-01",
-        "gender": "male"
+        "gender": "male",
+        "birthDate": "1950-01-01"
       },
       "request": {
         "method": "PUT",
-        "url": "Patient/extract-OutpatientPriorAuthorizationRequest.2"
+        "url": "Patient/extract-OutpatientPriorAuthorizationRequest-2"
       }
     }
   ]


### PR DESCRIPTION
Remove CPG Strategy profile from RequestGroups.
Only add to instantiatesCanonical the direct PlanDefinition that is being instantiated by a RequestGroup (not any nested PlanDefinitions)