### PR TITLE
Fix for canonical url splitting

### DIFF
--- a/cqf-fhir-api/pom.xml
+++ b/cqf-fhir-api/pom.xml
@@ -5,14 +5,14 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-api</artifactId>
-  <version>3.0.0-PRE17-SNAPSHOT</version>
+  <version>3.0.0-PRE17</version>
   <name>FHIR Clinical Reasoning (APIs)</name>
   <description>FHIR Repository APIs used by this project. Implement these to incorporate clinical reasoning on your platform</description>
 
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-PRE17-SNAPSHOT</version>
+    <version>3.0.0-PRE17</version>
   </parent>
 
   <dependencies>

--- a/cqf-fhir-benchmark/pom.xml
+++ b/cqf-fhir-benchmark/pom.xml
@@ -5,26 +5,26 @@
 
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir-benchmark</artifactId>
-    <version>3.0.0-PRE17-SNAPSHOT</version>
+    <version>3.0.0-PRE17</version>
     <name>FHIR Clinical Reasoning (Benchmarks)</name>
     <description>Tests validating performance of FHIR Clinical Reasoning operations</description>
 
     <parent>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir</artifactId>
-        <version>3.0.0-PRE17-SNAPSHOT</version>
+        <version>3.0.0-PRE17</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>org.opencds.cqf.fhir</groupId>
             <artifactId>cqf-fhir-cr</artifactId>
-            <version>3.0.0-PRE17-SNAPSHOT</version>
+            <version>3.0.0-PRE17</version>
         </dependency>
         <dependency>
             <groupId>org.opencds.cqf.fhir</groupId>
             <artifactId>cqf-fhir-test</artifactId>
-            <version>3.0.0-PRE17-SNAPSHOT</version>
+            <version>3.0.0-PRE17</version>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
@@ -34,14 +34,14 @@
         <dependency>
             <groupId>org.opencds.cqf.fhir</groupId>
             <artifactId>cqf-fhir-cr</artifactId>
-            <version>3.0.0-PRE17-SNAPSHOT</version>
+            <version>3.0.0-PRE17</version>
             <!--TODO: test-jars don't seem to work very well. Need to investigate some alternatives -->
             <type>test-jar</type>
         </dependency>
         <dependency>
             <groupId>org.opencds.cqf.fhir</groupId>
             <artifactId>cqf-fhir-jackson</artifactId>
-            <version>3.0.0-PRE17-SNAPSHOT</version>
+            <version>3.0.0-PRE17</version>
             <type>pom</type>
             <scope>test</scope>
         </dependency>

--- a/cqf-fhir-bom/pom.xml
+++ b/cqf-fhir-bom/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-bom</artifactId>
-  <version>3.0.0-PRE17-SNAPSHOT</version>
+  <version>3.0.0-PRE17</version>
   <packaging>pom</packaging>
   <name>FHIR Clinical Reasoning (Bill Of Materials)</name>
   <description>This bom can be used to simplify dependency management when using this project</description>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-PRE17-SNAPSHOT</version>
+    <version>3.0.0-PRE17</version>
   </parent>
 
   <dependencyManagement>
@@ -21,44 +21,44 @@
       <dependency>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir-api</artifactId>
-        <version>3.0.0-PRE17-SNAPSHOT</version>
+        <version>3.0.0-PRE17</version>
       </dependency>
       <dependency>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir-test</artifactId>
-        <version>3.0.0-PRE17-SNAPSHOT</version>
+        <version>3.0.0-PRE17</version>
       </dependency>
       <dependency>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir-utility</artifactId>
-        <version>3.0.0-PRE17-SNAPSHOT</version>
+        <version>3.0.0-PRE17</version>
       </dependency>
       <dependency>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir-cql</artifactId>
-        <version>3.0.0-PRE17-SNAPSHOT</version>
+        <version>3.0.0-PRE17</version>
       </dependency>
       <dependency>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir-jackson</artifactId>
-        <version>3.0.0-PRE17-SNAPSHOT</version>
+        <version>3.0.0-PRE17</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir-jaxb</artifactId>
-        <version>3.0.0-PRE17-SNAPSHOT</version>
+        <version>3.0.0-PRE17</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir-cr</artifactId>
-        <version>3.0.0-PRE17-SNAPSHOT</version>
+        <version>3.0.0-PRE17</version>
       </dependency>
       <dependency>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir-cr-cli</artifactId>
