### PR TITLE
Add input parameter resolution to $populate operation

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/activitydefinition/apply/ApplyRequest.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/activitydefinition/apply/ApplyRequest.java
@@ -1,5 +1,7 @@
 package org.opencds.cqf.fhir.cr.activitydefinition.apply;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import ca.uhn.fhir.context.FhirVersionEnum;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseDatatype;
@@ -49,6 +51,7 @@ public class ApplyRequest implements ICpgRequest {
             IBaseBundle bundle,
             LibraryEngine libraryEngine,
             ModelResolver modelResolver) {
+        checkNotNull(libraryEngine, "expected non-null value for libraryEngine");
         this.activityDefinition = activityDefinition;
         this.subjectId = subjectId;
         this.encounterId = encounterId;
@@ -66,16 +69,14 @@ public class ApplyRequest implements ICpgRequest {
         this.modelResolver = modelResolver;
         fhirVersion = activityDefinition.getStructureFhirVersionEnum();
         defaultLibraryUrl = resolveDefaultLibraryUrl();
-        inputParameterResolver = libraryEngine == null
-                ? null
-                : IInputParameterResolver.createResolver(
-                        libraryEngine.getRepository(),
-                        this.subjectId,
-                        this.encounterId,
-                        this.practitionerId,
-                        this.parameters,
-                        this.useServerData,
-                        this.bundle);
+        inputParameterResolver = IInputParameterResolver.createResolver(
+                libraryEngine.getRepository(),
+                this.subjectId,
+                this.encounterId,
+                this.practitionerId,
+                this.parameters,
+                this.useServerData,
+                this.bundle);
     }
 
     public IBaseResource getActivityDefinition() {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/inputparameters/IInputParameterResolver.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/inputparameters/IInputParameterResolver.java
@@ -1,5 +1,7 @@
 package org.opencds.cqf.fhir.cr.inputparameters;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.List;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
@@ -21,6 +23,7 @@ public interface IInputParameterResolver {
             IBaseParameters parameters,
             Boolean useServerData,
             IBaseBundle bundle) {
+        checkNotNull(repository, "expected non-null value for repository");
         var fhirVersion = repository.fhirContext().getVersion().getVersion();
         switch (fhirVersion) {
             case DSTU3:

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ApplyRequest.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ApplyRequest.java
@@ -1,5 +1,6 @@
 package org.opencds.cqf.fhir.cr.plandefinition.apply;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.opencds.cqf.fhir.cr.inputparameters.IInputParameterResolver.createResolver;
 import static org.opencds.cqf.fhir.utility.Constants.APPLY_PARAMETER_ACTIVITY_DEFINITION;
 import static org.opencds.cqf.fhir.utility.Constants.APPLY_PARAMETER_DATA;
@@ -69,6 +70,7 @@ public class ApplyRequest implements ICpgRequest {
             LibraryEngine libraryEngine,
             ModelResolver modelResolver,
             IInputParameterResolver inputParameterResolver) {
+        checkNotNull(libraryEngine, "expected non-null value for libraryEngine");
         this.planDefinition = planDefinition;
         this.subjectId = subjectId;
         this.encounterId = encounterId;
@@ -87,16 +89,14 @@ public class ApplyRequest implements ICpgRequest {
         fhirVersion = planDefinition.getStructureFhirVersionEnum();
         this.inputParameterResolver = inputParameterResolver != null
                 ? inputParameterResolver
-                : this.libraryEngine == null
-                        ? null
-                        : createResolver(
-                                libraryEngine.getRepository(),
-                                this.subjectId,
-                                this.encounterId,
-                                this.practitionerId,
-                                this.parameters,
-                                this.useServerData,
-                                this.bundle);
+                : createResolver(
+                        libraryEngine.getRepository(),
+                        this.subjectId,
+                        this.encounterId,
+                        this.practitionerId,
+                        this.parameters,
+                        this.useServerData,
+                        this.bundle);
         defaultLibraryUrl = resolveDefaultLibraryUrl();
         requestResources = new ArrayList<>();
         extractedResources = new ArrayList<>();

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/QuestionnaireProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/QuestionnaireProcessor.java
@@ -189,6 +189,7 @@ public class QuestionnaireProcessor {
             String subjectId,
             IBaseParameters parameters,
             IBaseBundle bundle,
+            Boolean useServerData,
             LibraryEngine libraryEngine) {
         return new PopulateRequest(
                 operationName,
@@ -196,6 +197,7 @@ public class QuestionnaireProcessor {
                 Ids.newId(fhirVersion, Ids.ensureIdType(subjectId, SUBJECT_TYPE)),
                 parameters,
                 bundle,
+                useServerData,
                 libraryEngine != null ? libraryEngine : new LibraryEngine(repository, evaluationSettings),
                 modelResolver);
     }
@@ -231,7 +233,12 @@ public class QuestionnaireProcessor {
             Repository terminologyRepository) {
         repository = proxy(repository, useServerData, dataRepository, contentRepository, terminologyRepository);
         return prePopulate(
-                questionnaire, patientId, parameters, bundle, new LibraryEngine(repository, evaluationSettings));
+                questionnaire,
+                patientId,
+                parameters,
+                bundle,
+                useServerData,
+                new LibraryEngine(repository, evaluationSettings));
     }
 
     public <C extends IPrimitiveType<String>, R extends IBaseResource> R prePopulate(
@@ -239,8 +246,10 @@ public class QuestionnaireProcessor {
             String patientId,
             IBaseParameters parameters,
             IBaseBundle bundle,
+            Boolean useServerData,
             LibraryEngine libraryEngine) {
-        return prePopulate(resolveQuestionnaire(questionnaire), patientId, parameters, bundle, libraryEngine);
+        return prePopulate(
+                resolveQuestionnaire(questionnaire), patientId, parameters, bundle, useServerData, libraryEngine);
     }
 
     public <R extends IBaseResource> R prePopulate(
@@ -248,9 +257,10 @@ public class QuestionnaireProcessor {
             String subjectId,
             IBaseParameters parameters,
             IBaseBundle bundle,
+            Boolean useServerData,
             LibraryEngine libraryEngine) {
-        return prePopulate(
-                buildPopulateRequest("prepopulate", questionnaire, subjectId, parameters, bundle, libraryEngine));
+        return prePopulate(buildPopulateRequest(
+                "prepopulate", questionnaire, subjectId, parameters, bundle, useServerData, libraryEngine));
     }
 
     @SuppressWarnings("unchecked")
@@ -289,7 +299,12 @@ public class QuestionnaireProcessor {
             Repository terminologyRepository) {
         repository = proxy(repository, useServerData, dataRepository, contentRepository, terminologyRepository);
         return populate(
-                questionnaire, patientId, parameters, bundle, new LibraryEngine(repository, this.evaluationSettings));
+                questionnaire,
+                patientId,
+                parameters,
+                bundle,
+                useServerData,
+                new LibraryEngine(repository, this.evaluationSettings));
     }
 
     public <C extends IPrimitiveType<String>, R extends IBaseResource> IBaseResource populate(
@@ -297,8 +312,10 @@ public class QuestionnaireProcessor {
             String patientId,
             IBaseParameters parameters,
             IBaseBundle bundle,
+            Boolean useServerData,
             LibraryEngine libraryEngine) {
-        return populate(resolveQuestionnaire(questionnaire), patientId, parameters, bundle, libraryEngine);
+        return populate(
+                resolveQuestionnaire(questionnaire), patientId, parameters, bundle, useServerData, libraryEngine);
     }
 
     public IBaseResource populate(
@@ -306,8 +323,10 @@ public class QuestionnaireProcessor {
             String subjectId,
             IBaseParameters parameters,
             IBaseBundle bundle,
+            Boolean useServerData,
             LibraryEngine libraryEngine) {
-        return populate(buildPopulateRequest("populate", questionnaire, subjectId, parameters, bundle, libraryEngine));
+        return populate(buildPopulateRequest(
+                "populate", questionnaire, subjectId, parameters, bundle, useServerData, libraryEngine));
     }
 
     public IBaseResource populate(PopulateRequest request) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/PopulateRequest.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/PopulateRequest.java
@@ -1,5 +1,7 @@
 package org.opencds.cqf.fhir.cr.questionnaire.populate;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import ca.uhn.fhir.context.FhirVersionEnum;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
@@ -36,6 +38,7 @@ public class PopulateRequest implements IQuestionnaireRequest {
             Boolean useServerData,
             LibraryEngine libraryEngine,
             ModelResolver modelResolver) {
+        checkNotNull(libraryEngine, "expected non-null value for libraryEngine");
         this.operationName = operationName;
         this.questionnaire = questionnaire;
         this.subjectId = subjectId;
@@ -46,16 +49,14 @@ public class PopulateRequest implements IQuestionnaireRequest {
         this.modelResolver = modelResolver;
         this.fhirVersion = questionnaire.getStructureFhirVersionEnum();
         this.defaultLibraryUrl = resolveDefaultLibraryUrl();
-        inputParameterResolver = libraryEngine == null
-                ? null
-                : IInputParameterResolver.createResolver(
-                        libraryEngine.getRepository(),
-                        this.subjectId,
-                        null,
-                        null,
-                        this.parameters,
-                        this.useServerData,
-                        this.bundle);
+        inputParameterResolver = IInputParameterResolver.createResolver(
+                libraryEngine.getRepository(),
+                this.subjectId,
+                null,
+                null,
+                this.parameters,
+                this.useServerData,
+                this.bundle);
     }
 
     @Override

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/PopulateRequest.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/PopulateRequest.java
@@ -9,7 +9,6 @@ import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.fhir.cql.LibraryEngine;
-import org.opencds.cqf.fhir.cql.engine.model.FhirModelResolverCache;
 import org.opencds.cqf.fhir.cr.common.IQuestionnaireRequest;
 import org.opencds.cqf.fhir.cr.inputparameters.IInputParameterResolver;
 import org.opencds.cqf.fhir.utility.Constants;
@@ -27,21 +26,6 @@ public class PopulateRequest implements IQuestionnaireRequest {
     private final Boolean useServerData;
     private final IInputParameterResolver inputParameterResolver;
     private IBaseOperationOutcome operationOutcome;
-
-    // test constructor
-    public PopulateRequest(FhirVersionEnum fhirVersion, String operationName) {
-        this.operationName = operationName;
-        this.questionnaire = null;
-        this.subjectId = null;
-        this.parameters = null;
-        this.bundle = null;
-        this.useServerData = true;
-        this.libraryEngine = null;
-        this.modelResolver = FhirModelResolverCache.resolverForVersion(fhirVersion);
-        this.fhirVersion = fhirVersion;
-        this.defaultLibraryUrl = null;
-        inputParameterResolver = null;
-    }
 
     public PopulateRequest(
             String operationName,

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/PopulateRequest.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/PopulateRequest.java
@@ -11,6 +11,7 @@ import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.fhir.cql.LibraryEngine;
 import org.opencds.cqf.fhir.cql.engine.model.FhirModelResolverCache;
 import org.opencds.cqf.fhir.cr.common.IQuestionnaireRequest;
+import org.opencds.cqf.fhir.cr.inputparameters.IInputParameterResolver;
 import org.opencds.cqf.fhir.utility.Constants;
 
 public class PopulateRequest implements IQuestionnaireRequest {
@@ -23,6 +24,8 @@ public class PopulateRequest implements IQuestionnaireRequest {
     private final ModelResolver modelResolver;
     private final FhirVersionEnum fhirVersion;
     private final String defaultLibraryUrl;
+    private final Boolean useServerData;
+    private final IInputParameterResolver inputParameterResolver;
     private IBaseOperationOutcome operationOutcome;
 
     // test constructor
@@ -32,10 +35,12 @@ public class PopulateRequest implements IQuestionnaireRequest {
         this.subjectId = null;
         this.parameters = null;
         this.bundle = null;
+        this.useServerData = true;
         this.libraryEngine = null;
         this.modelResolver = FhirModelResolverCache.resolverForVersion(fhirVersion);
         this.fhirVersion = fhirVersion;
         this.defaultLibraryUrl = null;
+        inputParameterResolver = null;
     }
 
     public PopulateRequest(
@@ -44,6 +49,7 @@ public class PopulateRequest implements IQuestionnaireRequest {
             IIdType subjectId,
             IBaseParameters parameters,
             IBaseBundle bundle,
+            Boolean useServerData,
             LibraryEngine libraryEngine,
             ModelResolver modelResolver) {
         this.operationName = operationName;
@@ -51,10 +57,21 @@ public class PopulateRequest implements IQuestionnaireRequest {
         this.subjectId = subjectId;
         this.parameters = parameters;
         this.bundle = bundle;
+        this.useServerData = useServerData;
         this.libraryEngine = libraryEngine;
         this.modelResolver = modelResolver;
         this.fhirVersion = questionnaire.getStructureFhirVersionEnum();
         this.defaultLibraryUrl = resolveDefaultLibraryUrl();
+        inputParameterResolver = libraryEngine == null
+                ? null
+                : IInputParameterResolver.createResolver(
+                        libraryEngine.getRepository(),
+                        this.subjectId,
+                        null,
+                        null,
+                        this.parameters,
+                        this.useServerData,
+                        this.bundle);
     }
 
     @Override
@@ -79,7 +96,7 @@ public class PopulateRequest implements IQuestionnaireRequest {
 
     @Override
     public IBaseParameters getParameters() {
-        return parameters;
+        return inputParameterResolver.getParameters();
     }
 
     @Override

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/activitydefinition/RequestResourceResolver.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/activitydefinition/RequestResourceResolver.java
@@ -7,6 +7,8 @@ import java.nio.file.Paths;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.opencds.cqf.fhir.api.Repository;
+import org.opencds.cqf.fhir.cql.EvaluationSettings;
+import org.opencds.cqf.fhir.cql.LibraryEngine;
 import org.opencds.cqf.fhir.cr.activitydefinition.apply.ApplyRequest;
 import org.opencds.cqf.fhir.cr.activitydefinition.apply.BaseRequestResourceResolver;
 import org.opencds.cqf.fhir.cr.activitydefinition.apply.IRequestResolverFactory;
@@ -52,11 +54,12 @@ public class RequestResourceResolver {
                     .getImplementingClass();
             var activityDefinition =
                     repository.read(activityDefinitionClass, Ids.newId(activityDefinitionClass, activityDefinitionId));
-            return new When(activityDefinition, buildResolver(activityDefinition));
+            return new When(repository, activityDefinition, buildResolver(activityDefinition));
         }
     }
 
     public static class When {
+        private final Repository repository;
         private final IBaseResource activityDefinition;
         private final BaseRequestResourceResolver resolver;
         private IIdType subjectId;
@@ -64,7 +67,8 @@ public class RequestResourceResolver {
         private IIdType practitionerId;
         private IIdType organizationId;
 
-        When(IBaseResource activityDefinition, BaseRequestResourceResolver resolver) {
+        When(Repository repository, IBaseResource activityDefinition, BaseRequestResourceResolver resolver) {
+            this.repository = repository;
             this.activityDefinition = activityDefinition;
             this.resolver = resolver;
         }
@@ -104,7 +108,7 @@ public class RequestResourceResolver {
                     null,
                     null,
                     null,
-                    null,
+                    new LibraryEngine(repository, EvaluationSettings.getDefault()),
                     null));
         }
     }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/common/DynamicValueProcessorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/common/DynamicValueProcessorTests.java
@@ -32,7 +32,8 @@ public class DynamicValueProcessorTests {
 
     @Test
     void testUnsupportedFhirVersion() {
-        var request = RequestHelpers.newPDApplyRequestForVersion(FhirVersionEnum.R4B);
+        var request =
+                RequestHelpers.newPDApplyRequestForVersion(FhirVersionEnum.R4B, libraryEngine, inputParameterResolver);
         assertNull(fixture.getDynamicValueExpression(request, null));
     }
 

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/helpers/RequestHelpers.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/helpers/RequestHelpers.java
@@ -23,14 +23,6 @@ public class RequestHelpers {
     public static final String PROFILE_ID = "profileId";
     public static final String PROFILE_URL = "http://test.fhir.org/fhir/StructureDefinition/";
 
-    // public static ApplyRequest newPDApplyRequestForVersion(FhirVersionEnum fhirVersion) {
-    //     return new ApplyRequest(fhirVersion);
-    // }
-
-    public static ApplyRequest newPDApplyRequestForVersion(FhirVersionEnum fhirVersion) {
-        return newPDApplyRequestForVersion(fhirVersion, null, null);
-    }
-
     public static ApplyRequest newPDApplyRequestForVersion(
             FhirVersionEnum fhirVersion, LibraryEngine libraryEngine, IInputParameterResolver inputParameterResolver) {
         var fhirContext = FhirContext.forCached(fhirVersion);

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/helpers/RequestHelpers.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/helpers/RequestHelpers.java
@@ -164,6 +164,7 @@ public class RequestHelpers {
                 Ids.newId(fhirVersion, Ids.ensureIdType(PATIENT_ID, "Patient")),
                 null,
                 null,
+                true,
                 libraryEngine,
                 FhirModelResolverCache.resolverForVersion(fhirVersion));
     }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/helpers/RequestHelpers.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/helpers/RequestHelpers.java
@@ -144,10 +144,6 @@ public class RequestHelpers {
                 FhirModelResolverCache.resolverForVersion(fhirVersion));
     }
 
-    public static PopulateRequest newPopulateRequestForVersion(FhirVersionEnum fhirVersion, String operationName) {
-        return new PopulateRequest(fhirVersion, operationName);
-    }
-
     public static PopulateRequest newPopulateRequestForVersion(
             FhirVersionEnum fhirVersion, LibraryEngine libraryEngine, IBaseResource questionnaire) {
         return newPopulateRequestForVersion(fhirVersion, libraryEngine, questionnaire, "populate");

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ApplyRequestTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ApplyRequestTests.java
@@ -24,7 +24,8 @@ public class ApplyRequestTests {
 
     @Test
     void testInvalidVersionReturnsNull() {
-        var request = RequestHelpers.newPDApplyRequestForVersion(FhirVersionEnum.R4B);
+        var request =
+                RequestHelpers.newPDApplyRequestForVersion(FhirVersionEnum.R4B, libraryEngine, inputParameterResolver);
         var activityDef = new org.hl7.fhir.r4.model.ActivityDefinition();
         assertNull(request.transformRequestParameters(activityDef));
     }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ProcessActionTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ProcessActionTests.java
@@ -2,9 +2,12 @@ package org.opencds.cqf.fhir.cr.plandefinition.apply;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
 import static org.opencds.cqf.fhir.cr.helpers.RequestHelpers.newPDApplyRequestForVersion;
 
+import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -12,12 +15,16 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opencds.cqf.fhir.api.Repository;
+import org.opencds.cqf.fhir.cql.LibraryEngine;
 import org.opencds.cqf.fhir.cr.questionnaire.generate.GenerateProcessor;
 
 @ExtendWith(MockitoExtension.class)
 public class ProcessActionTests {
     @Mock
     Repository repository;
+
+    @Mock
+    LibraryEngine libraryEngine;
 
     @Mock
     ApplyProcessor applyProcessor;
@@ -29,9 +36,15 @@ public class ProcessActionTests {
     @Spy
     ProcessAction fixture;
 
+    @BeforeEach
+    void setup() {
+        doReturn(repository).when(libraryEngine).getRepository();
+    }
+
     @Test
     void unsupportedVersionShouldReturnNull() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4B);
+        doReturn(FhirContext.forR4BCached()).when(repository).fhirContext();
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4B, libraryEngine, null);
         var action = new org.hl7.fhir.r4b.model.PlanDefinition.PlanDefinitionActionComponent();
         var requestAction = fixture.generateRequestAction(request, action);
         assertNull(requestAction);
@@ -39,7 +52,8 @@ public class ProcessActionTests {
 
     @Test
     void testDstu3Request() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.DSTU3);
+        doReturn(FhirContext.forDstu3Cached()).when(repository).fhirContext();
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.DSTU3, libraryEngine, null);
         var action = new org.hl7.fhir.dstu3.model.PlanDefinition.PlanDefinitionActionComponent();
         var requestAction = fixture.generateRequestAction(request, action);
         assertTrue(requestAction instanceof org.hl7.fhir.dstu3.model.RequestGroup.RequestGroupActionComponent);
@@ -47,7 +61,8 @@ public class ProcessActionTests {
 
     @Test
     void testR4Request() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4);
+        doReturn(FhirContext.forR4Cached()).when(repository).fhirContext();
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4, libraryEngine, null);
         var action = new org.hl7.fhir.r4.model.PlanDefinition.PlanDefinitionActionComponent();
         var requestAction = fixture.generateRequestAction(request, action);
         assertTrue(requestAction instanceof org.hl7.fhir.r4.model.RequestGroup.RequestGroupActionComponent);
@@ -55,7 +70,8 @@ public class ProcessActionTests {
 
     @Test
     void testR5Request() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.R5);
+        doReturn(FhirContext.forR5Cached()).when(repository).fhirContext();
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.R5, libraryEngine, null);
         var action = new org.hl7.fhir.r5.model.PlanDefinition.PlanDefinitionActionComponent();
         var requestAction = fixture.generateRequestAction(request, action);
         assertTrue(

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ProcessDefinitionTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ProcessDefinitionTests.java
@@ -13,6 +13,7 @@ import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Questionnaire;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -20,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opencds.cqf.fhir.api.Repository;
+import org.opencds.cqf.fhir.cql.LibraryEngine;
 
 @ExtendWith(MockitoExtension.class)
 public class ProcessDefinitionTests {
@@ -34,15 +36,24 @@ public class ProcessDefinitionTests {
     Repository repository;
 
     @Mock
+    LibraryEngine libraryEngine;
+
+    @Mock
     ApplyProcessor applyProcessor;
 
     @Spy
     @InjectMocks
     ProcessDefinition fixture;
 
+    @BeforeEach
+    void setup() {
+        doReturn(repository).when(libraryEngine).getRepository();
+        doReturn(FhirContext.forR4Cached()).when(repository).fhirContext();
+    }
+
     @Test
     void applyActivityDefinitionShouldReturnNullOnException() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4);
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4, libraryEngine, null);
         var definition = new CanonicalType(ACTIVITYDEFINITION);
         doReturn(fhirContextR4).when(repository).fhirContext();
         var result = fixture.applyActivityDefinition(request, definition);
@@ -53,7 +64,7 @@ public class ProcessDefinitionTests {
 
     @Test
     void applyNestedPlanDefinitionShouldReturnNullOnException() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4);
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4, libraryEngine, null);
         var definition = new CanonicalType(PLANDEFINITION);
         doReturn(fhirContextR4).when(repository).fhirContext();
         var result = fixture.applyNestedPlanDefinition(request, definition);
@@ -64,7 +75,7 @@ public class ProcessDefinitionTests {
 
     @Test
     void resolveDefinitionShouldReturnQuestionnaire() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4);
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4, libraryEngine, null);
         var definition = new CanonicalType(QUESTIONNAIRE);
         var expectedQuestionnaire = new Questionnaire().setUrl(QUESTIONNAIRE);
         doReturn(expectedQuestionnaire).when(fixture).resolveRepository(definition);
@@ -76,7 +87,7 @@ public class ProcessDefinitionTests {
 
     @Test
     void applyQuestionnaireDefinitionShouldReturnContainedQuestionnaire() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4);
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4, libraryEngine, null);
         var definition = new CanonicalType("#Questionnaire/test");
         var expectedQuestionnaire = new Questionnaire().setUrl(QUESTIONNAIRE);
         doReturn(expectedQuestionnaire).when(fixture).resolveContained(request, definition.getValue());
@@ -88,7 +99,7 @@ public class ProcessDefinitionTests {
 
     @Test
     void applyQuestionnaireDefinitionShouldReturnNullOnException() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4);
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4, libraryEngine, null);
         var definition = new CanonicalType(QUESTIONNAIRE);
         doReturn(fhirContextR4).when(repository).fhirContext();
         var result = fixture.applyQuestionnaireDefinition(request, definition);
@@ -99,7 +110,7 @@ public class ProcessDefinitionTests {
 
     @Test
     void resolveDefinitionShouldFailOnInvalidAction() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4);
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4, libraryEngine, null);
         var definition = new CanonicalType(TASK);
         doReturn("Task").when(fixture).resolveResourceName(request, definition);
         assertThrows(FHIRException.class, () -> {
@@ -109,7 +120,7 @@ public class ProcessDefinitionTests {
 
     @Test
     void resolveResourceNameShouldFailIfCanonicalHasNoValue() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4);
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4, libraryEngine, null);
         assertThrows(FHIRException.class, () -> {
             fixture.resolveResourceName(request, new CanonicalType());
         });

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ProcessGoalTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ProcessGoalTests.java
@@ -3,18 +3,39 @@ package org.opencds.cqf.fhir.cr.plandefinition.apply;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
 import static org.opencds.cqf.fhir.cr.helpers.RequestHelpers.newPDApplyRequestForVersion;
 
+import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import org.hl7.fhir.dstu3.model.Coding;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opencds.cqf.fhir.api.Repository;
+import org.opencds.cqf.fhir.cql.LibraryEngine;
 
+@ExtendWith(MockitoExtension.class)
 public class ProcessGoalTests {
+    @Mock
+    Repository repository;
+
+    @Mock
+    LibraryEngine libraryEngine;
+
     ProcessGoal fixture = new ProcessGoal();
+
+    @BeforeEach
+    void setup() {
+        doReturn(repository).when(libraryEngine).getRepository();
+    }
 
     @Test
     void unsupportedVersionShouldReturnNull() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4B);
+        doReturn(FhirContext.forR4BCached()).when(repository).fhirContext();
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4B, libraryEngine, null);
         var goalElement = new org.hl7.fhir.r4b.model.PlanDefinition.PlanDefinitionGoalComponent();
         var result = fixture.convertGoal(request, goalElement);
         assertNull(result);
@@ -22,7 +43,8 @@ public class ProcessGoalTests {
 
     @Test
     void testConvertDstu3Goal() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.DSTU3);
+        doReturn(FhirContext.forDstu3Cached()).when(repository).fhirContext();
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.DSTU3, libraryEngine, null);
         var goalElement = new org.hl7.fhir.dstu3.model.PlanDefinition.PlanDefinitionGoalComponent()
                 .addTarget(new org.hl7.fhir.dstu3.model.PlanDefinition.PlanDefinitionGoalTargetComponent()
                         .setDetail(new org.hl7.fhir.dstu3.model.CodeableConcept(new Coding("test", "test", "test"))));
@@ -34,7 +56,8 @@ public class ProcessGoalTests {
 
     @Test
     void testConvertR4Goal() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4);
+        doReturn(FhirContext.forR4Cached()).when(repository).fhirContext();
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4, libraryEngine, null);
         var goalElement = new org.hl7.fhir.r4.model.PlanDefinition.PlanDefinitionGoalComponent()
                 .addTarget(new org.hl7.fhir.r4.model.PlanDefinition.PlanDefinitionGoalTargetComponent());
         var result = fixture.convertGoal(request, goalElement);
@@ -45,7 +68,8 @@ public class ProcessGoalTests {
 
     @Test
     void testConvertR5Goal() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.R5);
+        doReturn(FhirContext.forR5Cached()).when(repository).fhirContext();
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.R5, libraryEngine, null);
         var goalElement = new org.hl7.fhir.r5.model.PlanDefinition.PlanDefinitionGoalComponent()
                 .addTarget(new org.hl7.fhir.r5.model.PlanDefinition.PlanDefinitionGoalTargetComponent());
         var result = fixture.convertGoal(request, goalElement);

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ProcessRequestTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ProcessRequestTests.java
@@ -2,17 +2,38 @@ package org.opencds.cqf.fhir.cr.plandefinition.apply;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
 import static org.opencds.cqf.fhir.cr.helpers.RequestHelpers.newPDApplyRequestForVersion;
 
+import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opencds.cqf.fhir.api.Repository;
+import org.opencds.cqf.fhir.cql.LibraryEngine;
 
+@ExtendWith(MockitoExtension.class)
 public class ProcessRequestTests {
+    @Mock
+    Repository repository;
+
+    @Mock
+    LibraryEngine libraryEngine;
+
     ProcessRequest fixture = new ProcessRequest();
+
+    @BeforeEach
+    void setup() {
+        doReturn(repository).when(libraryEngine).getRepository();
+    }
 
     @Test
     void unsupportedVersionShouldReturnNull() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4B);
+        doReturn(FhirContext.forR4BCached()).when(repository).fhirContext();
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4B, libraryEngine, null);
         var requestOrchestration = fixture.generateRequestOrchestration(request);
         assertNull(requestOrchestration);
         var carePlan = fixture.generateCarePlan(request, requestOrchestration);
@@ -21,7 +42,8 @@ public class ProcessRequestTests {
 
     @Test
     void testDstu3Request() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.DSTU3);
+        doReturn(FhirContext.forDstu3Cached()).when(repository).fhirContext();
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.DSTU3, libraryEngine, null);
         var requestOrchestration = fixture.generateRequestOrchestration(request);
         assertTrue(requestOrchestration instanceof org.hl7.fhir.dstu3.model.RequestGroup);
 
@@ -31,7 +53,8 @@ public class ProcessRequestTests {
 
     @Test
     void testR4Request() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4);
+        doReturn(FhirContext.forR4Cached()).when(repository).fhirContext();
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.R4, libraryEngine, null);
         var requestOrchestration = fixture.generateRequestOrchestration(request);
         assertTrue(requestOrchestration instanceof org.hl7.fhir.r4.model.RequestGroup);
 
@@ -41,7 +64,8 @@ public class ProcessRequestTests {
 
     @Test
     void testR5Request() {
-        var request = newPDApplyRequestForVersion(FhirVersionEnum.R5);
+        doReturn(FhirContext.forR5Cached()).when(repository).fhirContext();
+        var request = newPDApplyRequestForVersion(FhirVersionEnum.R5, libraryEngine, null);
         var requestOrchestration = fixture.generateRequestOrchestration(request);
         assertTrue(requestOrchestration instanceof org.hl7.fhir.r5.model.RequestOrchestration);
 

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/TestQuestionnaire.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/TestQuestionnaire.java
@@ -129,6 +129,7 @@ public class TestQuestionnaire {
                     Ids.newId(fhirContext(), "Patient", subjectId),
                     parameters,
                     bundle,
+                    true,
                     new LibraryEngine(repository, processor.evaluationSettings),
                     processor.modelResolver);
         }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/populate/PopulateProcessorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/populate/PopulateProcessorTests.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.opencds.cqf.fhir.cr.helpers.RequestHelpers.PATIENT_ID;
 import static org.opencds.cqf.fhir.cr.helpers.RequestHelpers.newPopulateRequestForVersion;
 
+import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.Collections;
 import java.util.List;
@@ -17,20 +18,30 @@ import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Questionnaire;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
 import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.cql.LibraryEngine;
 
 @ExtendWith(MockitoExtension.class)
 class PopulateProcessorTests {
     @Mock
+    private Repository repository;
+
+    @Mock
     private LibraryEngine libraryEngine;
 
     @Spy
     private final PopulateProcessor fixture = new PopulateProcessor();
+
+    @BeforeEach
+    void setup() {
+        doReturn(repository).when(libraryEngine).getRepository();
+    }
 
     @Test
     void populateShouldReturnQuestionnaireResponseResourceWithPopulatedFieldsDstu3() {
@@ -40,6 +51,7 @@ class PopulateProcessorTests {
         final var originalQuestionnaire = new org.hl7.fhir.dstu3.model.Questionnaire();
         originalQuestionnaire.setId(prePopulatedQuestionnaireId);
         originalQuestionnaire.setUrl(questionnaireUrl);
+        doReturn(FhirContext.forDstu3Cached()).when(repository).fhirContext();
         final PopulateRequest request =
                 newPopulateRequestForVersion(FhirVersionEnum.DSTU3, libraryEngine, originalQuestionnaire);
         final var expectedResponses = getExpectedResponses(request);
@@ -77,6 +89,7 @@ class PopulateProcessorTests {
         final var originalQuestionnaire = new Questionnaire();
         originalQuestionnaire.setId(prePopulatedQuestionnaireId);
         originalQuestionnaire.setUrl(questionnaireUrl);
+        doReturn(FhirContext.forR4Cached()).when(repository).fhirContext();
         final PopulateRequest request =
                 newPopulateRequestForVersion(FhirVersionEnum.R4, libraryEngine, originalQuestionnaire);
         final var expectedResponses = getExpectedResponses(request);
@@ -110,6 +123,7 @@ class PopulateProcessorTests {
         final var originalQuestionnaire = new org.hl7.fhir.r5.model.Questionnaire();
         originalQuestionnaire.setId(prePopulatedQuestionnaireId);
         originalQuestionnaire.setUrl(questionnaireUrl);
+        doReturn(FhirContext.forR5Cached()).when(repository).fhirContext();
         final PopulateRequest request =
                 newPopulateRequestForVersion(FhirVersionEnum.R5, libraryEngine, originalQuestionnaire);
         final var expectedResponses = getExpectedResponses(request);
@@ -205,6 +219,7 @@ class PopulateProcessorTests {
         // setup
         final OperationOutcome operationOutcome = withOperationOutcomeWithIssue();
         final Questionnaire questionnaire = new Questionnaire();
+        doReturn(FhirContext.forR4Cached()).when(repository).fhirContext();
         final PopulateRequest request = newPopulateRequestForVersion(FhirVersionEnum.R4, libraryEngine, questionnaire);
         request.setOperationOutcome(operationOutcome);
         // execute
@@ -218,6 +233,7 @@ class PopulateProcessorTests {
         // setup
         final OperationOutcome operationOutcome = new OperationOutcome();
         final Questionnaire questionnaire = new Questionnaire();
+        doReturn(FhirContext.forR4Cached()).when(repository).fhirContext();
         final PopulateRequest request = newPopulateRequestForVersion(FhirVersionEnum.R4, libraryEngine, questionnaire);
         request.setOperationOutcome(operationOutcome);
         // execute

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessItemTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessItemTests.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.opencds.cqf.fhir.cr.helpers.RequestHelpers.newPopulateRequestForVersion;
 
+import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import org.hl7.fhir.instance.model.api.IBase;
@@ -15,12 +16,14 @@ import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.r4.model.Questionnaire;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.cql.CqfExpression;
 import org.opencds.cqf.fhir.cql.LibraryEngine;
 import org.opencds.cqf.fhir.cr.common.ExpressionProcessor;
@@ -30,6 +33,9 @@ import org.opencds.cqf.fhir.utility.Constants;
 @ExtendWith(MockitoExtension.class)
 class ProcessItemTests {
     @Mock
+    private Repository repository;
+
+    @Mock
     private ExpressionProcessor expressionProcessorService;
 
     @Mock
@@ -38,6 +44,11 @@ class ProcessItemTests {
     @Spy
     @InjectMocks
     private ProcessItem fixture;
+
+    @BeforeEach
+    void setup() {
+        doReturn(repository).when(libraryEngine).getRepository();
+    }
 
     @AfterEach
     void tearDown() {
@@ -49,6 +60,7 @@ class ProcessItemTests {
     void processItemShouldReturnQuestionnaireItemComponentDstu3() throws ResolveExpressionException {
         // setup
         final org.hl7.fhir.dstu3.model.Questionnaire questionnaire = new org.hl7.fhir.dstu3.model.Questionnaire();
+        doReturn(FhirContext.forDstu3Cached()).when(repository).fhirContext();
         final PopulateRequest prePopulateRequest =
                 newPopulateRequestForVersion(FhirVersionEnum.DSTU3, libraryEngine, questionnaire);
         final IBaseBackboneElement originalQuestionnaireItemComponent =
@@ -75,6 +87,7 @@ class ProcessItemTests {
     void processItemShouldReturnQuestionnaireItemComponentR4() throws ResolveExpressionException {
         // setup
         final Questionnaire questionnaire = new Questionnaire();
+        doReturn(FhirContext.forR4Cached()).when(repository).fhirContext();
         final PopulateRequest prePopulateRequest =
                 newPopulateRequestForVersion(FhirVersionEnum.R4, libraryEngine, questionnaire);
         final IBaseBackboneElement originalQuestionnaireItemComponent = new QuestionnaireItemComponent();
@@ -102,6 +115,7 @@ class ProcessItemTests {
     void processItemShouldReturnQuestionnaireItemComponentR5() throws ResolveExpressionException {
         // setup
         final org.hl7.fhir.r5.model.Questionnaire questionnaire = new org.hl7.fhir.r5.model.Questionnaire();
+        doReturn(FhirContext.forR5Cached()).when(repository).fhirContext();
         final PopulateRequest prePopulateRequest =
                 newPopulateRequestForVersion(FhirVersionEnum.R5, libraryEngine, questionnaire);
         final IBaseBackboneElement originalQuestionnaireItemComponent =
@@ -151,6 +165,7 @@ class ProcessItemTests {
     void getExpressionResultsShouldReturnEmptyListIfInitialExpressionIsNull() throws ResolveExpressionException {
         // setup
         final Questionnaire questionnaire = new Questionnaire();
+        doReturn(FhirContext.forR4Cached()).when(repository).fhirContext();
         final PopulateRequest prePopulateRequest =
                 newPopulateRequestForVersion(FhirVersionEnum.R4, libraryEngine, questionnaire);
         final QuestionnaireItemComponent questionnaireItemComponent = new QuestionnaireItemComponent();
@@ -171,6 +186,7 @@ class ProcessItemTests {
         // setup
         final List<IBase> expected = withExpressionResults(FhirVersionEnum.R4);
         final Questionnaire questionnaire = new Questionnaire();
+        doReturn(FhirContext.forR4Cached()).when(repository).fhirContext();
         final PopulateRequest prePopulateRequest =
                 newPopulateRequestForVersion(FhirVersionEnum.R4, libraryEngine, questionnaire);
         final QuestionnaireItemComponent questionnaireItemComponent = new QuestionnaireItemComponent();

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessResponseItemTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessResponseItemTests.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.opencds.cqf.fhir.cr.helpers.RequestHelpers.newPopulateRequestForVersion;
 
+import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,16 +19,21 @@ import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemAnsw
 import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.Type;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.cql.LibraryEngine;
 import org.opencds.cqf.fhir.utility.Constants;
 
 @ExtendWith(MockitoExtension.class)
 public class ProcessResponseItemTests {
+    @Mock
+    private Repository repository;
+
     @Mock
     private LibraryEngine libraryEngine;
 
@@ -36,6 +42,11 @@ public class ProcessResponseItemTests {
 
     private final ProcessResponseItem processResponseItem = new ProcessResponseItem();
 
+    @BeforeEach
+    void setup() {
+        doReturn(repository).when(libraryEngine).getRepository();
+    }
+
     @Test
     void processResponseItemShouldSetBasePropertiesOnQuestionnaireResponseItemComponent() {
         // setup
@@ -43,6 +54,7 @@ public class ProcessResponseItemTests {
         final String definition = "definition";
         final StringType textElement = new StringType("textElement");
         final Questionnaire questionnaire = new Questionnaire();
+        doReturn(FhirContext.forR4Cached()).when(repository).fhirContext();
         final PopulateRequest request = newPopulateRequestForVersion(FhirVersionEnum.R4, libraryEngine, questionnaire);
         final IBaseBackboneElement questionnaireItem = new QuestionnaireItemComponent()
                 .setLinkId(linkId)
@@ -61,6 +73,7 @@ public class ProcessResponseItemTests {
     void processResponseItemShouldProcessResponseItemsRecursivelyIfQuestionnaireItemHasItems() {
         // setup
         final Questionnaire questionnaire = new Questionnaire();
+        doReturn(FhirContext.forR4Cached()).when(repository).fhirContext();
         final PopulateRequest request = newPopulateRequestForVersion(FhirVersionEnum.R4, libraryEngine, questionnaire);
         final QuestionnaireItemComponent questionnaireItem = new QuestionnaireItemComponent();
         final List<QuestionnaireItemComponent> nestedQuestionnaireItems = List.of(
@@ -89,6 +102,7 @@ public class ProcessResponseItemTests {
         // setup
         final FhirVersionEnum fhirVersion = FhirVersionEnum.DSTU3;
         final org.hl7.fhir.dstu3.model.Questionnaire questionnaire = new org.hl7.fhir.dstu3.model.Questionnaire();
+        doReturn(FhirContext.forDstu3Cached()).when(repository).fhirContext();
         final PopulateRequest request = newPopulateRequestForVersion(fhirVersion, libraryEngine, questionnaire);
         final List<IBaseDatatype> expectedValues = withTypeValues(fhirVersion);
         final IBaseBackboneElement questionnaireItemComponent =
@@ -105,6 +119,7 @@ public class ProcessResponseItemTests {
         // setup
         final FhirVersionEnum fhirVersion = FhirVersionEnum.R4;
         final Questionnaire questionnaire = new Questionnaire();
+        doReturn(FhirContext.forR4Cached()).when(repository).fhirContext();
         final PopulateRequest request = newPopulateRequestForVersion(fhirVersion, libraryEngine, questionnaire);
         final List<IBaseDatatype> expectedValues = withTypeValues(fhirVersion);
         final IBaseBackboneElement questionnaireItemComponent =
@@ -121,6 +136,7 @@ public class ProcessResponseItemTests {
         // setup
         final FhirVersionEnum fhirVersion = FhirVersionEnum.R5;
         final org.hl7.fhir.r5.model.Questionnaire questionnaire = new org.hl7.fhir.r5.model.Questionnaire();
+        doReturn(FhirContext.forR5Cached()).when(repository).fhirContext();
         final PopulateRequest request = newPopulateRequestForVersion(fhirVersion, libraryEngine, questionnaire);
         final List<IBaseDatatype> expectedValues = withTypeValues(fhirVersion);
         final IBaseBackboneElement questionnaireItemComponent =
@@ -137,6 +153,7 @@ public class ProcessResponseItemTests {
         // setup
         final FhirVersionEnum fhirVersion = FhirVersionEnum.R4;
         final Questionnaire questionnaire = new Questionnaire();
+        doReturn(FhirContext.forR4Cached()).when(repository).fhirContext();
         final PopulateRequest request = newPopulateRequestForVersion(fhirVersion, libraryEngine, questionnaire);
         final var expectedValues = withTypeValues(fhirVersion);
         final IBaseBackboneElement questionnaireItemComponent =
@@ -190,6 +207,7 @@ public class ProcessResponseItemTests {
     void processResponseItemShouldAddExtensionIfResponseExtensionPresent() {
         // setup
         final Questionnaire questionnaire = new Questionnaire();
+        doReturn(FhirContext.forR4Cached()).when(repository).fhirContext();
         final PopulateRequest request = newPopulateRequestForVersion(FhirVersionEnum.R4, libraryEngine, questionnaire);
         final QuestionnaireItemComponent questionnaireItemComponent = new QuestionnaireItemComponent();
         final Extension extension = new Extension(Constants.QUESTIONNAIRE_RESPONSE_AUTHOR, new StringType("theAuthor"));


### PR DESCRIPTION
Add the InputParameterResolver to the PopulateRequest which resolves the input parameters to resources to allow them to be referenced within an expression, e.g. %subject.id