### PR TITLE
Fix $extract bug with answerValue transform

### DIFF
--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaireresponse/QuestionnaireResponseProcessorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaireresponse/QuestionnaireResponseProcessorTests.java
@@ -76,7 +76,11 @@ public class QuestionnaireResponseProcessorTests {
         var resources = BundleHelper.getEntryResources(result);
         var obs1 = (Observation) resources.get(0);
         var obs2 = (Observation) resources.get(1);
+        assertTrue(obs1.hasCode());
+        assertTrue(obs1.hasStatus());
         assertTrue(obs1.hasValueCodeableConcept());
+        assertTrue(obs2.hasCode());
+        assertTrue(obs2.hasStatus());
         assertTrue(obs2.hasValueDateTimeType());
     }
 }

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/questionnaireresponse/r4/tests/QuestionnaireResponse-TherapyMonitoringRecommendation.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/questionnaireresponse/r4/tests/QuestionnaireResponse-TherapyMonitoringRecommendation.json
@@ -25,6 +25,32 @@
               }
             }
           ]
+        },
+        {
+          "linkId": "1.2",
+          "definition": "http://example.org/StructureDefinition/ActiveTherapyFeature#Observation.code",
+          "text": "Type of observation (code / type)",
+          "answer": [
+            {
+              "valueCoding": {
+                "code": "on-medication-therapy",
+                "system": "http://example.org/CodeSystem/CaseFeatureCodes"
+              }
+            }
+          ]
+        },
+        {
+          "linkId": "1.3",
+          "definition": "http://example.org/StructureDefinition/ActiveTherapyFeature#Observation.status",
+          "text": "The status of the result value.",
+          "answer": [
+            {
+              "valueCoding": {
+                "code": "final",
+                "system": "http://hl7.org/fhir/observation-status"
+              }
+            }
+          ]
         }
       ]
     },
@@ -40,6 +66,32 @@
           "answer": [
             {
               "valueDateTime": "2024-01-22T11:45:33+11:00"
+            }
+          ]
+        },
+        {
+          "linkId": "2.2",
+          "definition": "http://example.org/StructureDefinition/ActiveTherapyFeature#Observation.code",
+          "text": "Type of observation (code / type)",
+          "answer": [
+            {
+              "valueCoding": {
+                "code": "last-cbc-panel-report-date",
+                "system": "http://example.org/CodeSystem/CaseFeatureCodes"
+              }
+            }
+          ]
+        },
+        {
+          "linkId": "2.3",
+          "definition": "http://example.org/StructureDefinition/ActiveTherapyFeature#Observation.status",
+          "text": "The status of the result value.",
+          "answer": [
+            {
+              "valueCoding": {
+                "code": "final",
+                "system": "http://hl7.org/fhir/observation-status"
+              }
             }
           ]
         }


### PR DESCRIPTION
Added logic to the $extract operation to determine if type transformation needs to occur when setting values on the extracted resource from the QuestionnaireResponse answerValues and if needed perform that transformation.