-        <version>3.0.0-PRE17-SNAPSHOT</version>
+        <version>3.0.0-PRE17</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/cqf-fhir-cql/pom.xml
+++ b/cqf-fhir-cql/pom.xml
@@ -5,26 +5,26 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-cql</artifactId>
-  <version>3.0.0-PRE17-SNAPSHOT</version>
+  <version>3.0.0-PRE17</version>
   <name>FHIR Clinical Reasoning (CQL)</name>
   <description>Tools, utilities, code gen to support CQL in FHIR Clinical Reasoning operations</description>
 
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-PRE17-SNAPSHOT</version>
+    <version>3.0.0-PRE17</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.0.0-PRE17-SNAPSHOT</version>
+      <version>3.0.0-PRE17</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-utility</artifactId>
-      <version>3.0.0-PRE17-SNAPSHOT</version>
+      <version>3.0.0-PRE17</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
@@ -53,13 +53,13 @@
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-test</artifactId>
-      <version>3.0.0-PRE17-SNAPSHOT</version>
+      <version>3.0.0-PRE17</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-jackson</artifactId>
-      <version>3.0.0-PRE17-SNAPSHOT</version>
+      <version>3.0.0-PRE17</version>
       <type>pom</type>
       <scope>test</scope>
     </dependency>

--- a/cqf-fhir-cr-cli/pom.xml
+++ b/cqf-fhir-cr-cli/pom.xml
@@ -6,36 +6,36 @@
 
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir-cr-cli</artifactId>
-    <version>3.0.0-PRE17-SNAPSHOT</version>
+    <version>3.0.0-PRE17</version>
     <name>FHIR Clinical Reasoning (CLI)</name>
     <description>CLI for running FHIR Clincial Reasoning operations</description>
 
     <parent>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir</artifactId>
-        <version>3.0.0-PRE17-SNAPSHOT</version>
+        <version>3.0.0-PRE17</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>org.opencds.cqf.fhir</groupId>
             <artifactId>cqf-fhir-api</artifactId>
-            <version>3.0.0-PRE17-SNAPSHOT</version>
+            <version>3.0.0-PRE17</version>
         </dependency>
         <dependency>
             <groupId>org.opencds.cqf.fhir</groupId>
             <artifactId>cqf-fhir-utility</artifactId>
-            <version>3.0.0-PRE17-SNAPSHOT</version>
+            <version>3.0.0-PRE17</version>
         </dependency>
         <dependency>
             <groupId>org.opencds.cqf.fhir</groupId>
             <artifactId>cqf-fhir-cql</artifactId>
-            <version>3.0.0-PRE17-SNAPSHOT</version>
+            <version>3.0.0-PRE17</version>
         </dependency>
         <dependency>
             <groupId>org.opencds.cqf.fhir</groupId>
             <artifactId>cqf-fhir-jackson</artifactId>
-            <version>3.0.0-PRE17-SNAPSHOT</version>
+            <version>3.0.0-PRE17</version>
             <type>pom</type>
         </dependency>
         <dependency>

--- a/cqf-fhir-cr-spring/pom.xml
+++ b/cqf-fhir-cr-spring/pom.xml
@@ -6,21 +6,21 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-cr-spring</artifactId>
-  <version>3.0.0-PRE17-SNAPSHOT</version>
+  <version>3.0.0-PRE17</version>
   <name>FHIR Clinical Reasoning (Spring)</name>
   <description>Spring configurations for FHIR Clinical Reasoning</description>
 
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-PRE17-SNAPSHOT</version>
+    <version>3.0.0-PRE17</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-cr</artifactId>
-      <version>3.0.0-PRE17-SNAPSHOT</version>
+      <version>3.0.0-PRE17</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/cqf-fhir-cr/pom.xml
+++ b/cqf-fhir-cr/pom.xml
@@ -5,45 +5,45 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-cr</artifactId>
-  <version>3.0.0-PRE17-SNAPSHOT</version>
+  <version>3.0.0-PRE17</version>
   <name>FHIR Clinical Reasoning (Operations)</name>
   <description>Implementations of clinical reasoning operations</description>
 
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-PRE17-SNAPSHOT</version>
+    <version>3.0.0-PRE17</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.0.0-PRE17-SNAPSHOT</version>
+      <version>3.0.0-PRE17</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-cql</artifactId>
-      <version>3.0.0-PRE17-SNAPSHOT</version>
+      <version>3.0.0-PRE17</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-utility</artifactId>
-      <version>3.0.0-PRE17-SNAPSHOT</version>
+      <version>3.0.0-PRE17</version>
     </dependency>
 
     <!-- test dependencies-->
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-jackson</artifactId>
-      <version>3.0.0-PRE17-SNAPSHOT</version>
+      <version>3.0.0-PRE17</version>
       <type>pom</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-test</artifactId>
-      <version>3.0.0-PRE17-SNAPSHOT</version>
+      <version>3.0.0-PRE17</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/EXM108/resources/measure/measure-EXM108-8.3.000.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/EXM108/resources/measure/measure-EXM108-8.3.000.json
@@ -57,7 +57,7 @@
       "display": "Health Quality Measure Document"
     } ]
   } ],
