### PR TITLE
isolate getsubjects method in Measure Processor

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureProcessor.java
@@ -53,8 +53,34 @@ public class R4MeasureProcessor {
             String reportType,
             List<String> subjectIds,
             IBaseBundle additionalData) {
+
+        var evalType = MeasureEvalType.fromCode(reportType)
+                .orElse(
+                        subjectIds.get(0) == null || subjectIds == null || subjectIds.isEmpty()
+                                ? MeasureEvalType.POPULATION
+                                : MeasureEvalType.SUBJECT);
+
+        var actualRepo = this.repository;
+        if (additionalData != null) {
+            actualRepo = new FederatedRepository(
+                    this.repository, new InMemoryFhirRepository(this.repository.fhirContext(), additionalData));
+        }
+        var subjects =
+                subjectProvider.getSubjects(actualRepo, evalType, subjectIds).collect(Collectors.toList());
+
+        return this.evaluateMeasure(measure, periodStart, periodEnd, reportType, subjects, additionalData, evalType);
+    }
+
+    public MeasureReport evaluateMeasure(
+            Either3<CanonicalType, IdType, Measure> measure,
+            String periodStart,
+            String periodEnd,
+            String reportType,
+            List<String> subjectIds,
+            IBaseBundle additionalData,
+            MeasureEvalType evalType) {
         var m = measure.fold(this::resolveByUrl, this::resolveById, Function.identity());
-        return this.evaluateMeasure(m, periodStart, periodEnd, reportType, subjectIds, additionalData);
+        return this.evaluateMeasure(m, periodStart, periodEnd, reportType, subjectIds, additionalData, evalType);
     }
 
     protected MeasureReport evaluateMeasure(
@@ -63,7 +89,8 @@ public class R4MeasureProcessor {
             String periodEnd,
             String reportType,
             List<String> subjectIds,
-            IBaseBundle additionalData) {
+            IBaseBundle additionalData,
+            MeasureEvalType evalType) {
 
         if (!measure.hasLibrary()) {
             throw new IllegalArgumentException(
@@ -83,23 +110,16 @@ public class R4MeasureProcessor {
 
         context.getState().init(lib.getLibrary());
 
-        var evalType = MeasureEvalType.fromCode(reportType)
-                .orElse(
-                        subjectIds.get(0) == null || subjectIds == null || subjectIds.isEmpty()
-                                ? MeasureEvalType.POPULATION
-                                : MeasureEvalType.SUBJECT);
-
-        var actualRepo = this.repository;
-        if (additionalData != null) {
-            actualRepo = new FederatedRepository(
-                    this.repository, new InMemoryFhirRepository(this.repository.fhirContext(), additionalData));
+        if (evalType == null) {
+            evalType = MeasureEvalType.fromCode(reportType)
+                    .orElse(
+                            subjectIds.get(0) == null || subjectIds == null || subjectIds.isEmpty()
+                                    ? MeasureEvalType.POPULATION
+                                    : MeasureEvalType.SUBJECT);
         }
 
-        var subjects =
-                subjectProvider.getSubjects(actualRepo, evalType, subjectIds).collect(Collectors.toList());
-
         R4MeasureEvaluation measureEvaluator = new R4MeasureEvaluation(context, measure);
-        return measureEvaluator.evaluate(evalType, subjects, measurementPeriod);
+        return measureEvaluator.evaluate(evalType, subjectIds, measurementPeriod);
     }
 
     protected Measure resolveByUrl(CanonicalType url) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureService.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureService.java
@@ -67,7 +67,7 @@ public class R4MeasureService {
 
         if (StringUtils.isNotBlank(practitioner)) {
             if (practitioner.indexOf("/") == -1) {
-                subjectId = "Practitioner/".concat(practitioner);
+                practitioner = "Practitioner/".concat(practitioner);
             }
             subjectId = practitioner;
         }


### PR DESCRIPTION
Related Issue: https://github.com/alphora/dqm-platform/issues/362

Allow for subjects to be passed into processor to avoid redundant calls of getSubjects