### PR TITLE
Add missing author extension for items with Population Context Extension

### DIFF
--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/Engines.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/Engines.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import ca.uhn.fhir.context.FhirContext;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessItemWithContext.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessItemWithContext.java
@@ -1,5 +1,7 @@
 package org.opencds.cqf.fhir.cr.questionnaire.populate;
 
+import static org.opencds.cqf.fhir.cr.common.ExtensionBuilders.QUESTIONNAIRE_RESPONSE_AUTHOR_EXTENSION;
+import static org.opencds.cqf.fhir.cr.common.ExtensionBuilders.buildReferenceExt;
 import static org.opencds.cqf.fhir.cr.common.ItemValueTransformer.transformValueToItem;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
@@ -16,14 +18,14 @@ import org.opencds.cqf.fhir.cr.common.ExpressionProcessor;
 import org.opencds.cqf.fhir.cr.common.ResolveExpressionException;
 import org.opencds.cqf.fhir.utility.Constants;
 
-public class ProcessItemWithExtension {
+public class ProcessItemWithContext {
     private final ExpressionProcessor expressionProcessor;
 
-    public ProcessItemWithExtension() {
+    public ProcessItemWithContext() {
         this(new ExpressionProcessor());
     }
 
-    private ProcessItemWithExtension(ExpressionProcessor expressionProcessor) {
+    private ProcessItemWithContext(ExpressionProcessor expressionProcessor) {
         this.expressionProcessor = expressionProcessor;
     }
 
@@ -59,6 +61,14 @@ public class ProcessItemWithExtension {
                 .split("\\.")[1]
                 .replace("[x]", "");
         final var initialValue = request.getModelResolver().resolvePath(context, path);
+        if (initialValue != null) {
+            request.getModelResolver()
+                    .setValue(
+                            populatedItem,
+                            "extension",
+                            Collections.singletonList(buildReferenceExt(
+                                    request.getFhirVersion(), QUESTIONNAIRE_RESPONSE_AUTHOR_EXTENSION, false)));
+        }
         if (initialValue instanceof IBase) {
             request.getModelResolver()
                     .setValue(

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/QuestionnaireProcessorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/QuestionnaireProcessorTests.java
@@ -233,7 +233,9 @@ public class QuestionnaireProcessorTests {
                 .thenPopulate(true)
                 .hasItems(13)
                 .itemHasAnswer("1")
-                .itemHasAnswer("2");
+                .itemHasAuthorExt("1")
+                .itemHasAnswer("2")
+                .itemHasAuthorExt("2");
     }
 
     @Test

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/TestQuestionnaire.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/TestQuestionnaire.java
@@ -2,6 +2,7 @@ package org.opencds.cqf.fhir.cr.questionnaire;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.opencds.cqf.fhir.test.Resources.getResourcePath;
@@ -348,6 +349,17 @@ public class TestQuestionnaire {
                     .collect(Collectors.toList());
             for (var item : matchingItems) {
                 assertFalse(request.resolvePathList(item, "answer").isEmpty());
+            }
+
+            return this;
+        }
+
+        public GeneratedQuestionnaireResponse itemHasAuthorExt(String theLinkId) {
+            var matchingItems = items.stream()
+                    .filter(i -> request.getItemLinkId(i).equals(theLinkId))
+                    .collect(Collectors.toList());
+            for (var item : matchingItems) {
+                assertNotNull(request.getExtensionByUrl(item, Constants.QUESTIONNAIRE_RESPONSE_AUTHOR));
             }
 
             return this;


### PR DESCRIPTION
When populating an item with the SDC Questionnaire Item Population Context extension no QuestionnaireResponse Author extension was being added denoting that the item had been answered by CQL Evaluation.