### PR TITLE
Fix UnsupportedOperationException

### DIFF
--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/Engines.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/Engines.java
@@ -57,7 +57,8 @@ public class Engines {
             Repository repository, EvaluationSettings settings, NpmProcessor npmProcessor, Boolean useLibraryCache) {
         var terminologyProvider = new RepositoryTerminologyProvider(
                 repository, settings.getValueSetCache(), settings.getTerminologySettings());
-        var sources = Collections.singletonList(buildLibrarySource(repository));
+        var sources = new ArrayList<LibrarySourceProvider>();
+        sources.add(buildLibrarySource(repository));
 
         var dataProviders = buildDataProviders(repository, null, terminologyProvider, settings.getRetrieveSettings());
         var environment =


### PR DESCRIPTION
Calling `Engines.forRepository(repository)` fails with an exception:

```
Caused by: java.lang.UnsupportedOperationException: null
	at java.base/java.util.AbstractList.add(AbstractList.java:155) ~[na:na]
	at java.base/java.util.AbstractList.add(AbstractList.java:113) ~[na:na]
	at org.opencds.cqf.fhir.cql.Engines.buildEnvironment(Engines.java:112) ~[cqf-fhir-cql-3.0.0.jar:3.0.0]
	at org.opencds.cqf.fhir.cql.Engines.forRepository(Engines.java:64) ~[cqf-fhir-cql-3.0.0.jar:3.0.0]
	at org.opencds.cqf.fhir.cql.Engines.forRepository(Engines.java:53) ~[cqf-fhir-cql-3.0.0.jar:3.0.0]
	at org.opencds.cqf.fhir.cql.Engines.forRepository(Engines.java:49) ~[cqf-fhir-cql-3.0.0.jar:3.0.0]
	at gov.ri.reporting.web.SampleController.<init>(SampleController.java:41) ~[classes/:na]
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62) ~[na:na]
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502) ~[na:na]
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486) ~[na:na]
	at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:210) ~[spring-beans-6.1.3.jar:6.1.3]
	... 21 common frames omitted
```