### PR TITLE
Measure service subject reporttype bugs

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/dstu3/Dstu3MeasureService.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/dstu3/Dstu3MeasureService.java
@@ -1,0 +1,137 @@
+package org.opencds.cqf.fhir.cr.measure.dstu3;
+
+import ca.uhn.fhir.util.BundleBuilder;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.CodeableConcept;
+import org.hl7.fhir.dstu3.model.Coding;
+import org.hl7.fhir.dstu3.model.ContactDetail;
+import org.hl7.fhir.dstu3.model.ContactPoint;
+import org.hl7.fhir.dstu3.model.Endpoint;
+import org.hl7.fhir.dstu3.model.Enumerations;
+import org.hl7.fhir.dstu3.model.Extension;
+import org.hl7.fhir.dstu3.model.IdType;
+import org.hl7.fhir.dstu3.model.MeasureReport;
+import org.hl7.fhir.dstu3.model.SearchParameter;
+import org.hl7.fhir.dstu3.model.StringType;
+import org.opencds.cqf.fhir.api.Repository;
+import org.opencds.cqf.fhir.cr.measure.MeasureEvaluationOptions;
+import java.util.Collections;
+import java.util.List;
+
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.COUNTRY_CODING_SYSTEM_CODE;
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.MEASUREREPORT_MEASURE_SUPPLEMENTALDATA_EXTENSION;
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.MEASUREREPORT_SUPPLEMENTALDATA_SEARCHPARAMETER_DEFINITION_DATE;
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.MEASUREREPORT_SUPPLEMENTALDATA_SEARCHPARAMETER_URL;
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.MEASUREREPORT_SUPPLEMENTALDATA_SEARCHPARAMETER_VERSION;
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.US_COUNTRY_CODE;
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.US_COUNTRY_DISPLAY;
+
+public class Dstu3MeasureService {
+    private final Repository repository;
+    private final MeasureEvaluationOptions measureEvaluationOptions;
+
+    public Dstu3MeasureService(Repository theRepository, MeasureEvaluationOptions theMeasureEvaluationOptions) {
+        repository = theRepository;
+        measureEvaluationOptions = theMeasureEvaluationOptions;
+    }
+
+    public static final List<ContactDetail> CQI_CONTACT_DETAIL = Collections.singletonList(new ContactDetail()
+        .addTelecom(new ContactPoint()
+            .setSystem(ContactPoint.ContactPointSystem.URL)
+            .setValue("http://www.hl7.org/Special/committees/cqi/index.cfm")));
+
+    public static final List<CodeableConcept> US_JURISDICTION_CODING = Collections.singletonList(new CodeableConcept()
+        .addCoding(new Coding(COUNTRY_CODING_SYSTEM_CODE, US_COUNTRY_CODE, US_COUNTRY_DISPLAY)));
+
+    public static final SearchParameter SUPPLEMENTAL_DATA_SEARCHPARAMETER = (SearchParameter) new SearchParameter()
+        .setUrl(MEASUREREPORT_SUPPLEMENTALDATA_SEARCHPARAMETER_URL)
+        .setVersion(MEASUREREPORT_SUPPLEMENTALDATA_SEARCHPARAMETER_VERSION)
+        .setName("DEQMMeasureReportSupplementalData")
+        .setStatus(Enumerations.PublicationStatus.ACTIVE)
+        .setDate(MEASUREREPORT_SUPPLEMENTALDATA_SEARCHPARAMETER_DEFINITION_DATE)
+        .setPublisher("HL7 International - Clinical Quality Information Work Group")
+        .setContact(CQI_CONTACT_DETAIL)
+        .setDescription(String.format(
+            "Returns resources (supplemental data) from references on extensions on the MeasureReport with urls matching %s.",
+            MEASUREREPORT_MEASURE_SUPPLEMENTALDATA_EXTENSION))
+        .setJurisdiction(US_JURISDICTION_CODING)
+        .addBase("MeasureReport")
+        .setCode("supplemental-data")
+        .setType(Enumerations.SearchParamType.REFERENCE)
+        .setExpression(String.format(
+            "MeasureReport.extension('%s').value", MEASUREREPORT_MEASURE_SUPPLEMENTALDATA_EXTENSION))
+        .setXpath(String.format(
+            "f:MeasureReport/f:extension[@url='%s'].value", MEASUREREPORT_MEASURE_SUPPLEMENTALDATA_EXTENSION))
+        .setXpathUsage(SearchParameter.XPathUsageType.NORMAL)
+        .setTitle("Supplemental Data")
+        .setId("deqm-measurereport-supplemental-data");
+
+    /**
+     * Get The details (such as tenant) of this request. Usually auto-populated HAPI.
+     *
+     */
+
+    /**
+     * Implements the <a href=
+     * "https://www.hl7.org/fhir/operation-measure-evaluate-measure.html">$evaluate-measure</a>
+     * operation found in the
+     * <a href="http://www.hl7.org/fhir/clinicalreasoning-module.html">FHIR Clinical
+     * Reasoning Module</a>. This implementation aims to be compatible with the CQF
+     * IG.
+     *
+     * @param theId                  the Id of the Measure to evaluate
+     * @param thePeriodStart         The start of the reporting period
+     * @param thePeriodEnd           The end of the reporting period
+     * @param theReportType          The type of MeasureReport to generate
+     * @param thePractitioner        the practitioner to use for the evaluation
+     * @param theLastReceivedOn      the date the results of this measure were last
+     *                               received.
+     * @param theProductLine         the productLine (e.g. Medicare, Medicaid, etc) to use
+     *                               for the evaluation. This is a non-standard parameter.
+     * @param theAdditionalData      the data bundle containing additional data
+     * @param theTerminologyEndpoint the endpoint of terminology services for your measure valuesets
+     * @return the calculated MeasureReport
+     */
+    public MeasureReport evaluateMeasure(
+        IdType theId,
+        String thePeriodStart,
+        String thePeriodEnd,
+        String theReportType,
+        String theSubject,
+        String thePractitioner,
+        String theLastReceivedOn,
+        String theProductLine,
+        Bundle theAdditionalData,
+        Endpoint theTerminologyEndpoint) {
+
+        ensureSupplementalDataElementSearchParameter();
+
+        var dstu3MeasureProcessor = new Dstu3MeasureProcessor(repository, measureEvaluationOptions);
+
+        MeasureReport report = dstu3MeasureProcessor.evaluateMeasure(
+            theId,
+            thePeriodStart,
+            thePeriodEnd,
+            theReportType,
+            Collections.singletonList(theSubject),
+            theAdditionalData);
+
+        if (theProductLine != null) {
+            Extension ext = new Extension();
+            ext.setUrl("http://hl7.org/fhir/us/cqframework/cqfmeasures/StructureDefinition/cqfm-productLine");
+            ext.setValue(new StringType(theProductLine));
+            report.addExtension(ext);
+        }
+
+        return report;
+    }
+
+    protected void ensureSupplementalDataElementSearchParameter() {
+        // create a transaction bundle
+        BundleBuilder builder = new BundleBuilder(repository.fhirContext());
+
+        // set the request to be condition on code == supplemental data
+        builder.addTransactionCreateEntry(SUPPLEMENTAL_DATA_SEARCHPARAMETER).conditional("code=supplemental-data");
+        repository.transaction(builder.getBundle());
+    }
+}

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureProcessor.java
@@ -96,9 +96,7 @@ public class R4MeasureProcessor {
         var subjects =
                 subjectProvider.getSubjects(actualRepo, evalType, subjectIds).collect(Collectors.toList());
 
-        if(StringUtils.isNotBlank(reportType)){
-            evalType = MeasureEvalType.fromCode(reportType).get();
-        } else if (subjects.size()>1){
+        if (subjects.size()>1){
             evalType = MeasureEvalType.POPULATION;
         } else {
             evalType = MeasureEvalType.SUBJECT;

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureProcessor.java
@@ -83,11 +83,9 @@ public class R4MeasureProcessor {
 
         context.getState().init(lib.getLibrary());
 
-        var evalType = MeasureEvalType.fromCode(reportType)
-                .orElse(
-                        subjectIds == null || subjectIds.isEmpty()
-                                ? MeasureEvalType.POPULATION
-                                : MeasureEvalType.SUBJECT);
+        MeasureEvalType evalType = null;
+
+
 
         var actualRepo = this.repository;
         if (additionalData != null) {
@@ -97,6 +95,14 @@ public class R4MeasureProcessor {
 
         var subjects =
                 subjectProvider.getSubjects(actualRepo, evalType, subjectIds).collect(Collectors.toList());
+
+        if(StringUtils.isNotBlank(reportType)){
+            evalType = MeasureEvalType.fromCode(reportType).get();
+        } else if (subjects.size()>1){
+            evalType = MeasureEvalType.POPULATION;
+        } else {
+            evalType = MeasureEvalType.SUBJECT;
+        }
 
         R4MeasureEvaluation measureEvaluator = new R4MeasureEvaluation(context, measure);
         return measureEvaluator.evaluate(evalType, subjects, measurementPeriod);

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureService.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureService.java
@@ -1,16 +1,49 @@
 package org.opencds.cqf.fhir.cr.measure.r4;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import ca.uhn.fhir.model.api.IQueryParameterType;
+import ca.uhn.fhir.rest.param.ReferenceParam;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.util.BundleBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.CanonicalType;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.ContactDetail;
+import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.Endpoint;
+import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.Group;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Measure;
 import org.hl7.fhir.r4.model.MeasureReport;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.SearchParameter;
+import org.hl7.fhir.r4.model.StringType;
 import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.cr.measure.MeasureEvaluationOptions;
+import org.opencds.cqf.fhir.cr.measure.common.MeasureReportType;
+import org.opencds.cqf.fhir.utility.iterable.BundleIterator;
 import org.opencds.cqf.fhir.utility.monad.Either3;
+import org.opencds.cqf.fhir.utility.monad.Eithers;
 import org.opencds.cqf.fhir.utility.repository.Repositories;
+
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.COUNTRY_CODING_SYSTEM_CODE;
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.MEASUREREPORT_MEASURE_SUPPLEMENTALDATA_EXTENSION;
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.MEASUREREPORT_PRODUCT_LINE_EXT_URL;
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.MEASUREREPORT_SUPPLEMENTALDATA_SEARCHPARAMETER_DEFINITION_DATE;
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.MEASUREREPORT_SUPPLEMENTALDATA_SEARCHPARAMETER_URL;
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.MEASUREREPORT_SUPPLEMENTALDATA_SEARCHPARAMETER_VERSION;
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.US_COUNTRY_CODE;
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.US_COUNTRY_DISPLAY;
 
 public class R4MeasureService {
 
@@ -32,12 +65,175 @@ public class R4MeasureService {
             Endpoint contentEndpoint,
             Endpoint terminologyEndpoint,
             Endpoint dataEndpoint,
-            Bundle additionalData) {
+            Bundle additionalData,
+            String productLine,
+            String practitioner,
+            String reporter
+            ) {
 
         var repo = Repositories.proxy(repository, dataEndpoint, contentEndpoint, terminologyEndpoint);
         var processor = new R4MeasureProcessor(repo, this.measureEvaluationOptions, new R4RepositorySubjectProvider());
 
-        return processor.evaluateMeasure(
-                measure, periodStart, periodEnd, reportType, Collections.singletonList(subjectId), additionalData);
+        ensureSupplementalDataElementSearchParameter();
+
+        MeasureReport measureReport = null;
+
+        // SUBJECT LIST SETTERS
+        if (StringUtils.isBlank(subjectId) && StringUtils.isNotBlank(practitioner)) {
+            List<String> subjectIds = getPractitionerPatients(practitioner);
+
+            measureReport = processor.evaluateMeasure(
+                measure,
+                periodStart,
+                periodEnd,
+                reportType,
+                subjectIds,
+                additionalData);
+
+        } else if (StringUtils.isNotBlank(subjectId)) {
+            measureReport = processor.evaluateMeasure(
+                measure,
+                periodStart,
+                periodEnd,
+                reportType,
+                Collections.singletonList(subjectId),
+                additionalData);
+
+        } else if (StringUtils.isBlank(subjectId) && StringUtils.isBlank(practitioner)) {
+            measureReport = processor.evaluateMeasure(
+                measure,
+                periodStart,
+                periodEnd,
+                reportType,
+                null,
+                additionalData);
+        }
+        // add ProductLine after report is generated
+        addProductLineExtension(measureReport, productLine);
+
+        // add Reporter after report is generated
+        if(StringUtils.isNotBlank(reporter)) {
+            measureReport.setReporter(new Reference(reporter));
+        }
+
+        // add subject reference for non-individual reportTypes
+        if((StringUtils.isNotBlank(practitioner) || StringUtils.isNotBlank(subjectId)) && measureReport.getType().name().equals(
+            MeasureReportType.SUMMARY.name())){
+            if(StringUtils.isNotBlank(practitioner)){
+                measureReport.setSubject(new Reference(practitioner));
+            } else {
+                measureReport.setSubject(new Reference(subjectId));
+            }
+        }
+        return measureReport;
     }
+
+    
+
+    private List<String> getPractitionersInGroup(String practGroup) {
+        List<String> practitioners = new ArrayList<>();
+
+        IdType id = new IdType(practGroup);
+        org.hl7.fhir.r4.model.Group r =repository.read(Group.class, id);
+
+        if (r == null) {
+            throw new ResourceNotFoundException(id);
+        }
+
+        for (Group.GroupMemberComponent gmc : r.getMember()) {
+            IIdType ref = gmc.getEntity().getReferenceElement();
+            practitioners.add(ref.getResourceType() + "/" + ref.getIdPart());
+        }
+        return practitioners;
+    }
+
+    public List<String> getPractitionerPatients(String thePractitioner) {
+        List<String> patients = new ArrayList<>();
+
+        //Group of Practitioners
+        if(thePractitioner.startsWith("Group")){
+            var practitioners = getPractitionersInGroup(thePractitioner);
+            for (String prac : practitioners)
+            {
+                var pracPatients = getPractitionerSubjectIds(prac);
+                pracPatients.addAll(patients);
+            }
+            return patients;
+            //Individual Practitioner Reference
+        } else {
+            return getPractitionerSubjectIds(thePractitioner);
+        }
+    }
+
+    public List<String> getPractitionerSubjectIds(String thePractitioner){
+        List<String> patients = new ArrayList<>();
+
+        Map<String, List<IQueryParameterType>> map = new HashMap<>();
+        map.put(
+            "general-practitioner",
+            Collections.singletonList(new ReferenceParam(
+                thePractitioner.startsWith("Practitioner/")
+                    ? thePractitioner
+                    : "Practitioner/" + thePractitioner)));
+
+        var bundle = repository.search(Bundle.class, Patient.class, map);
+        var iterator = new BundleIterator<>(repository, bundle);
+
+        while (iterator.hasNext()) {
+            var patient = iterator.next().getResource();
+            var refString = patient.getIdElement().getResourceType() + "/"
+                + patient.getIdElement().getIdPart();
+            patients.add(refString);
+        }
+        return patients;
+    }
+
+    private void addProductLineExtension(MeasureReport theMeasureReport, String theProductLine) {
+        if (theProductLine != null) {
+            Extension ext = new Extension();
+            ext.setUrl(MEASUREREPORT_PRODUCT_LINE_EXT_URL);
+            ext.setValue(new StringType(theProductLine));
+            theMeasureReport.addExtension(ext);
+        }
+    }
+
+    protected void ensureSupplementalDataElementSearchParameter() {
+        // create a transaction bundle
+        BundleBuilder builder = new BundleBuilder(repository.fhirContext());
+
+        // set the request to be condition on code == supplemental data
+        builder.addTransactionCreateEntry(SUPPLEMENTAL_DATA_SEARCHPARAMETER).conditional("code=supplemental-data");
+        repository.transaction(builder.getBundle());
+    }
+
+    public static final List<ContactDetail> CQI_CONTACTDETAIL = Collections.singletonList(new ContactDetail()
+        .addTelecom(new ContactPoint()
+            .setSystem(ContactPoint.ContactPointSystem.URL)
+            .setValue("http://www.hl7.org/Special/committees/cqi/index.cfm")));
+
+    public static final List<CodeableConcept> US_JURISDICTION_CODING = Collections.singletonList(new CodeableConcept()
+        .addCoding(new Coding(COUNTRY_CODING_SYSTEM_CODE, US_COUNTRY_CODE, US_COUNTRY_DISPLAY)));
+
+    public static final SearchParameter SUPPLEMENTAL_DATA_SEARCHPARAMETER = (SearchParameter) new SearchParameter()
+        .setUrl(MEASUREREPORT_SUPPLEMENTALDATA_SEARCHPARAMETER_URL)
+        .setVersion(MEASUREREPORT_SUPPLEMENTALDATA_SEARCHPARAMETER_VERSION)
+        .setName("DEQMMeasureReportSupplementalData")
+        .setStatus(Enumerations.PublicationStatus.ACTIVE)
+        .setDate(MEASUREREPORT_SUPPLEMENTALDATA_SEARCHPARAMETER_DEFINITION_DATE)
+        .setPublisher("HL7 International - Clinical Quality Information Work Group")
+        .setContact(CQI_CONTACTDETAIL)
+        .setDescription(String.format(
+            "Returns resources (supplemental data) from references on extensions on the MeasureReport with urls matching %s.",
+            MEASUREREPORT_MEASURE_SUPPLEMENTALDATA_EXTENSION))
+        .setJurisdiction(US_JURISDICTION_CODING)
+        .addBase("MeasureReport")
+        .setCode("supplemental-data")
+        .setType(Enumerations.SearchParamType.REFERENCE)
+        .setExpression(String.format(
+            "MeasureReport.extension('%s').value", MEASUREREPORT_MEASURE_SUPPLEMENTALDATA_EXTENSION))
+        .setXpath(String.format(
+            "f:MeasureReport/f:extension[@url='%s'].value", MEASUREREPORT_MEASURE_SUPPLEMENTALDATA_EXTENSION))
+        .setXpathUsage(SearchParameter.XPathUsageType.NORMAL)
+        .setTitle("Supplemental Data")
+        .setId("deqm-measurereport-supplemental-data");
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureService.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureService.java
@@ -1,16 +1,9 @@
 package org.opencds.cqf.fhir.cr.measure.r4;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import ca.uhn.fhir.model.api.IQueryParameterType;
-import ca.uhn.fhir.rest.param.ReferenceParam;
-import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.util.BundleBuilder;
 import org.apache.commons.lang3.StringUtils;
-import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.CodeableConcept;
@@ -20,7 +13,6 @@ import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.Endpoint;
 import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.Extension;
-import org.hl7.fhir.r4.model.Group;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Measure;
 import org.hl7.fhir.r4.model.MeasureReport;
@@ -31,9 +23,7 @@ import org.hl7.fhir.r4.model.StringType;
 import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.cr.measure.MeasureEvaluationOptions;
 import org.opencds.cqf.fhir.cr.measure.common.MeasureReportType;
-import org.opencds.cqf.fhir.utility.iterable.BundleIterator;
 import org.opencds.cqf.fhir.utility.monad.Either3;
-import org.opencds.cqf.fhir.utility.monad.Eithers;
 import org.opencds.cqf.fhir.utility.repository.Repositories;
 
 import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.COUNTRY_CODING_SYSTEM_CODE;
@@ -46,7 +36,8 @@ import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.US
 import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.US_COUNTRY_DISPLAY;
 
 public class R4MeasureService {
-
+    private static final org.slf4j.Logger ourLog =
+        org.slf4j.LoggerFactory.getLogger(R4MeasureService.class);
     private final Repository repository;
     private final MeasureEvaluationOptions measureEvaluationOptions;
 
@@ -67,8 +58,7 @@ public class R4MeasureService {
             Endpoint dataEndpoint,
             Bundle additionalData,
             String productLine,
-            String practitioner,
-            String reporter
+            String practitioner
             ) {
 
         var repo = Repositories.proxy(repository, dataEndpoint, contentEndpoint, terminologyEndpoint);
@@ -78,20 +68,15 @@ public class R4MeasureService {
 
         MeasureReport measureReport = null;
 
-        // SUBJECT LIST SETTERS
-        if (StringUtils.isBlank(subjectId) && StringUtils.isNotBlank(practitioner)) {
-            List<String> subjectIds = getPractitionerPatients(practitioner);
 
-            measureReport = processor.evaluateMeasure(
-                measure,
-                periodStart,
-                periodEnd,
-                reportType,
-                subjectIds,
-                additionalData);
+        if(StringUtils.isNotBlank(practitioner)){
+            if (practitioner.indexOf("/") == -1) {
+                subjectId = "Practitioner/".concat(practitioner);
+            }
+            subjectId = practitioner;
+        }
 
-        } else if (StringUtils.isNotBlank(subjectId)) {
-            measureReport = processor.evaluateMeasure(
+        measureReport = processor.evaluateMeasure(
                 measure,
                 periodStart,
                 periodEnd,
@@ -99,22 +84,8 @@ public class R4MeasureService {
                 Collections.singletonList(subjectId),
                 additionalData);
 
-        } else if (StringUtils.isBlank(subjectId) && StringUtils.isBlank(practitioner)) {
-            measureReport = processor.evaluateMeasure(
-                measure,
-                periodStart,
-                periodEnd,
-                reportType,
-                null,
-                additionalData);
-        }
         // add ProductLine after report is generated
         addProductLineExtension(measureReport, productLine);
-
-        // add Reporter after report is generated
-        if(StringUtils.isNotBlank(reporter)) {
-            measureReport.setReporter(new Reference(reporter));
-        }
 
         // add subject reference for non-individual reportTypes
         if((StringUtils.isNotBlank(practitioner) || StringUtils.isNotBlank(subjectId)) && measureReport.getType().name().equals(
@@ -126,66 +97,6 @@ public class R4MeasureService {
             }
         }
         return measureReport;
-    }
-
-    
-
-    private List<String> getPractitionersInGroup(String practGroup) {
-        List<String> practitioners = new ArrayList<>();
-
-        IdType id = new IdType(practGroup);
-        org.hl7.fhir.r4.model.Group r =repository.read(Group.class, id);
-
-        if (r == null) {
-            throw new ResourceNotFoundException(id);
-        }
-
-        for (Group.GroupMemberComponent gmc : r.getMember()) {
-            IIdType ref = gmc.getEntity().getReferenceElement();
-            practitioners.add(ref.getResourceType() + "/" + ref.getIdPart());
-        }
-        return practitioners;
-    }
-
-    public List<String> getPractitionerPatients(String thePractitioner) {
-        List<String> patients = new ArrayList<>();
-
-        //Group of Practitioners
-        if(thePractitioner.startsWith("Group")){
-            var practitioners = getPractitionersInGroup(thePractitioner);
-            for (String prac : practitioners)
-            {
-                var pracPatients = getPractitionerSubjectIds(prac);
-                pracPatients.addAll(patients);
-            }
-            return patients;
-            //Individual Practitioner Reference
-        } else {
-            return getPractitionerSubjectIds(thePractitioner);
-        }
-    }
-
-    public List<String> getPractitionerSubjectIds(String thePractitioner){
-        List<String> patients = new ArrayList<>();
-
-        Map<String, List<IQueryParameterType>> map = new HashMap<>();
-        map.put(
-            "general-practitioner",
-            Collections.singletonList(new ReferenceParam(
-                thePractitioner.startsWith("Practitioner/")
-                    ? thePractitioner
-                    : "Practitioner/" + thePractitioner)));
-
-        var bundle = repository.search(Bundle.class, Patient.class, map);
-        var iterator = new BundleIterator<>(repository, bundle);
-
-        while (iterator.hasNext()) {
-            var patient = iterator.next().getResource();
-            var refString = patient.getIdElement().getResourceType() + "/"
-                + patient.getIdElement().getIdPart();
-            patients.add(refString);
-        }
-        return patients;
     }
 
     private void addProductLineExtension(MeasureReport theMeasureReport, String theProductLine) {
@@ -203,7 +114,12 @@ public class R4MeasureService {
 
         // set the request to be condition on code == supplemental data
         builder.addTransactionCreateEntry(SUPPLEMENTAL_DATA_SEARCHPARAMETER).conditional("code=supplemental-data");
-        repository.transaction(builder.getBundle());
+        try {
+            repository.transaction(builder.getBundle());
+        } catch (UnsupportedOperationException e) {
+            ourLog.debug(
+                "e");
+        }
     }
 
     public static final List<ContactDetail> CQI_CONTACTDETAIL = Collections.singletonList(new ContactDetail()

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4RepositorySubjectProvider.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4RepositorySubjectProvider.java
@@ -1,19 +1,25 @@
 package org.opencds.cqf.fhir.cr.measure.r4;
 
+import ca.uhn.fhir.model.api.IQueryParameterType;
+import ca.uhn.fhir.rest.param.ReferenceParam;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Group;
 import org.hl7.fhir.r4.model.Group.GroupMemberComponent;
+import org.hl7.fhir.r4.model.Group.GroupType;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Patient;
 import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.cr.measure.common.MeasureEvalType;
 import org.opencds.cqf.fhir.cr.measure.common.SubjectProvider;
+import org.opencds.cqf.fhir.utility.iterable.BundleIterator;
 import org.opencds.cqf.fhir.utility.iterable.BundleMappingIterable;
 import org.opencds.cqf.fhir.utility.search.Searches;
 
@@ -26,6 +32,7 @@ public class R4RepositorySubjectProvider implements SubjectProvider {
 
     @Override
     public Stream<String> getSubjects(Repository repository, MeasureEvalType measureEvalType, List<String> subjectIds) {
+        // All patients in system
         if (subjectIds == null
                 || subjectIds.isEmpty()
                 || subjectIds.get(0) == null
@@ -40,9 +47,11 @@ public class R4RepositorySubjectProvider implements SubjectProvider {
 
         List<String> subjects = new ArrayList<>();
         subjectIds.forEach(subjectId -> {
+            // add resource reference if missing
             if (subjectId.indexOf("/") == -1) {
                 subjectId = "Patient/".concat(subjectId);
             }
+            // Single Patient
             if (subjectId.startsWith("Patient")) {
                 IdType id = new IdType(subjectId);
                 Patient r = repository.read(Patient.class, id);
@@ -52,6 +61,12 @@ public class R4RepositorySubjectProvider implements SubjectProvider {
                 }
 
                 subjects.add(r.getIdElement().toUnqualifiedVersionless().getValue());
+            // Single Practitioner
+            } else if (subjectId.startsWith("Practitioner")){
+
+                addPractitionerSubjectIds(subjectId, repository, subjects);
+
+            // Group Subject
             } else if (subjectId.startsWith("Group")) {
                 IdType id = new IdType(subjectId);
                 Group r = repository.read(Group.class, id);
@@ -59,10 +74,23 @@ public class R4RepositorySubjectProvider implements SubjectProvider {
                 if (r == null) {
                     throw new ResourceNotFoundException(id);
                 }
+                //Group of Patients
+                if (r.getType().equals(GroupType.PERSON)) {
+                    for (GroupMemberComponent gmc : r.getMember()) {
+                        IIdType ref = gmc.getEntity().getReferenceElement();
+                        subjects.add(ref.getResourceType() + "/" + ref.getIdPart());
+                    }
+                }
+                //Group of Practitioners
+                else if (r.getType().equals(GroupType.PRACTITIONER)){
+                    var practitionerGroupMembers = getMembersInGroup(r);
 
-                for (GroupMemberComponent gmc : r.getMember()) {
-                    IIdType ref = gmc.getEntity().getReferenceElement();
-                    subjects.add(ref.getResourceType() + "/" + ref.getIdPart());
+                    //Loop through each practitioner in group
+                    for (String practitioner : practitionerGroupMembers)
+                    {
+                        //add patients associated with practitioner to subjects list
+                        addPractitionerSubjectIds(practitioner, repository, subjects);
+                    }
                 }
 
             } else {
@@ -71,5 +99,36 @@ public class R4RepositorySubjectProvider implements SubjectProvider {
         });
 
         return subjects.stream();
+    }
+
+    private List<String> getMembersInGroup(Group group) {
+        List<String> members = new ArrayList<>();
+
+        for (Group.GroupMemberComponent gmc : group.getMember()) {
+            IIdType ref = gmc.getEntity().getReferenceElement();
+            members.add(ref.getResourceType() + "/" + ref.getIdPart());
+        }
+        return members;
+    }
+
+    public void addPractitionerSubjectIds(String thePractitioner, Repository repository, List<String> patients){
+        Map<String, List<IQueryParameterType>> map = new HashMap<>();
+
+        map.put(
+            "general-practitioner",
+            Collections.singletonList(new ReferenceParam(
+                thePractitioner.startsWith("Practitioner/")
+                    ? thePractitioner
+                    : "Practitioner/" + thePractitioner)));
+
+        var bundle = repository.search(Bundle.class, Patient.class, map);
+        var iterator = new BundleIterator<>(repository, bundle);
+
+        while (iterator.hasNext()) {
+            var patient = iterator.next().getResource();
+            var refString = patient.getIdElement().getResourceType() + "/"
+                + patient.getIdElement().getIdPart();
+            patients.add(refString);
+        }
     }
 }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureServiceTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureServiceTest.java
@@ -1,0 +1,153 @@
+package org.opencds.cqf.fhir.cr.measure.r4;
+
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.cr.measure.r4.Measure.Given;
+
+public class R4MeasureServiceTest {
+    protected static Given given = Measure.given().repositoryFor("EXM108");
+
+    @Test
+    public void exm108_individualPractitionerParam() {
+        given.when()
+            .measureId("measure-EXM108-8.3.000")
+            .periodStart("2018-12-31")
+            .periodEnd("2019-12-31")
+            .practitoner("Practitioner/exm108-practitioner-2")
+            .reportType("population")
+            .evaluate()
+            .then()
+            .hasSubjectReference("Practitioner/exm108-practitioner-2")
+            .firstGroup()
+            .population("numerator")
+            .hasCount(1)
+            .up()
+            .population("denominator")
+            .hasCount(1);
+
+        given.when()
+            .measureId("measure-EXM108-8.3.000")
+            .periodStart("2018-12-31")
+            .periodEnd("2019-12-31")
+            .practitoner("Practitioner/exm108-practitioner-1")
+            .reportType("population")
+            .evaluate()
+            .then()
+            .hasSubjectReference("Practitioner/exm108-practitioner-1")
+            .firstGroup()
+            .population("numerator")
+            .hasCount(0)
+            .up()
+            .population("denominator")
+            .hasCount(1);
+    }
+
+    @Test
+    public void exm108_groupPatientsParam() {
+
+        given.when()
+            .measureId("measure-EXM108-8.3.000")
+            .periodStart("2018-12-31")
+            .periodEnd("2019-12-31")
+            .subject("Group/patient-group-108")
+            .reportType("population")
+            .evaluate()
+            .then()
+            .hasSubjectReference("Group/patient-group-108")
+            .firstGroup()
+            .population("numerator")
+            .hasCount(1)
+            .up()
+            .population("denominator")
+            .hasCount(2);
+    }
+    @Test
+    public void exm108_allPatients() {
+
+        given.when()
+            .measureId("measure-EXM108-8.3.000")
+            .periodStart("2018-12-31")
+            .periodEnd("2019-12-31")
+            .practitoner(null)
+            .reportType("population")
+            .evaluate()
+            .then()
+            .hasSubjectReference(null)
+            .firstGroup()
+            .population("numerator")
+            .hasCount(1)
+            .up()
+            .population("denominator")
+            .hasCount(2);
+    }
+
+    @Test
+    public void exm108_noReportTypePopulation() {
+
+        given.when()
+            .measureId("measure-EXM108-8.3.000")
+            .periodStart("2018-12-31")
+            .periodEnd("2019-12-31")
+            .evaluate()
+            .then()
+            .firstGroup()
+            .population("numerator")
+            .hasCount(1)
+            .up()
+            .population("denominator")
+            .hasCount(2);
+    }
+    @Test
+    public void exm108_noReportTypeIndividual() {
+
+        given.when()
+            .measureId("measure-EXM108-8.3.000")
+            .periodStart("2018-12-31")
+            .periodEnd("2019-12-31")
+            .subject("Patient/numer-EXM108")
+            .evaluate()
+            .then()
+            .hasSubjectReference("Patient/numer-EXM108")
+            .firstGroup()
+            .population("numerator")
+            .hasCount(1)
+            .up()
+            .population("denominator")
+            .hasCount(1);
+    }
+
+    @Test
+    public void exm108_wrongReportTypePassed1() {
+
+        given.when()
+            .measureId("measure-EXM108-8.3.000")
+            .periodStart("2018-12-31")
+            .periodEnd("2019-12-31")
+            .reportType("individual")
+            .evaluate()
+            .then()
+            .firstGroup()
+            .population("numerator")
+            .hasCount(1)
+            .up()
+            .population("denominator")
+            .hasCount(2);
+    }
+    @Test
+    public void exm108_wrongReportTypePassed2() {
+
+        given.when()
+            .measureId("measure-EXM108-8.3.000")
+            .periodStart("2018-12-31")
+            .periodEnd("2019-12-31")
+            .reportType("summary")
+            .subject("Patient/numer-EXM108")
+            .evaluate()
+            .then()
+            .firstGroup()
+            .population("numerator")
+            .hasCount(1)
+            .up()
+            .population("denominator")
+            .hasCount(1);
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/SimpleMeasureProcessorTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/SimpleMeasureProcessorTest.java
@@ -13,7 +13,6 @@ public class SimpleMeasureProcessorTest {
     protected static Given given = Measure.given().repositoryFor("EXM108");
 
     @Test
-    @Disabled("Need to test at the service level to enable this")
     public void exm108_partialSubjectId() {
         given.when()
                 .measureId("measure-EXM108-8.3.000")
@@ -45,6 +44,7 @@ public class SimpleMeasureProcessorTest {
                 .population("denominator")
                 .hasCount(1);
     }
+
 
     @Test
     public void exm108_fullSubjectId() {

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/EXM108/tests/group/patient-group-108.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/EXM108/tests/group/patient-group-108.json
@@ -1,0 +1,10 @@
+{
+  "resourceType": "Group",
+  "id": "patient-group-108",
+  "type": "person",
+  "actual": true,
+  "member": [
+    {  "entity": {  "reference": "Patient/denom-EXM108" } },
+    {  "entity": {  "reference": "Patient/numer-EXM108" } }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/EXM108/tests/group/practitioner-group-108.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/EXM108/tests/group/practitioner-group-108.json
@@ -1,0 +1,10 @@
+{
+  "resourceType": "Group",
+  "id": "practitioner-group-108",
+  "type": "practitioner",
+  "actual": true,
+  "member": [
+    {  "entity": {  "reference": "Practitioner/exm108-practitioner-2" } },
+    {  "entity": {  "reference": "Practitioner/exm108-practitioner-1" } }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/EXM108/tests/organization/reporter-org.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/EXM108/tests/organization/reporter-org.json
@@ -1,0 +1,58 @@
+"resource": {
+"resourceType": "Organization",
+"id": "reporter-org",
+"meta": {
+"profile": [
+"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/organization-deqm"
+]
+},
+"identifier": [
+{
+"system": "urn:oid:2.16.840.1.113883.4.4",
+"value": "123456789",
+"use": "official",
+"type": {
+"coding": [
+{
+"code": "TAX",
+"system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+"display": "Tax ID number"
+}
+]
+},
+"assigner": {
+"display": "www.irs.gov"
+}
+}
+],
+"active": true,
+"type": [
+{
+"coding": [
+{
+"code": "prov",
+"system": "http://terminology.hl7.org/CodeSystem/organization-type",
+"display": "Healthcare Provider"
+}
+]
+}
+],
+"name": "reporter-org",
+"telecom": [
+{
+"system": "phone",
+"value": "(+1) 401-555-1212"
+}
+],
+"address": [
+{
+"line": [
+"73 Lakewood Street"
+],
+"city": "Warwick",
+"state": "RI",
+"postalCode": "02886",
+"country": "USA"
+}
+]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/EXM108/tests/patient/denom-EXM108-2.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/EXM108/tests/patient/denom-EXM108-2.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "Patient",
-  "id": "numer-EXM108",
+  "id": "denom-EXM108-2",
   "meta": {
     "profile": [ "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient" ]
   },
@@ -35,15 +35,15 @@
       } ]
     },
     "system": "http://hospital.smarthealthit.org",
-    "value": "999999997"
+    "value": "999999955"
   } ],
   "name": [ {
-    "family": "Smith",
-    "given": [ "Jill" ]
+    "family": "Jonesy",
+    "given": [ "Franky" ]
   } ],
-  "gender": "female",
-  "birthDate": "1963-09-13",
+  "gender": "male",
+  "birthDate": "1952-05-01",
   "generalPractitioner": {
-    "reference": "Practitioner/exm108-practitioner-2"
+    "reference": "Practitioner/exm108-practitioner-1"
   }
 }

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/EXM108/tests/patient/denom-EXM108.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/EXM108/tests/patient/denom-EXM108.json
@@ -42,5 +42,8 @@
     "given": [ "Frank" ]
   } ],
   "gender": "male",
-  "birthDate": "1951-05-01"
+  "birthDate": "1951-05-01",
+  "generalPractitioner": {
+    "reference": "Practitioner/exm108-practitioner-1"
+  }
 }

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/EXM108/tests/patient/numer-EXM108-2.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/EXM108/tests/patient/numer-EXM108-2.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "Patient",
-  "id": "numer-EXM108",
+  "id": "numer-EXM108-2",
   "meta": {
     "profile": [ "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient" ]
   },
@@ -35,14 +35,14 @@
       } ]
     },
     "system": "http://hospital.smarthealthit.org",
-    "value": "999999997"
+    "value": "999999999"
   } ],
   "name": [ {
-    "family": "Smith",
-    "given": [ "Jill" ]
+    "family": "Smithers",
+    "given": [ "Jillian" ]
   } ],
   "gender": "female",
-  "birthDate": "1963-09-13",
+  "birthDate": "1962-07-13",
   "generalPractitioner": {
     "reference": "Practitioner/exm108-practitioner-2"
   }

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/EXM108/tests/practitioner/practitioner-108-1.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/EXM108/tests/practitioner/practitioner-108-1.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "Practitioner",
+  "id": "exm108-practitioner-1",
+  "meta": {
+    "profile": [ "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitioner" ]
+  },
+  "name": [ {
+    "family": "Careful",
+    "given": [ "Justin" ],
+    "prefix": [ "Dr" ]
+  } ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/EXM108/tests/practitioner/practitioner-108-2.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/EXM108/tests/practitioner/practitioner-108-2.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "Practitioner",
+  "id": "exm108-practitioner-2",
+  "meta": {
+    "profile": [ "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitioner" ]
+  },
+  "name": [ {
+    "family": "Careful",
+    "given": [ "Ali" ],
+    "prefix": [ "Dr" ]
+  } ]
+}


### PR DESCRIPTION
- Update r4MeasureService from hapi-fhir MeasureService
- Fix [bug](https://github.com/cqframework/clinical-reasoning/issues/344) where reportType=null does not cause error
- Add capability for r4 evaluateMeasure to handle practitioner & practitioner group via R4SubjectProvider
- Fix [bug ](https://github.com/alphora/dqm-platform/issues/295) where summary subject references were not being populated by Group/Practitioner references 
- update Measure Given tests to use MeasureService instead of processor