### PR TITLE
multi-measure feature enhancements

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MultiMeasureService.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MultiMeasureService.java
@@ -3,14 +3,13 @@ package org.opencds.cqf.fhir.cr.measure.r4;
 import static org.opencds.cqf.fhir.cr.measure.r4.utils.R4MeasureServiceUtils.getFullUrl;
 
 import com.google.common.base.Strings;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleType;
-import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.Endpoint;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Measure;
@@ -23,7 +22,6 @@ import org.opencds.cqf.fhir.cr.measure.common.MeasureEvalType;
 import org.opencds.cqf.fhir.cr.measure.r4.utils.R4MeasureServiceUtils;
 import org.opencds.cqf.fhir.utility.Ids;
 import org.opencds.cqf.fhir.utility.builder.BundleBuilder;
-import org.opencds.cqf.fhir.utility.monad.Either3;
 import org.opencds.cqf.fhir.utility.repository.Repositories;
 
 // Alternate MeasureService call to Process MeasureEvaluation for the selected population of subjects against n-number
@@ -31,68 +29,127 @@ import org.opencds.cqf.fhir.utility.repository.Repositories;
 
 public class R4MultiMeasureService {
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(R4MultiMeasureService.class);
-    private final Repository repository;
+    private Repository repository;
     private final MeasureEvaluationOptions measureEvaluationOptions;
     private String serverBase;
+
+    private final R4RepositorySubjectProvider subjectProvider;
+
+    private R4MeasureProcessor r4Processor;
+
+    private R4MeasureServiceUtils r4MeasureServiceUtils;
 
     public R4MultiMeasureService(
             Repository repository, MeasureEvaluationOptions measureEvaluationOptions, String serverBase) {
         this.repository = repository;
         this.measureEvaluationOptions = measureEvaluationOptions;
         this.serverBase = serverBase;
+
+        subjectProvider = new R4RepositorySubjectProvider();
+
+        r4Processor = new R4MeasureProcessor(repository, this.measureEvaluationOptions, subjectProvider);
+
+        r4MeasureServiceUtils = new R4MeasureServiceUtils(repository);
     }
 
     public Bundle evaluate(
-            List<Either3<CanonicalType, IdType, Measure>> measures,
+            List<IdType> measureId,
+            List<String> measureUrl,
             String periodStart,
             String periodEnd,
             String reportType,
-            String subjectId,
+            String subject, // practitioner passed in here
             Endpoint contentEndpoint,
             Endpoint terminologyEndpoint,
             Endpoint dataEndpoint,
             Bundle additionalData,
             Parameters parameters,
             String productLine,
-            String practitioner,
             String reporter) {
 
-        var repo = Repositories.proxy(repository, true, dataEndpoint, contentEndpoint, terminologyEndpoint);
+        if (dataEndpoint != null && contentEndpoint != null && terminologyEndpoint != null) {
+            // if needing to use proxy repository, override constructors
+            repository = Repositories.proxy(repository, true, dataEndpoint, contentEndpoint, terminologyEndpoint);
 
-        var subjectProvider = new R4RepositorySubjectProvider();
+            r4Processor = new R4MeasureProcessor(repository, this.measureEvaluationOptions, subjectProvider);
 
-        var processor = new R4MeasureProcessor(repo, this.measureEvaluationOptions, subjectProvider);
-
-        R4MeasureServiceUtils r4MeasureServiceUtils = new R4MeasureServiceUtils(repository);
+            r4MeasureServiceUtils = new R4MeasureServiceUtils(repository);
+        }
         r4MeasureServiceUtils.ensureSupplementalDataElementSearchParameter();
-
+        List<Measure> measures = r4MeasureServiceUtils.getMeasures(measureId, null, measureUrl);
         log.info("multi-evaluate-measure, measures to evaluate: {}", measures.size());
 
         var evalType = MeasureEvalType.fromCode(reportType)
-                .orElse(
-                        subjectId == null || subjectId.isEmpty()
-                                ? MeasureEvalType.POPULATION
-                                : MeasureEvalType.SUBJECT);
+                .orElse(subject == null || subject.isEmpty() ? MeasureEvalType.POPULATION : MeasureEvalType.SUBJECT);
 
         // get subjects
-        var subjects = getSubjects(subjectProvider, practitioner, subjectId, evalType);
+        var subjects = getSubjects(subjectProvider, subject, evalType);
 
         // create bundle
         Bundle bundle = new BundleBuilder<>(Bundle.class)
                 .withType(BundleType.SEARCHSET.toString())
                 .build();
 
-        for (Either3<CanonicalType, IdType, Measure> measure : measures) {
+        // evaluate Measures
+        if (evalType.equals(MeasureEvalType.POPULATION) || evalType.equals(MeasureEvalType.SUBJECTLIST)) {
+            populationMeasureReport(
+                    bundle,
+                    measures,
+                    periodStart,
+                    periodEnd,
+                    reportType,
+                    evalType,
+                    subject,
+                    subjects,
+                    parameters,
+                    additionalData,
+                    productLine,
+                    reporter);
+        } else {
+            subjectMeasureReport(
+                    bundle,
+                    measures,
+                    periodStart,
+                    periodEnd,
+                    reportType,
+                    evalType,
+                    subjects,
+                    parameters,
+                    additionalData,
+                    productLine,
+                    reporter);
+        }
+
+        return bundle;
+    }
+
+    protected void populationMeasureReport(
+            Bundle bundle,
+            List<Measure> measures,
+            String periodStart,
+            String periodEnd,
+            String reportType,
+            MeasureEvalType evalType,
+            String subjectParam,
+            List<String> subjects,
+            Parameters parameters,
+            Bundle additionalData,
+            String productLine,
+            String reporter) {
+
+        // one aggregated MeasureReport per Measure
+        var totalMeasures = measures.size();
+        for (Measure measure : measures) {
             MeasureReport measureReport;
             // evaluate each measure
-            measureReport = processor.evaluateMeasure(
+            measureReport = r4Processor.evaluateMeasure(
                     measure, periodStart, periodEnd, reportType, subjects, additionalData, parameters, evalType);
 
             // add ProductLine after report is generated
             measureReport = r4MeasureServiceUtils.addProductLineExtension(measureReport, productLine);
 
             // add subject reference for non-individual reportTypes
-            measureReport = r4MeasureServiceUtils.addSubjectReference(measureReport, practitioner, subjectId);
+            measureReport = r4MeasureServiceUtils.addSubjectReference(measureReport, null, subjectParam);
 
             // add reporter if available
             if (reporter != null && !reporter.isEmpty()) {
@@ -107,25 +164,78 @@ public class R4MultiMeasureService {
             // progress feedback
             var measureUrl = measureReport.getMeasure();
             if (!measureUrl.isEmpty()) {
-                log.info("MeasureReport complete for Measure: {}", measureUrl);
+                log.debug(
+                        "Completed evaluation for Measure: {}, Measures remaining to evaluate: {}",
+                        measureUrl,
+                        totalMeasures--);
             }
         }
+    }
 
-        return bundle;
+    protected void subjectMeasureReport(
+            Bundle bundle,
+            List<Measure> measures,
+            String periodStart,
+            String periodEnd,
+            String reportType,
+            MeasureEvalType evalType,
+            List<String> subjects,
+            Parameters parameters,
+            Bundle additionalData,
+            String productLine,
+            String reporter) {
+
+        // create individual reports for each subject, and each measure
+        var totalReports = subjects.size() * measures.size();
+        var totalMeasures = measures.size();
+        log.debug(
+                "Evaluating individual MeasureReports for {} patients, and {} measures",
+                subjects.size(),
+                measures.size());
+        for (Measure measure : measures) {
+            for (String subject : subjects) {
+                MeasureReport measureReport;
+                // evaluate each measure
+                measureReport = r4Processor.evaluateMeasure(
+                        measure,
+                        periodStart,
+                        periodEnd,
+                        reportType,
+                        Collections.singletonList(subject),
+                        additionalData,
+                        parameters,
+                        evalType);
+
+                // add ProductLine after report is generated
+                measureReport = r4MeasureServiceUtils.addProductLineExtension(measureReport, productLine);
+
+                // add reporter if available
+                if (reporter != null && !reporter.isEmpty()) {
+                    measureReport.setReporter(r4MeasureServiceUtils.getReporter(reporter));
+                }
+                // add id to measureReport
+                initializeReport(measureReport);
+
+                // add report to bundle
+                bundle.addEntry(getBundleEntry(serverBase, measureReport));
+
+                // progress feedback
+                var measureUrl = measureReport.getMeasure();
+                if (!measureUrl.isEmpty()) {
+                    log.debug("MeasureReports remaining to evaluate {}", totalReports--);
+                }
+            }
+            if (measure.hasUrl()) {
+                log.info(
+                        "Completed evaluation for Measure: {}, Measures remaining to evaluate: {}",
+                        measure.getUrl(),
+                        totalMeasures--);
+            }
+        }
     }
 
     protected List<String> getSubjects(
-            R4RepositorySubjectProvider subjectProvider,
-            String practitioner,
-            String subjectId,
-            MeasureEvalType evalType) {
-        // check for practitioner parameter before subject
-        if (StringUtils.isNotBlank(practitioner)) {
-            if (!practitioner.contains("/")) {
-                practitioner = "Practitioner/".concat(practitioner);
-            }
-            subjectId = practitioner;
-        }
+            R4RepositorySubjectProvider subjectProvider, String subjectId, MeasureEvalType evalType) {
 
         return subjectProvider.getSubjects(repository, evalType, subjectId).collect(Collectors.toList());
     }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/utils/R4MeasureServiceUtils.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/utils/R4MeasureServiceUtils.java
@@ -185,6 +185,7 @@ public class R4MeasureServiceUtils {
 
     public Measure resolveByIdentifier(String identifier) {
         List<IQueryParameterType> params = new ArrayList<>();
+        Map<String, List<IQueryParameterType>> searchParams = new HashMap<>();
         Bundle bundle;
         if (identifier.contains("|")) {
             // system & value
@@ -196,8 +197,7 @@ public class R4MeasureServiceUtils {
             // value only
             params.add(new TokenParam(identifier));
         }
-
-        Map<String, List<IQueryParameterType>> searchParams = Map.of("identifier", params);
+        searchParams.put("identifier", params);
         bundle = this.repository.search(Bundle.class, Measure.class, searchParams);
 
         if (bundle != null && !bundle.getEntry().isEmpty()) {
@@ -244,7 +244,7 @@ public class R4MeasureServiceUtils {
                 measureList.add(measureByIdentifier);
             }*/
             // TODO: resolve IGRepository search for identifier
-            throw new UnsupportedOperationException("search for identifier not implemented.");
+            throw new NotImplementedOperationException("search for identifier not implemented.");
         }
 
         Map<String, Measure> result = new HashMap<>();

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/utils/R4MeasureServiceUtils.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/utils/R4MeasureServiceUtils.java
@@ -183,6 +183,8 @@ public class R4MeasureServiceUtils {
         return (Measure) result.getEntryFirstRep().getResource();
     }
 
+    /*
+    TODO: stubbing for future identifier search implementation
     public Measure resolveByIdentifier(String identifier) {
         List<IQueryParameterType> params = new ArrayList<>();
         Map<String, List<IQueryParameterType>> searchParams = new HashMap<>();
@@ -211,7 +213,7 @@ public class R4MeasureServiceUtils {
             var msg = String.format("Measure Identifier: %s, found no matching measure resources", identifier);
             throw new IllegalArgumentException(msg);
         }
-    }
+    }*/
 
     public List<Measure> getMeasures(
             List<IdType> measureIds, List<String> measureIdentifiers, List<String> measureCanonicals) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/utils/R4MeasureServiceUtils.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/utils/R4MeasureServiceUtils.java
@@ -14,17 +14,26 @@ import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.RE
 import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.US_COUNTRY_CODE;
 import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.US_COUNTRY_DISPLAY;
 
+import ca.uhn.fhir.model.api.IQueryParameterType;
+import ca.uhn.fhir.rest.param.TokenParam;
+import ca.uhn.fhir.rest.param.UriParam;
 import ca.uhn.fhir.rest.server.exceptions.NotImplementedOperationException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.ContactDetail;
 import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Measure;
 import org.hl7.fhir.r4.model.MeasureReport;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.SearchParameter;
@@ -149,5 +158,98 @@ public class R4MeasureServiceUtils {
         }
 
         return reference;
+    }
+
+    public Measure resolveById(IdType id) {
+        return this.repository.read(Measure.class, id);
+    }
+
+    public Measure resolveByUrl(String url) {
+        Bundle bundle;
+        Map<String, List<IQueryParameterType>> searchParameters = new HashMap<>();
+        if (url.contains("|")) {
+            // uri & version
+            var splitId = url.split("\\|");
+            var uri = splitId[0];
+            var version = splitId[1];
+            searchParameters.put("url", Collections.singletonList(new UriParam(uri)));
+            searchParameters.put("version", Collections.singletonList(new TokenParam(version)));
+        } else {
+            // uri only
+            searchParameters.put("url", Collections.singletonList(new UriParam(url)));
+        }
+
+        Bundle result = this.repository.search(Bundle.class, Measure.class, searchParameters);
+        return (Measure) result.getEntryFirstRep().getResource();
+    }
+
+    public Measure resolveByIdentifier(String identifier) {
+        List<IQueryParameterType> params = new ArrayList<>();
+        Bundle bundle;
+        if (identifier.contains("|")) {
+            // system & value
+            var splitId = identifier.split("\\|");
+            var system = splitId[0];
+            var code = splitId[1];
+            params.add(new TokenParam(system, code));
+        } else {
+            // value only
+            params.add(new TokenParam(identifier));
+        }
+
+        Map<String, List<IQueryParameterType>> searchParams = Map.of("identifier", params);
+        bundle = this.repository.search(Bundle.class, Measure.class, searchParams);
+
+        if (bundle != null && !bundle.getEntry().isEmpty()) {
+            if (bundle.getEntry().size() > 1) {
+                var msg = String.format(
+                        "Measure Identifier: %s, found more than one matching measure resource", identifier);
+                throw new IllegalArgumentException(msg);
+            }
+            return (Measure) bundle.getEntryFirstRep().getResource();
+        } else {
+            var msg = String.format("Measure Identifier: %s, found no matching measure resources", identifier);
+            throw new IllegalArgumentException(msg);
+        }
+    }
+
+    public List<Measure> getMeasures(
+            List<IdType> measureIds, List<String> measureIdentifiers, List<String> measureCanonicals) {
+        boolean hasMeasureIds = measureIds != null && !measureIds.isEmpty();
+        boolean hasMeasureIdentifiers = measureIdentifiers != null && !measureIdentifiers.isEmpty();
+        boolean hasMeasureUrls = measureCanonicals != null && !measureCanonicals.isEmpty();
+        if (!hasMeasureIds && !hasMeasureIdentifiers && !hasMeasureUrls) {
+            return Collections.emptyList();
+        }
+
+        List<Measure> measureList = new ArrayList<>();
+
+        if (hasMeasureIds) {
+            for (IdType measureId : measureIds) {
+                Measure measureById = resolveById(measureId);
+                measureList.add(measureById);
+            }
+        }
+
+        if (hasMeasureUrls) {
+            for (String measureCanonical : measureCanonicals) {
+                Measure measureByUrl = resolveByUrl(measureCanonical);
+                measureList.add(measureByUrl);
+            }
+        }
+
+        if (hasMeasureIdentifiers) {
+            /*for (String measureIdentifier : measureIdentifiers) {
+                Measure measureByIdentifier = resolveByIdentifier(measureIdentifier);
+                measureList.add(measureByIdentifier);
+            }*/
+            // TODO: resolve IGRepository search for identifier
+            throw new UnsupportedOperationException("search for identifier not implemented.");
+        }
+
+        Map<String, Measure> result = new HashMap<>();
+        measureList.forEach(measure -> result.putIfAbsent(measure.getUrl(), measure));
+
+        return new ArrayList<>(result.values());
     }
 }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasureServiceTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasureServiceTest.java
@@ -5,11 +5,11 @@ import static org.junit.Assert.assertThrows;
 import org.junit.jupiter.api.Test;
 import org.opencds.cqf.fhir.cr.measure.r4.MultiMeasure.Given;
 
-public class MultiMeasureServiceTest {
+class MultiMeasureServiceTest {
     private static final Given GIVEN_REPO = MultiMeasure.given().repositoryFor("MinimalMeasureEvaluation");
 
     @Test
-    void MultiMeasure_EightMeasures_AllSubjects() {
+    void MultiMeasure_EightMeasures_AllSubjects_MeasureId() {
         var when = GIVEN_REPO
                 .when()
                 .measureId("MinimalProportionNoBasisSingleGroup")
@@ -155,6 +155,290 @@ public class MultiMeasureServiceTest {
                 .up()
                 .population("measure-population-exclusion")
                 .hasCount(2);
+    }
+
+    @Test
+    void MultiMeasure_EightMeasures_AllSubjects_MeasureUrl() {
+        var when = GIVEN_REPO
+                .when()
+                .measureUrl("http://example.com/Measure/MinimalProportionNoBasisSingleGroup")
+                .measureUrl("http://example.com/Measure/MinimalProportionBooleanBasisSingleGroup")
+                .measureUrl("http://example.com/Measure/MinimalRatioBooleanBasisSingleGroup")
+                .measureUrl("http://example.com/Measure/MinimalRatioResourceBasisSingleGroup")
+                .measureUrl("http://example.com/Measure/MinimalCohortResourceBasisSingleGroup")
+                .measureUrl("http://example.com/Measure/MinimalCohortBooleanBasisSingleGroup")
+                .measureUrl("http://example.com/Measure/MinimalContinuousVariableResourceBasisSingleGroup")
+                .measureUrl("http://example.com/Measure/MinimalContinuousVariableBooleanBasisSingleGroup")
+                .periodStart("2024-01-01")
+                .periodEnd("2024-12-31")
+                .reportType("population")
+                .evaluate();
+
+        when.then()
+                .hasMeasureReportCount(8)
+                .measureReport("http://example.com/Measure/MinimalProportionNoBasisSingleGroup")
+                .hasReportType("Summary")
+                .firstGroup()
+                .population("initial-population")
+                .hasCount(8)
+                .up()
+                .population("denominator")
+                .hasCount(5)
+                .up()
+                .population("denominator-exclusion")
+                .hasCount(2)
+                .up()
+                .population("denominator-exception")
+                .hasCount(1)
+                .up()
+                .population("numerator-exclusion")
+                .hasCount(2)
+                .up()
+                .population("numerator")
+                .hasCount(3)
+                .up()
+                .hasScore("0.6")
+                .up()
+                .up()
+                .measureReport("http://example.com/Measure/MinimalProportionBooleanBasisSingleGroup")
+                .hasReportType("Summary")
+                .firstGroup()
+                .population("initial-population")
+                .hasCount(8)
+                .up()
+                .population("denominator")
+                .hasCount(5)
+                .up()
+                .population("denominator-exclusion")
+                .hasCount(2)
+                .up()
+                .population("denominator-exception")
+                .hasCount(1)
+                .up()
+                .population("numerator-exclusion")
+                .hasCount(2)
+                .up()
+                .population("numerator")
+                .hasCount(3)
+                .up()
+                .hasScore("0.6")
+                .up()
+                .up()
+                .measureReport("http://example.com/Measure/MinimalRatioBooleanBasisSingleGroup")
+                .firstGroup()
+                .population("initial-population")
+                .hasCount(8)
+                .up()
+                .population("denominator")
+                .hasCount(6)
+                .up()
+                .population("denominator-exclusion")
+                .hasCount(2)
+                .up()
+                .population("numerator-exclusion")
+                .hasCount(2)
+                .up()
+                .population("numerator")
+                .hasCount(3)
+                .up()
+                .hasScore("0.5")
+                .up()
+                .up()
+                .measureReport("http://example.com/Measure/MinimalRatioResourceBasisSingleGroup")
+                .firstGroup()
+                .population("initial-population")
+                .hasCount(9)
+                .up()
+                .population("denominator")
+                .hasCount(7)
+                .up()
+                .population("denominator-exclusion")
+                .hasCount(2)
+                .up()
+                .population("numerator-exclusion")
+                .hasCount(2)
+                .up()
+                .population("numerator")
+                .hasCount(3)
+                .up()
+                .hasScore("0.42857142857142855")
+                .up()
+                .up()
+                .measureReport("http://example.com/Measure/MinimalCohortResourceBasisSingleGroup")
+                .firstGroup()
+                .population("initial-population")
+                .hasCount(9)
+                .up()
+                .up()
+                .up()
+                .measureReport("http://example.com/Measure/MinimalCohortBooleanBasisSingleGroup")
+                .firstGroup()
+                .population("initial-population")
+                .hasCount(8)
+                .up()
+                .up()
+                .up()
+                .measureReport("http://example.com/Measure/MinimalContinuousVariableResourceBasisSingleGroup")
+                .firstGroup()
+                .population("initial-population")
+                .hasCount(9)
+                .up()
+                .population("measure-population")
+                .hasCount(7)
+                .up()
+                .population("measure-population-exclusion")
+                .hasCount(2)
+                .up()
+                .population("measure-observation")
+                .hasCount(7)
+                .up()
+                .up()
+                .up()
+                .measureReport("http://example.com/Measure/MinimalContinuousVariableBooleanBasisSingleGroup")
+                .firstGroup()
+                .population("initial-population")
+                .hasCount(8)
+                .up()
+                .population("measure-population")
+                .hasCount(6)
+                .up()
+                .population("measure-population-exclusion")
+                .hasCount(2);
+    }
+
+    @Test
+    void MultiMeasure_EightMeasures_SubjectEvalType_AllSubjects() {
+        var when = GIVEN_REPO
+                .when()
+                .measureId("MinimalProportionNoBasisSingleGroup")
+                .measureId("MinimalProportionBooleanBasisSingleGroup")
+                .measureId("MinimalRatioBooleanBasisSingleGroup")
+                .measureId("MinimalRatioResourceBasisSingleGroup")
+                .measureId("MinimalCohortResourceBasisSingleGroup")
+                .measureId("MinimalCohortBooleanBasisSingleGroup")
+                .measureId("MinimalContinuousVariableResourceBasisSingleGroup")
+                .measureId("MinimalContinuousVariableBooleanBasisSingleGroup")
+                .periodStart("2024-01-01")
+                .periodEnd("2024-12-31")
+                .reportType("subject")
+                .evaluate();
+
+        when.then()
+                .hasMeasureReportCount(64)
+                .hasMeasureReportCountPerUrl(8, "http://example.com/Measure/MinimalProportionNoBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(8, "http://example.com/Measure/MinimalProportionBooleanBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(8, "http://example.com/Measure/MinimalRatioBooleanBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(8, "http://example.com/Measure/MinimalRatioResourceBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(8, "http://example.com/Measure/MinimalCohortResourceBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(8, "http://example.com/Measure/MinimalCohortBooleanBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(
+                        8, "http://example.com/Measure/MinimalContinuousVariableResourceBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(
+                        8, "http://example.com/Measure/MinimalContinuousVariableBooleanBasisSingleGroup")
+                .getFirstMeasureReport()
+                .hasReportType("Individual");
+    }
+
+    @Test
+    void MultiMeasure_EightMeasures_SubjectEvalType_GroupPatients() {
+        var when = GIVEN_REPO
+                .when()
+                .measureId("MinimalProportionNoBasisSingleGroup")
+                .measureId("MinimalProportionBooleanBasisSingleGroup")
+                .measureId("MinimalRatioBooleanBasisSingleGroup")
+                .measureId("MinimalRatioResourceBasisSingleGroup")
+                .measureId("MinimalCohortResourceBasisSingleGroup")
+                .measureId("MinimalCohortBooleanBasisSingleGroup")
+                .measureId("MinimalContinuousVariableResourceBasisSingleGroup")
+                .measureId("MinimalContinuousVariableBooleanBasisSingleGroup")
+                .periodStart("2024-01-01")
+                .periodEnd("2024-12-31")
+                .reportType("subject")
+                .subject("Group/group-patients-1")
+                .evaluate();
+
+        when.then()
+                .hasMeasureReportCount(64)
+                .hasMeasureReportCountPerUrl(8, "http://example.com/Measure/MinimalProportionNoBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(8, "http://example.com/Measure/MinimalProportionBooleanBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(8, "http://example.com/Measure/MinimalRatioBooleanBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(8, "http://example.com/Measure/MinimalRatioResourceBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(8, "http://example.com/Measure/MinimalCohortResourceBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(8, "http://example.com/Measure/MinimalCohortBooleanBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(
+                        8, "http://example.com/Measure/MinimalContinuousVariableResourceBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(
+                        8, "http://example.com/Measure/MinimalContinuousVariableBooleanBasisSingleGroup")
+                .getFirstMeasureReport()
+                .hasReportType("Individual");
+    }
+
+    @Test
+    void MultiMeasure_EightMeasures_SubjectEvalType_GroupPractitioner() {
+        var when = GIVEN_REPO
+                .when()
+                .measureId("MinimalProportionNoBasisSingleGroup")
+                .measureId("MinimalProportionBooleanBasisSingleGroup")
+                .measureId("MinimalRatioBooleanBasisSingleGroup")
+                .measureId("MinimalRatioResourceBasisSingleGroup")
+                .measureId("MinimalCohortResourceBasisSingleGroup")
+                .measureId("MinimalCohortBooleanBasisSingleGroup")
+                .measureId("MinimalContinuousVariableResourceBasisSingleGroup")
+                .measureId("MinimalContinuousVariableBooleanBasisSingleGroup")
+                .periodStart("2024-01-01")
+                .periodEnd("2024-12-31")
+                .reportType("subject")
+                .subject("Group/group-practitioners-1")
+                .evaluate();
+
+        when.then()
+                .hasMeasureReportCount(8)
+                .hasMeasureReportCountPerUrl(1, "http://example.com/Measure/MinimalProportionNoBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(1, "http://example.com/Measure/MinimalProportionBooleanBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(1, "http://example.com/Measure/MinimalRatioBooleanBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(1, "http://example.com/Measure/MinimalRatioResourceBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(1, "http://example.com/Measure/MinimalCohortResourceBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(1, "http://example.com/Measure/MinimalCohortBooleanBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(
+                        1, "http://example.com/Measure/MinimalContinuousVariableResourceBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(
+                        1, "http://example.com/Measure/MinimalContinuousVariableBooleanBasisSingleGroup")
+                .getFirstMeasureReport()
+                .hasReportType("Individual");
+    }
+
+    @Test
+    void MultiMeasure_EightMeasures_SubjectEvalType_Practitioner() {
+        var when = GIVEN_REPO
+                .when()
+                .measureId("MinimalProportionNoBasisSingleGroup")
+                .measureId("MinimalProportionBooleanBasisSingleGroup")
+                .measureId("MinimalRatioBooleanBasisSingleGroup")
+                .measureId("MinimalRatioResourceBasisSingleGroup")
+                .measureId("MinimalCohortResourceBasisSingleGroup")
+                .measureId("MinimalCohortBooleanBasisSingleGroup")
+                .measureId("MinimalContinuousVariableResourceBasisSingleGroup")
+                .measureId("MinimalContinuousVariableBooleanBasisSingleGroup")
+                .periodStart("2024-01-01")
+                .periodEnd("2024-12-31")
+                .reportType("subject")
+                .subject("Practitioner/tester")
+                .evaluate();
+
+        when.then()
+                .hasMeasureReportCount(8)
+                .hasMeasureReportCountPerUrl(1, "http://example.com/Measure/MinimalProportionNoBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(1, "http://example.com/Measure/MinimalProportionBooleanBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(1, "http://example.com/Measure/MinimalRatioBooleanBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(1, "http://example.com/Measure/MinimalRatioResourceBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(1, "http://example.com/Measure/MinimalCohortResourceBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(1, "http://example.com/Measure/MinimalCohortBooleanBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(
+                        1, "http://example.com/Measure/MinimalContinuousVariableResourceBasisSingleGroup")
+                .hasMeasureReportCountPerUrl(
+                        1, "http://example.com/Measure/MinimalContinuousVariableBooleanBasisSingleGroup")
+                .getFirstMeasureReport()
+                .hasReportType("Individual");
     }
 
     @Test
@@ -512,42 +796,6 @@ public class MultiMeasureServiceTest {
     }
 
     @Test
-    void MultiMeasure_EightMeasures_PractitionerJustId() {
-        var when = GIVEN_REPO
-                .when()
-                .measureId("MinimalProportionNoBasisSingleGroup")
-                .periodStart("2024-01-01")
-                .periodEnd("2024-12-31")
-                .reportType("population")
-                .practitioner("tester")
-                .evaluate();
-
-        when.then()
-                .hasMeasureReportCount(1)
-                .measureReport("http://example.com/Measure/MinimalProportionNoBasisSingleGroup")
-                .hasReportType("Summary")
-                .hasSubjectReference("Practitioner/tester")
-                .firstGroup()
-                .population("initial-population")
-                .hasCount(1)
-                .up()
-                .population("denominator")
-                .hasCount(0)
-                .up()
-                .population("denominator-exclusion")
-                .hasCount(0)
-                .up()
-                .population("denominator-exception")
-                .hasCount(1)
-                .up()
-                .population("numerator-exclusion")
-                .hasCount(0)
-                .up()
-                .population("numerator")
-                .hasCount(0);
-    }
-
-    @Test
     void MultiMeasure_EightMeasures_Practitioner() {
         var when = GIVEN_REPO
                 .when()
@@ -555,7 +803,7 @@ public class MultiMeasureServiceTest {
                 .periodStart("2024-01-01")
                 .periodEnd("2024-12-31")
                 .reportType("population")
-                .practitioner("Practitioner/tester")
+                .subject("Practitioner/tester")
                 .evaluate();
 
         when.then()
@@ -591,7 +839,7 @@ public class MultiMeasureServiceTest {
                 .periodStart("2024-01-01")
                 .periodEnd("2024-12-31")
                 .reportType("population")
-                .practitioner("tester")
+                .subject("Practitioner/tester")
                 .reporter("Practitioner/empty")
                 .evaluate();
 
@@ -611,7 +859,7 @@ public class MultiMeasureServiceTest {
                 .periodStart("2024-01-01")
                 .periodEnd("2024-12-31")
                 .reportType("population")
-                .practitioner("tester")
+                .subject("Practitioner/tester")
                 .reporter("PractitionerRole/test")
                 .evaluate();
 
@@ -631,7 +879,7 @@ public class MultiMeasureServiceTest {
                 .periodStart("2024-01-01")
                 .periodEnd("2024-12-31")
                 .reportType("population")
-                .practitioner("tester")
+                .subject("Practitioner/tester")
                 .reporter("Location/office")
                 .evaluate();
 
@@ -651,7 +899,7 @@ public class MultiMeasureServiceTest {
                 .periodStart("2024-01-01")
                 .periodEnd("2024-12-31")
                 .reportType("population")
-                .practitioner("tester")
+                .subject("Practitioner/tester")
                 .reporter("Organization/payer")
                 .evaluate();
 
@@ -671,7 +919,7 @@ public class MultiMeasureServiceTest {
                 .periodStart("2024-01-01")
                 .periodEnd("2024-12-31")
                 .reportType("population")
-                .practitioner("tester")
+                .subject("Practitioner/tester")
                 .reporter("payer")
                 .evaluate();
 
@@ -691,7 +939,7 @@ public class MultiMeasureServiceTest {
                 .periodStart("2024-01-01")
                 .periodEnd("2024-12-31")
                 .reportType("population")
-                .practitioner("tester")
+                .subject("Practitioner/tester")
                 .reporter(null)
                 .evaluate();
 
@@ -711,7 +959,7 @@ public class MultiMeasureServiceTest {
                 .periodStart("2024-01-01")
                 .periodEnd("2024-12-31")
                 .reportType("population")
-                .practitioner("tester")
+                .subject("Practitioner/tester")
                 .reporter("Patient/male-2022")
                 .evaluate();
 

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MinimalMeasureEvaluation/resources/measure/MinimalProportionNoBasisSingleGroup.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MinimalMeasureEvaluation/resources/measure/MinimalProportionNoBasisSingleGroup.json
@@ -1,6 +1,23 @@
 {
   "id": "MinimalProportionNoBasisSingleGroup",
   "resourceType": "Measure",
+  "identifier": [ {
+    "use": "official",
+    "system": "http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms",
+    "value": "test123"
+  },
+    {
+      "use": "official",
+      "type": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/us/cqfmeasures/CodeSystem/identifier-type",
+            "code": "publisher"
+          }
+        ]
+      },
+      "value": "123"
+    } ],
   "url": "http://example.com/Measure/MinimalProportionNoBasisSingleGroup",
   "library": [
     "http://example.com/Library/MinimalProportionBooleanBasisSingleGroup"

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MinimalMeasureEvaluation/tests/group/group-patients-1.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MinimalMeasureEvaluation/tests/group/group-patients-1.json
@@ -1,0 +1,17 @@
+{
+  "resourceType": "Group",
+  "id": "group-patients-1",
+  "type": "person",
+  "actual": true,
+  "name": "Patient Group",
+  "member": [
+    {  "entity": {  "reference": "Patient/female-1931" } },
+    {  "entity": {  "reference": "Patient/female-1944" } },
+    {  "entity": {  "reference": "Patient/female-1988" } },
+    {  "entity": {  "reference": "Patient/female-2021" } },
+    {  "entity": {  "reference": "Patient/male-1931" } },
+    {  "entity": {  "reference": "Patient/male-1944" } },
+    {  "entity": {  "reference": "Patient/male-1988" } },
+    {  "entity": {  "reference": "Patient/male-2022" } }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MinimalMeasureEvaluation/tests/group/group-practitioners-1.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MinimalMeasureEvaluation/tests/group/group-practitioners-1.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Group",
+  "id": "group-practitioners-1",
+  "type": "practitioner",
+  "actual": true,
+  "name": "Practitioner Group",
+  "member": [
+    {  "entity": {  "reference": "Practitioner/tester" } }
+
+  ]
+}


### PR DESCRIPTION
new feature expansion to multi-measure evaluate request:
- individual measureReport mode, that allows for individual MeasureReport creation for each subject identified via the subject parameter
- consolidated practitioner parameter capability into subject parameter, for a single population parameter. This allows for simplified explanation and use of api
- canonicalUrl Measure parameter that allows for both measureId and measureUrl to be used to identify the Measure to use.
- stubbed in identifier search logic for measures once implemented

closes https://github.com/cqframework/clinical-reasoning/issues/492