-  "library": [ "http://fhir.org/guides/dbcg/connectathon/Library/EXM108" ],
+  "library": [ "http://fhir.org/guides/dbcg/connectathon/Library/EXM108|8.3.000" ],
   "disclaimer": "These performance measures are not clinical guidelines and do not establish a standard of medical care, and have not been tested for all potential applications. The measures and specifications are provided without warranty",
   "scoring": {
     "coding": [ {

--- a/cqf-fhir-jackson/pom.xml
+++ b/cqf-fhir-jackson/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-jackson</artifactId>
-  <version>3.0.0-PRE17-SNAPSHOT</version>
+  <version>3.0.0-PRE17</version>
   <packaging>pom</packaging>
   <name>FHIR Clinical Reasoning (Jackson)</name>
   <description>Aggregator module for Jackson dependencies</description>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-PRE17-SNAPSHOT</version>
+    <version>3.0.0-PRE17</version>
   </parent>
 
   <dependencies>

--- a/cqf-fhir-jaxb/pom.xml
+++ b/cqf-fhir-jaxb/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-jaxb</artifactId>
-  <version>3.0.0-PRE17-SNAPSHOT</version>
+  <version>3.0.0-PRE17</version>
   <packaging>pom</packaging>
   <name>FHIR Clinical Reasoning (JAXB)</name>
   <description>Aggregator module for JAXB dependencies</description>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-PRE17-SNAPSHOT</version>
+    <version>3.0.0-PRE17</version>
   </parent>
 
   <dependencies>

--- a/cqf-fhir-test/pom.xml
+++ b/cqf-fhir-test/pom.xml
@@ -5,26 +5,26 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-test</artifactId>
-  <version>3.0.0-PRE17-SNAPSHOT</version>
+  <version>3.0.0-PRE17</version>
   <name>FHIR Clinical Reasoning (Test Utilities)</name>
   <description>Utilities to support unit testing clinical reasoning operations</description>
 
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-PRE17-SNAPSHOT</version>
+    <version>3.0.0-PRE17</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.0.0-PRE17-SNAPSHOT</version>
+      <version>3.0.0-PRE17</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-utility</artifactId>
-      <version>3.0.0-PRE17-SNAPSHOT</version>
+      <version>3.0.0-PRE17</version>
     </dependency>
     <dependency>
       <groupId>org.skyscreamer</groupId>

--- a/cqf-fhir-utility/pom.xml
+++ b/cqf-fhir-utility/pom.xml
@@ -5,21 +5,21 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-utility</artifactId>
-  <version>3.0.0-PRE17-SNAPSHOT</version>
+  <version>3.0.0-PRE17</version>
   <name>FHIR Clinical Reasoning (Utilities)</name>
   <description>Utilities to help develop clinical reasoning operations</description>
 
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-PRE17-SNAPSHOT</version>
+    <version>3.0.0-PRE17</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.0.0-PRE17-SNAPSHOT</version>
+      <version>3.0.0-PRE17</version>
     </dependency>
     <dependency>
       <groupId>ca.uhn.hapi.fhir</groupId>

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/search/Searches.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/search/Searches.java
@@ -10,6 +10,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.opencds.cqf.fhir.utility.Canonicals;
+
 /*
  * This is a utility class to help construct search maps, which are then passed into the Repository
  * to perform a search. If you find that you have a certain type of search that you are repeating
@@ -34,11 +36,11 @@ public class Searches {
     }
 
     public static Map<String, List<IQueryParameterType>> byCanonical(String canonical) {
-        if (canonical.contains("|")) {
-            var split = canonical.split("|");
-            return byUrlAndVersion(split[0], split[1]);
+        var parts = Canonicals.getParts(canonical);
+        if (parts.version() != null) {
+            return byUrlAndVersion(parts.url(), parts.version());
         } else {
-            return byUrl(canonical);
+            return byUrl(parts.url());
         }
     }
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>docs</artifactId>
-  <version>3.0.0-PRE17-SNAPSHOT</version>
+  <version>3.0.0-PRE17</version>
 
   <name>FHIR Clinical Reasoning (Documentation)</name>
   <description>Documentation website for FHIR Clinical Reasoning</description>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-PRE17-SNAPSHOT</version>
+    <version>3.0.0-PRE17</version>
   </parent>
 
   <dependencyManagement>
@@ -23,7 +23,7 @@
         <artifactId>cqf-fhir-bom</artifactId>
         <type>pom</type>
         <scope>import</scope>
-        <version>3.0.0-PRE17-SNAPSHOT</version>
+        <version>3.0.0-PRE17</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.0.0-PRE17-SNAPSHOT</version>
+    <version>3.0.0-PRE17</version>
     <packaging>pom</packaging>
     <name>FHIR Clinical Reasoning</name>
     <description>FHIR Clinical Reasoning Implementations</description>


### PR DESCRIPTION
* Update searches to use the Canonical helper class
* Update a test case to exercise that path