### PR TITLE
Resolve issue with Dstu3 Library identifier

### DIFF
--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/LibraryConstructor.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/LibraryConstructor.java
@@ -6,7 +6,6 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.fhirpath.IFhirPath;
 import java.util.List;
 import org.apache.commons.lang3.tuple.Pair;
-import org.hl7.elm.r1.VersionedIdentifier;
 import org.opencds.cqf.fhir.cql.engine.parameters.CqlParameterDefinition;
 import org.opencds.cqf.fhir.utility.FhirPathCache;
 import org.slf4j.Logger;
@@ -54,7 +53,7 @@ public class LibraryConstructor {
 
         if (libraries != null) {
             for (Pair<String, String> library : libraries) {
-                VersionedIdentifier vi = getVersionedIdentifier(library.getLeft());
+                var vi = VersionedIdentifiers.forUrl(library.getLeft());
                 sb.append(String.format("include \"%s\"", vi.getId()));
                 if (vi.getVersion() != null) {
                     sb.append(String.format(" version '%s'", vi.getVersion()));
@@ -99,33 +98,5 @@ public class LibraryConstructor {
 
     private void constructHeader(StringBuilder sb) {
         sb.append(String.format("library expression version '1.0.0'%n%n"));
-    }
-
-    protected VersionedIdentifier getVersionedIdentifier(String url) {
-        if (!url.contains("/Library/")) {
-            throw new IllegalArgumentException(
-                    "Invalid resource type for determining library version identifier: Library");
-        }
-        String[] urlSplit = url.split("/Library/");
-        if (urlSplit.length != 2) {
-            throw new IllegalArgumentException(
-                    "Invalid url, Library.url SHALL be <CQL namespace url>/Library/<CQL library name>");
-        }
-
-        // TODO: Use the namespace manager here to do the mapping?
-        // String cqlNamespaceUrl = urlSplit[0];
-
-        String cqlName = urlSplit[1];
-        VersionedIdentifier versionedIdentifier = new VersionedIdentifier();
-        if (cqlName.contains("|")) {
-            String[] nameVersion = cqlName.split("\\|");
-            String name = nameVersion[0];
-            String version = nameVersion[1];
-            versionedIdentifier.setId(name);
-            versionedIdentifier.setVersion(version);
-        } else {
-            versionedIdentifier.setId(cqlName);
-        }
-        return versionedIdentifier;
     }
 }

--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/VersionedIdentifiers.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/VersionedIdentifiers.java
@@ -9,17 +9,18 @@ public class VersionedIdentifiers {
     }
 
     public static VersionedIdentifier forUrl(String url) {
-        if (!url.contains("/Library/")) {
+        if (!url.contains("/Library/") && !url.startsWith("Library/")) {
             throw new IllegalArgumentException(
                     "Invalid resource type for determining library version identifier: Library");
         }
-        String[] urlSplit = url.split("/Library/");
-        if (urlSplit.length != 2) {
+
+        String[] urlSplit = url.split("Library/");
+        if (urlSplit.length > 2) {
             throw new IllegalArgumentException(
                     "Invalid url, Library.url SHALL be <CQL namespace url>/Library/<CQL library name>");
         }
 
-        String cqlName = urlSplit[1];
+        String cqlName = urlSplit.length == 1 ? urlSplit[0] : urlSplit[1];
         VersionedIdentifier versionedIdentifier = new VersionedIdentifier();
         if (cqlName.contains("|")) {
             String[] nameVersion = cqlName.split("\\|");

--- a/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/VersionedIdentifiersTests.java
+++ b/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/VersionedIdentifiersTests.java
@@ -2,10 +2,19 @@ package org.opencds.cqf.fhir.cql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 class VersionedIdentifiersTests {
+    @Test
+    void testExceptions() {
+        assertThrows(IllegalArgumentException.class, () ->
+            VersionedIdentifiers.forUrl("http://fhir.org/guides/cdc/opioid-cds/Binary/HelloWorld"));
+
+        assertThrows(IllegalArgumentException.class, () -> 
+            VersionedIdentifiers.forUrl("http://fhir.org/guides/cdc/opioid-cds/Library/HelloWorld/Library/HelloWorld"));
+    }
 
     @Test
     void testUrl() {

--- a/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/VersionedIdentifiersTests.java
+++ b/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/VersionedIdentifiersTests.java
@@ -9,11 +9,14 @@ import org.junit.jupiter.api.Test;
 class VersionedIdentifiersTests {
     @Test
     void testExceptions() {
-        assertThrows(IllegalArgumentException.class, () ->
-            VersionedIdentifiers.forUrl("http://fhir.org/guides/cdc/opioid-cds/Binary/HelloWorld"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> VersionedIdentifiers.forUrl("http://fhir.org/guides/cdc/opioid-cds/Binary/HelloWorld"));
 
-        assertThrows(IllegalArgumentException.class, () -> 
-            VersionedIdentifiers.forUrl("http://fhir.org/guides/cdc/opioid-cds/Library/HelloWorld/Library/HelloWorld"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> VersionedIdentifiers.forUrl(
+                        "http://fhir.org/guides/cdc/opioid-cds/Library/HelloWorld/Library/HelloWorld"));
     }
 
     @Test

--- a/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/VersionedIdentifiersTests.java
+++ b/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/VersionedIdentifiersTests.java
@@ -1,0 +1,33 @@
+package org.opencds.cqf.fhir.cql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class VersionedIdentifiersTests {
+
+    @Test
+    void testUrl() {
+        var url = "http://fhir.org/guides/cdc/opioid-cds/Library/HelloWorld";
+        var id = VersionedIdentifiers.forUrl(url);
+        assertEquals("HelloWorld", id.getId());
+        assertNull(id.getVersion());
+    }
+
+    @Test
+    void testCanonical() {
+        var url = "http://fhir.org/guides/cdc/opioid-cds/Library/HelloWorld|1.0.0";
+        var id = VersionedIdentifiers.forUrl(url);
+        assertEquals("HelloWorld", id.getId());
+        assertEquals("1.0.0", id.getVersion());
+    }
+
+    @Test
+    void testReference() {
+        var reference = "Library/HelloWorld";
+        var id = VersionedIdentifiers.forUrl(reference);
+        assertEquals("HelloWorld", id.getId());
+        assertNull(id.getVersion());
+    }
+}


### PR DESCRIPTION
Change VersionedIdentifiers helper method to allow for Dstu3 references which may be just resourceType/id due to how HAPI stores Dstu3 PlanDefinition resources.

Closes #445 