### PR TITLE
Fixes for malformed codes and valuesets

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
         "clinicalreasoning",
         "Codeable",
         "CODEABLECONCEPT",
+        "CODESYSTEM",
         "codesystems",
         "Configurer",
         "connectathon",
@@ -70,7 +71,8 @@
         "testng",
         "unsignedint",
         "Unvalidated",
-        "uscore"
+        "uscore",
+        "VALUESET"
     ],
     "cSpell.enabledLanguageIds": [
         "java",

--- a/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/engine/terminology/RepositoryTerminologyProviderTest.java
+++ b/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/engine/terminology/RepositoryTerminologyProviderTest.java
@@ -1,0 +1,91 @@
+package org.opencds.cqf.fhir.cql.engine.terminology;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ca.uhn.fhir.context.FhirContext;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.cql.engine.runtime.Code;
+import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
+import org.opencds.cqf.cql.engine.terminology.ValueSetInfo;
+import org.opencds.cqf.fhir.api.Repository;
+
+class RepositoryTerminologyProviderTest {
+
+    private static final String SYSTEM_FOR_CODES = "http://example.com/CodeSystem/Codes";
+    private static final String VALID_VALUE_SET_URL = "http://example.com/ValueSet/ValidValueSet";
+    private static final String MISSING_SYSTEM_VALUE_SET_URL = "http://example.com/ValueSet/MissingSystemValueSet";
+    private static final String MISSING_CODE_VALUE_SET_URL = "http://example.com/ValueSet/MissingCodeValueSet";
+
+    @Test
+    void validCodesInValueSet() {
+        var terminologyProvider = terminologyProviderWith("ValidValueSet");
+        var vsInfo = new ValueSetInfo().withId(VALID_VALUE_SET_URL);
+
+        var codeExistsInValueSet = new Code().withCode("123").withSystem(SYSTEM_FOR_CODES);
+        assertTrue(terminologyProvider.in(codeExistsInValueSet, vsInfo));
+
+        var codeDoesNotExistInValueSet = new Code().withCode("DNE").withSystem(SYSTEM_FOR_CODES);
+        assertFalse(terminologyProvider.in(codeDoesNotExistInValueSet, vsInfo));
+    }
+
+    @Test
+    void missingCodeValueSetMatches() {
+        var terminologyProvider = terminologyProviderWith("MissingCodeValueSet");
+        var vsInfo = new ValueSetInfo().withId(MISSING_CODE_VALUE_SET_URL);
+
+        var validCode = new Code().withCode("123").withSystem(SYSTEM_FOR_CODES);
+        assertTrue(terminologyProvider.in(validCode, vsInfo));
+
+        var codeMissingCode = new Code().withSystem(SYSTEM_FOR_CODES);
+        assertFalse(terminologyProvider.in(codeMissingCode, vsInfo));
+
+        var codeMissingSystem = new Code().withCode("123");
+        assertFalse(terminologyProvider.in(codeMissingSystem, vsInfo));
+    }
+
+    @Test
+    void missingSystemValueSetMatches() {
+        var terminologyProvider = terminologyProviderWith("MissingSystemValueSet");
+        var vsInfo = new ValueSetInfo().withId(MISSING_SYSTEM_VALUE_SET_URL);
+
+        var validCode = new Code().withCode("123").withSystem(SYSTEM_FOR_CODES);
+        assertTrue(terminologyProvider.in(validCode, vsInfo));
+
+        var codeMissingCode = new Code().withSystem(SYSTEM_FOR_CODES);
+        assertFalse(terminologyProvider.in(codeMissingCode, vsInfo));
+
+        var codeMissingSystem = new Code().withCode("123");
+        assertFalse(terminologyProvider.in(codeMissingSystem, vsInfo));
+    }
+
+    Repository mockRepositoryFor(String id) {
+        var vs = loadValueSet(id);
+        return mockRepositoryWithValueSet(vs);
+    }
+
+    Repository mockRepositoryWithValueSet(ValueSet valueSet) {
+        var mockRepository = mock(Repository.class);
+        when(mockRepository.fhirContext()).thenReturn(FhirContext.forR4Cached());
+        Bundle bundle = new Bundle();
+        bundle.addEntry().setFullUrl(valueSet.getUrl()).setResource(valueSet);
+        when(mockRepository.search(any(), any(), any(), isNull())).thenReturn(bundle);
+        return mockRepository;
+    }
+
+    ValueSet loadValueSet(String id) {
+        var resourceStream = this.getClass().getResourceAsStream(id + ".json");
+        return (ValueSet) FhirContext.forR4Cached().newJsonParser().parseResource(resourceStream);
+    }
+
+    TerminologyProvider terminologyProviderWith(String valueSetId) {
+        var repository = mockRepositoryFor(valueSetId);
+        return new RepositoryTerminologyProvider(repository, new TerminologySettings());
+    }
+}

--- a/cqf-fhir-cql/src/test/resources/org/opencds/cqf/fhir/cql/engine/terminology/MissingCodeValueSet.json
+++ b/cqf-fhir-cql/src/test/resources/org/opencds/cqf/fhir/cql/engine/terminology/MissingCodeValueSet.json
@@ -1,0 +1,20 @@
+{
+    "resourceType": "ValueSet",
+    "id": "MissingCodeValueSet",
+    "url": "http://example.com/ValueSet/MissingCodeValueSet",
+    "expansion": {
+        "contains": [
+            {
+                "system": "http://example.com/CodeSystem/Codes",
+                "code": "123"
+            },
+            {
+                "system": "http://example.com/CodeSystem/Codes"
+            },
+            {
+                "system": "http://example.com/CodeSystem/Codes",
+                "code": "456"
+            }
+        ]
+    }
+}

--- a/cqf-fhir-cql/src/test/resources/org/opencds/cqf/fhir/cql/engine/terminology/MissingSystemValueSet.json
+++ b/cqf-fhir-cql/src/test/resources/org/opencds/cqf/fhir/cql/engine/terminology/MissingSystemValueSet.json
@@ -1,0 +1,20 @@
+{
+    "resourceType": "ValueSet",
+    "id": "MissingSystemValueSet",
+    "url": "http://example.com/ValueSet/MissingSystemValueSet",
+    "expansion": {
+        "contains": [
+            {
+                "system": "http://example.com/CodeSystem/Codes",
+                "code": "123"
+            },
+            {
+                "code": "456"
+            },
+            {
+                "system": "http://example.com/CodeSystem/Codes",
+                "code": "789"
+            }
+        ]
+    }
+}

--- a/cqf-fhir-cql/src/test/resources/org/opencds/cqf/fhir/cql/engine/terminology/ValidValueSet.json
+++ b/cqf-fhir-cql/src/test/resources/org/opencds/cqf/fhir/cql/engine/terminology/ValidValueSet.json
@@ -1,0 +1,21 @@
+{
+    "resourceType": "ValueSet",
+    "id": "ValidValueSet",
+    "url": "http://example.com/ValueSet/ValidValueSet",
+    "expansion": {
+        "contains": [
+            {
+                "system": "http://example.com/CodeSystem/Codes",
+                "code": "123"
+            },
+            {
+                "system": "http://example.com/CodeSystem/Codes",
+                "code": "456"
+            },
+            {
+                "system": "http://example.com/CodeSystem/Codes",
+                "code": "789"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
* Fixes null pointer exceptions when codes are incompletely specified
* Fixes null pointer exceptions when valuesets are incompletely specified
* The above is accomplished by ignoring (i.e. filtering out) partially specified codes