### PR TITLE
Rethrow exceptions encountered during value set expansion

### DIFF
--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/visitor/dstu3/KnowledgeArtifactPackageVisitor.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/visitor/dstu3/KnowledgeArtifactPackageVisitor.java
@@ -336,8 +336,8 @@ public class KnowledgeArtifactPackageVisitor {
                         valueSet, authoritativeSourceUrl, expansionParameters, username, apiKey);
                 valueSet.setExpansion(expandedValueSet.getExpansion());
             } catch (Exception ex) {
-                System.out.println("Terminology Server expansion failed: {"
-                        + valueSet.getIdElement().getValue() + "}");
+                throw new UnprocessableEntityException(
+                        "Terminology Server expansion failed for: " + valueSet.getId(), ex.getMessage());
             }
         }
     }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/visitor/r4/KnowledgeArtifactPackageVisitor.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/visitor/r4/KnowledgeArtifactPackageVisitor.java
@@ -348,8 +348,8 @@ public class KnowledgeArtifactPackageVisitor {
                         valueSet, authoritativeSourceUrl, expansionParameters, username, apiKey);
                 valueSet.setExpansion(expandedValueSet.getExpansion());
             } catch (Exception ex) {
-                System.out.println("Terminology Server expansion failed: {"
-                        + valueSet.getIdElement().getValue() + "}");
+                throw new UnprocessableEntityException(
+                        "Terminology Server expansion failed for: " + valueSet.getId(), ex.getMessage());
             }
         }
     }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/visitor/r5/KnowledgeArtifactPackageVisitor.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/visitor/r5/KnowledgeArtifactPackageVisitor.java
@@ -344,8 +344,8 @@ public class KnowledgeArtifactPackageVisitor {
                         valueSet, authoritativeSourceUrl, expansionParameters, username, apiKey);
                 valueSet.setExpansion(expandedValueSet.getExpansion());
             } catch (Exception ex) {
-                System.out.println("Terminology Server expansion failed: {"
-                        + valueSet.getIdElement().getValue() + "}");
+                throw new UnprocessableEntityException(
+                        "Terminology Server expansion failed for: " + valueSet.getId(), ex.getMessage());
             }
         }
     }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/KnowledgeArtifactPackageVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/KnowledgeArtifactPackageVisitorTests.java
@@ -169,6 +169,32 @@ class KnowledgeArtifactPackageVisitorTests {
     }
 
     @Test
+    void packageOperation_should_fail_credentials_invalid() {
+        Bundle loadedBundle = (Bundle) jsonParser.parseResource(
+                KnowledgeArtifactPackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
+        spyRepository.transaction(loadedBundle);
+        KnowledgeArtifactPackageVisitor packageVisitor = new KnowledgeArtifactPackageVisitor();
+        Library library = spyRepository
+                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+                .copy();
+        LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
+        Parameters params = new Parameters();
+        Endpoint terminologyEndpoint = new Endpoint();
+        terminologyEndpoint.addExtension(Constants.VSAC_USERNAME, new StringType("someUsername"));
+        terminologyEndpoint.addExtension(Constants.APIKEY, new StringType("some-api-key"));
+        params.addParameter().setName("terminologyEndpoint").setResource(terminologyEndpoint);
+
+        UnprocessableEntityException maybeException = null;
+        try {
+            libraryAdapter.accept(packageVisitor, spyRepository, params);
+        } catch (UnprocessableEntityException e) {
+            maybeException = e;
+        }
+        assertTrue(maybeException.getMessage().contains("Terminology Server expansion failed for: "));
+        assertTrue(maybeException.getAdditionalMessages().stream().allMatch(msg -> msg.contains("HTTP 401")));
+    }
+
+    @Test
     void packageOperation_should_fail_non_matching_capability() {
         Bundle bundle =
                 (Bundle) jsonParser.parseResource(KnowledgeArtifactPackageVisitorTests.class.getResourceAsStream(

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/KnowledgeArtifactPackageVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/KnowledgeArtifactPackageVisitorTests.java
@@ -144,7 +144,7 @@ class KnowledgeArtifactPackageVisitorTests {
     }
 
     @Test
-    void packageOperation_should_fail_credentials_missing_apiyey() {
+    void packageOperation_should_fail_credentials_missing_apikey() {
         Bundle loadedBundle = (Bundle) jsonParser.parseResource(
                 KnowledgeArtifactPackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
         spyRepository.transaction(loadedBundle);
@@ -166,6 +166,32 @@ class KnowledgeArtifactPackageVisitorTests {
             maybeException = e;
         }
         assertTrue(maybeException.getMessage().contains("Cannot expand ValueSet without VSAC API Key: "));
+    }
+
+    @Test
+    void packageOperation_should_fail_credentials_invalid() {
+        Bundle loadedBundle = (Bundle) jsonParser.parseResource(
+                KnowledgeArtifactPackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
+        spyRepository.transaction(loadedBundle);
+        KnowledgeArtifactPackageVisitor packageVisitor = new KnowledgeArtifactPackageVisitor();
+        Library library = spyRepository
+                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+                .copy();
+        LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
+        Parameters params = new Parameters();
+        Endpoint terminologyEndpoint = new Endpoint();
+        terminologyEndpoint.addExtension(Constants.VSAC_USERNAME, new StringType("someUsername"));
+        terminologyEndpoint.addExtension(Constants.APIKEY, new StringType("some-api-key"));
+        params.addParameter().setName("terminologyEndpoint").setResource(terminologyEndpoint);
+
+        UnprocessableEntityException maybeException = null;
+        try {
+            libraryAdapter.accept(packageVisitor, spyRepository, params);
+        } catch (UnprocessableEntityException e) {
+            maybeException = e;
+        }
+        assertTrue(maybeException.getMessage().contains("Terminology Server expansion failed for:"));
+        assertTrue(maybeException.getAdditionalMessages().stream().allMatch(msg -> msg.contains("HTTP 401")));
     }
 
     @Test

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/KnowledgeArtifactPackageVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/KnowledgeArtifactPackageVisitorTests.java
@@ -169,6 +169,32 @@ class KnowledgeArtifactPackageVisitorTests {
     }
 
     @Test
+    void packageOperation_should_fail_credentials_invalid() {
+        Bundle loadedBundle = (Bundle) jsonParser.parseResource(
+                KnowledgeArtifactPackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
+        spyRepository.transaction(loadedBundle);
+        KnowledgeArtifactPackageVisitor packageVisitor = new KnowledgeArtifactPackageVisitor();
+        Library library = spyRepository
+                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+                .copy();
+        LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
+        Parameters params = new Parameters();
+        Endpoint terminologyEndpoint = new Endpoint();
+        terminologyEndpoint.addExtension(Constants.VSAC_USERNAME, new StringType("someUsername"));
+        terminologyEndpoint.addExtension(Constants.APIKEY, new StringType("some-api-key"));
+        params.addParameter().setName("terminologyEndpoint").setResource(terminologyEndpoint);
+
+        UnprocessableEntityException maybeException = null;
+        try {
+            libraryAdapter.accept(packageVisitor, spyRepository, params);
+        } catch (UnprocessableEntityException e) {
+            maybeException = e;
+        }
+        assertTrue(maybeException.getMessage().contains("Terminology Server expansion failed for: "));
+        assertTrue(maybeException.getAdditionalMessages().stream().allMatch(msg -> msg.contains("HTTP 401")));
+    }
+
+    @Test
     void packageOperation_should_fail_non_matching_capability() {
         Bundle bundle =
                 (Bundle) jsonParser.parseResource(KnowledgeArtifactPackageVisitorTests.class.getResourceAsStream(


### PR DESCRIPTION
We have elected to rethrow exceptions encountered during Value Set expansion. This will cause operations which include expansion to fail if a single value set cannot be expanded.