### PR TITLE
Filter out unsupported Expansion Parameters and Respect `canonical-version` and `system-version` when Releasing

### DIFF
--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/Constants.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/Constants.java
@@ -147,6 +147,8 @@ public class Constants {
     public static final String US_PH_CONTEXT_URL = "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context";
     public static final String LIBRARY_TYPE = "http://terminology.hl7.org/CodeSystem/library-type";
     public static final String ASSET_COLLECTION = "asset-collection";
+    public static final String SYSTEM_VERSION = "system-version";
+    public static final String CANONICAL_VERSION = "canonical-version";
 
     public static final String AUTHORITATIVE_SOURCE_URL =
             "http://hl7.org/fhir/StructureDefinition/valueset-authoritativeSource";

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/ExpandHelper.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/ExpandHelper.java
@@ -29,22 +29,25 @@ public class ExpandHelper {
 
     private final FhirContext fhirContext;
     private final TerminologyServerClient terminologyServerClient;
-    public static final List<String> unsupportedParametersToRemove = Collections.unmodifiableList(new ArrayList<String>(Arrays.asList(Constants.SYSTEM_VERSION, Constants.CANONICAL_VERSION)));
+    public static final List<String> unsupportedParametersToRemove = Collections.unmodifiableList(
+            new ArrayList<String>(Arrays.asList(Constants.SYSTEM_VERSION, Constants.CANONICAL_VERSION)));
 
     public ExpandHelper(FhirContext fhirContext, TerminologyServerClient server) {
         this.fhirContext = fhirContext;
         terminologyServerClient = server;
     }
+
     @SuppressWarnings("unchecked")
     private static void filterOutUnsupportedParameters(ParametersAdapter parameters) {
         var paramsToSet = parameters.getParameter();
         unsupportedParametersToRemove.forEach(parameterUrl -> {
-            while(parameters.getParameter(parameterUrl) != null) {
+            while (parameters.getParameter(parameterUrl) != null) {
                 paramsToSet.remove(parameters.getParameter(parameterUrl));
                 parameters.setParameter((List<IBaseBackboneElement>) paramsToSet);
             }
         });
     }
+
     public void expandValueSet(
             ValueSetAdapter valueSet,
             ParametersAdapter expansionParameters,

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/ExpandHelper.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/ExpandHelper.java
@@ -29,8 +29,8 @@ public class ExpandHelper {
 
     private final FhirContext fhirContext;
     private final TerminologyServerClient terminologyServerClient;
-    public static final List<String> unsupportedParametersToRemove = Collections.unmodifiableList(
-            new ArrayList<String>(Arrays.asList(Constants.SYSTEM_VERSION, Constants.CANONICAL_VERSION)));
+    public static final List<String> unsupportedParametersToRemove =
+            Collections.unmodifiableList(new ArrayList<String>(Arrays.asList(Constants.CANONICAL_VERSION)));
 
     public ExpandHelper(FhirContext fhirContext, TerminologyServerClient server) {
         this.fhirContext = fhirContext;

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/LibraryAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/LibraryAdapter.java
@@ -175,7 +175,7 @@ public class LibraryAdapter extends KnowledgeArtifactAdapter
         if (systemVersionExpansionParameters != null && !systemVersionExpansionParameters.isEmpty()) {
             for (String parameter : systemVersionExpansionParameters) {
                 var param = new ParametersParameterComponent();
-                param.setName("system-version");
+                param.setName(Constants.SYSTEM_VERSION);
                 param.setValue(new UriType(parameter));
                 newParameters.add(param);
             }
@@ -183,7 +183,7 @@ public class LibraryAdapter extends KnowledgeArtifactAdapter
         if (canonicalVersionExpansionParameters != null && !canonicalVersionExpansionParameters.isEmpty()) {
             for (String parameter : canonicalVersionExpansionParameters) {
                 var param = new ParametersParameterComponent();
-                param.setName("canonical-version");
+                param.setName(Constants.CANONICAL_VERSION);
                 param.setValue(new UriType(parameter));
                 newParameters.add(param);
             }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/LibraryAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/LibraryAdapter.java
@@ -177,7 +177,7 @@ public class LibraryAdapter extends KnowledgeArtifactAdapter
         if (systemVersionExpansionParameters != null && !systemVersionExpansionParameters.isEmpty()) {
             for (String parameter : systemVersionExpansionParameters) {
                 var param = new ParametersParameterComponent();
-                param.setName("system-version");
+                param.setName(Constants.SYSTEM_VERSION);
                 param.setValue(new UriType(parameter));
                 newParameters.add(param);
             }
@@ -185,7 +185,7 @@ public class LibraryAdapter extends KnowledgeArtifactAdapter
         if (canonicalVersionExpansionParameters != null && !canonicalVersionExpansionParameters.isEmpty()) {
             for (String parameter : canonicalVersionExpansionParameters) {
                 var param = new ParametersParameterComponent();
-                param.setName("canonical-version");
+                param.setName(Constants.CANONICAL_VERSION);
                 param.setValue(new UriType(parameter));
                 newParameters.add(param);
             }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/LibraryAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/LibraryAdapter.java
@@ -175,7 +175,7 @@ public class LibraryAdapter extends KnowledgeArtifactAdapter
         if (systemVersionExpansionParameters != null && !systemVersionExpansionParameters.isEmpty()) {
             for (String parameter : systemVersionExpansionParameters) {
                 var param = new ParametersParameterComponent();
-                param.setName("system-version");
+                param.setName(Constants.SYSTEM_VERSION);
                 param.setValue(new UriType(parameter));
                 newParameters.add(param);
             }
@@ -183,7 +183,7 @@ public class LibraryAdapter extends KnowledgeArtifactAdapter
         if (canonicalVersionExpansionParameters != null && !canonicalVersionExpansionParameters.isEmpty()) {
             for (String parameter : canonicalVersionExpansionParameters) {
                 var param = new ParametersParameterComponent();
-                param.setName("canonical-version");
+                param.setName(Constants.CANONICAL_VERSION);
                 param.setValue(new UriType(parameter));
                 newParameters.add(param);
             }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/visitor/ReleaseVisitor.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/visitor/ReleaseVisitor.java
@@ -25,6 +25,7 @@ import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.utility.BundleHelper;
 import org.opencds.cqf.fhir.utility.Canonicals;
+import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.PackageHelper;
 import org.opencds.cqf.fhir.utility.SearchHelper;
 import org.opencds.cqf.fhir.utility.adapter.AdapterFactory;
@@ -93,13 +94,13 @@ public class ReleaseVisitor implements KnowledgeArtifactVisitor {
                 .equalsIgnoreCase("depends-on"));
         var expansionParameters = rootAdapter.getExpansionParameters();
         var systemVersionParams = expansionParameters
-                .map(p -> VisitorHelper.getListParameter("system-version", p, IPrimitiveType.class)
+                .map(p -> VisitorHelper.getListParameter(Constants.SYSTEM_VERSION, p, IPrimitiveType.class)
                         .orElse(null))
                 .map(versions ->
                         versions.stream().map(v -> (String) v.getValue()).collect(Collectors.toList()))
                 .orElse(new ArrayList<String>());
         var canonicalVersionParams = expansionParameters
-                .map(p -> VisitorHelper.getListParameter("canonical-version", p, IPrimitiveType.class)
+                .map(p -> VisitorHelper.getListParameter(Constants.CANONICAL_VERSION, p, IPrimitiveType.class)
                         .orElse(null))
                 .map(versions ->
                         versions.stream().map(v -> (String) v.getValue()).collect(Collectors.toList()))

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/visitor/ReleaseVisitor.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/visitor/ReleaseVisitor.java
@@ -326,7 +326,7 @@ public class ReleaseVisitor implements KnowledgeArtifactVisitor {
                 }
                 expansionParametersVersion
                         .map(canonical -> Canonicals.getVersion(canonical))
-                        .ifPresent(version -> dependency.setReference(dependency.getReference() + "|" + version));
+                        .ifPresent(version -> dependency.setReference(Canonicals.getUrl(dependency.getReference()) + "|" + version));
 
                 Optional<KnowledgeArtifactAdapter> maybeAdapter = Optional.empty();
                 // if not available in expansion parameters then try to find the latest version and update the

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/ExpandHelperTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/ExpandHelperTest.java
@@ -137,7 +137,6 @@ public class ExpandHelperTest {
         expandHelper.expandValueSet(
                 (ValueSetAdapter) this.factory.createKnowledgeArtifactAdapter(grouper),
                 factory.createParameters(expansionParams),
-                // important part of the test
                 Optional.of(factory.createEndpoint(endpoint)),
                 new ArrayList<ValueSetAdapter>(),
                 new ArrayList<String>(),
@@ -189,7 +188,6 @@ public class ExpandHelperTest {
             expandHelper.expandValueSet(
                     (ValueSetAdapter) this.factory.createKnowledgeArtifactAdapter(grouper),
                     factory.createParameters(expansionParams),
-                    // important part of the test
                     Optional.of(factory.createEndpoint(endpoint)),
                     new ArrayList<ValueSetAdapter>(),
                     new ArrayList<String>(),
@@ -243,7 +241,6 @@ public class ExpandHelperTest {
             expandHelper.expandValueSet(
                     (ValueSetAdapter) this.factory.createKnowledgeArtifactAdapter(grouper),
                     factory.createParameters(expansionParams),
-                    // important part of the test
                     Optional.of(factory.createEndpoint(endpoint)),
                     new ArrayList<ValueSetAdapter>(),
                     new ArrayList<String>(),
@@ -299,7 +296,6 @@ public class ExpandHelperTest {
         expandHelper.expandValueSet(
                 (ValueSetAdapter) this.factory.createKnowledgeArtifactAdapter(grouper),
                 factory.createParameters(expansionParams),
-                // important part of the test
                 Optional.of(factory.createEndpoint(endpoint)),
                 new ArrayList<ValueSetAdapter>(),
                 new ArrayList<String>(),

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/ExpandHelperTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/ExpandHelperTest.java
@@ -264,54 +264,54 @@ public class ExpandHelperTest {
 
     @Test
     void unsupportedParametersAreRemovedWhenExpanding() {
-                // setup tx server endpoint
-                var baseUrl = "www.test.com/fhir";
-                var endpoint = new Endpoint();
-                endpoint.setAddress(baseUrl);
-                // setup Vsets
-                var leafUrl = baseUrl + "/ValueSet/leaf";
-                // ensure that the grouper is not expanded using the Tx Server
-                var grouperUrl = "www.different-base-url.com/fhir/ValueSet/grouper";
-                var grouperVersion = "1.9.2";
-                var grouper = new ValueSet();
-                grouper.setUrl(grouperUrl);
-                grouper.setVersion(grouperVersion);
-                grouper.getCompose().getIncludeFirstRep().getValueSet().add(new CanonicalType(leafUrl));
-                grouper.addExtension().setUrl(Constants.AUTHORITATIVE_SOURCE_URL).setValue(new UriType(grouperUrl));
-                var leaf = createLeafWithUrl(leafUrl);
-                leaf.setVersion("1.1.1");
+        // setup tx server endpoint
+        var baseUrl = "www.test.com/fhir";
+        var endpoint = new Endpoint();
+        endpoint.setAddress(baseUrl);
+        // setup Vsets
+        var leafUrl = baseUrl + "/ValueSet/leaf";
+        // ensure that the grouper is not expanded using the Tx Server
+        var grouperUrl = "www.different-base-url.com/fhir/ValueSet/grouper";
+        var grouperVersion = "1.9.2";
+        var grouper = new ValueSet();
+        grouper.setUrl(grouperUrl);
+        grouper.setVersion(grouperVersion);
+        grouper.getCompose().getIncludeFirstRep().getValueSet().add(new CanonicalType(leafUrl));
+        grouper.addExtension().setUrl(Constants.AUTHORITATIVE_SOURCE_URL).setValue(new UriType(grouperUrl));
+        var leaf = createLeafWithUrl(leafUrl);
+        leaf.setVersion("1.1.1");
 
-                // shouldn't be used
-                var rep = mockRepositoryWithValueSetR4(leaf);
-        
-                // should be used
-                var client = mockTerminologyServerWithValueSetR4(leaf);
-        
-                var expandHelper = new ExpandHelper(rep.fhirContext(), client);
-                var expansionParams = new Parameters();
-                // Setup exp params with Grouper URL and version
-                expansionParams.addParameter(TerminologyServerClient.urlParamName, grouperUrl);
-                expansionParams.addParameter(TerminologyServerClient.versionParamName, grouperVersion);
+        // shouldn't be used
+        var rep = mockRepositoryWithValueSetR4(leaf);
 
-                ExpandHelper.unsupportedParametersToRemove.forEach(unsupportedParam -> {
-                    expansionParams.addParameter(unsupportedParam, "test");
-                });
-                expandHelper.expandValueSet(
-                        (ValueSetAdapter) this.factory.createKnowledgeArtifactAdapter(grouper),
-                        factory.createParameters(expansionParams),
-                        // important part of the test
-                        Optional.of(factory.createEndpoint(endpoint)),
-                        new ArrayList<ValueSetAdapter>(),
-                        new ArrayList<String>(),
-                        rep,
-                        new Date());
-                var parametersCaptor = ArgumentCaptor.forClass(ParametersAdapter.class);
-                verify(client, times(1)).expand(any(ValueSetAdapter.class), any(), parametersCaptor.capture());
-                var filteredExpansionParams = parametersCaptor.getValue();
-                assertEquals(2, filteredExpansionParams.getParameter().size());
-                ExpandHelper.unsupportedParametersToRemove.forEach(parameterUrl -> {
-                    assertNull(filteredExpansionParams.getParameter(parameterUrl));
-                });
+        // should be used
+        var client = mockTerminologyServerWithValueSetR4(leaf);
+
+        var expandHelper = new ExpandHelper(rep.fhirContext(), client);
+        var expansionParams = new Parameters();
+        // Setup exp params with Grouper URL and version
+        expansionParams.addParameter(TerminologyServerClient.urlParamName, grouperUrl);
+        expansionParams.addParameter(TerminologyServerClient.versionParamName, grouperVersion);
+
+        ExpandHelper.unsupportedParametersToRemove.forEach(unsupportedParam -> {
+            expansionParams.addParameter(unsupportedParam, "test");
+        });
+        expandHelper.expandValueSet(
+                (ValueSetAdapter) this.factory.createKnowledgeArtifactAdapter(grouper),
+                factory.createParameters(expansionParams),
+                // important part of the test
+                Optional.of(factory.createEndpoint(endpoint)),
+                new ArrayList<ValueSetAdapter>(),
+                new ArrayList<String>(),
+                rep,
+                new Date());
+        var parametersCaptor = ArgumentCaptor.forClass(ParametersAdapter.class);
+        verify(client, times(1)).expand(any(ValueSetAdapter.class), any(), parametersCaptor.capture());
+        var filteredExpansionParams = parametersCaptor.getValue();
+        assertEquals(2, filteredExpansionParams.getParameter().size());
+        ExpandHelper.unsupportedParametersToRemove.forEach(parameterUrl -> {
+            assertNull(filteredExpansionParams.getParameter(parameterUrl));
+        });
     }
 
     ValueSet createLeafWithUrl(String url) {

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/ReleaseVisitorTests.java
@@ -392,14 +392,8 @@ class ReleaseVisitorTests {
 
         var expansionParameters =
                 new AdapterFactory().createLibrary(releasedLibrary).getExpansionParameters();
-        var systemVersionParams = expansionParameters
-                .map(p -> VisitorHelper.getListParameter("system-version", p, IPrimitiveType.class)
-                        .orElse(null))
-                .map(versions ->
-                        versions.stream().map(v -> (String) v.getValue()).collect(Collectors.toList()))
-                .orElse(new ArrayList<String>());
         var canonicalVersionParams = expansionParameters
-                .map(p -> VisitorHelper.getListParameter("canonical-version", p, IPrimitiveType.class)
+                .map(p -> VisitorHelper.getListParameter(Constants.CANONICAL_VERSION, p, IPrimitiveType.class)
                         .orElse(null))
                 .map(versions ->
                         versions.stream().map(v -> (String) v.getValue()).collect(Collectors.toList()))

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/ReleaseVisitorTests.java
@@ -404,39 +404,7 @@ class ReleaseVisitorTests {
                 .map(versions ->
                         versions.stream().map(v -> (String) v.getValue()).collect(Collectors.toList()))
                 .orElse(new ArrayList<String>());
-        var expectedNewCanonicalVersionParams = Arrays.asList(
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.6|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1063|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.360|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.120|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.362|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.528|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.408|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.409|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1469|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1866|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1906|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.480|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.481|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.761|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1223|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1182|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1181|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1184|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1601|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1600|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1603|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1602|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1082|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1439|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1436|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1435|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1446|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1438|2022-10-19");
-        assertEquals(expectedNewCanonicalVersionParams.size(), canonicalVersionParams.size());
-        for (final var expected : expectedNewCanonicalVersionParams) {
-            assertTrue(canonicalVersionParams.stream().anyMatch(p -> p.equals(expected)));
-        }
+        assertEquals(0, canonicalVersionParams.size());
     }
 
     @Test

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/ReleaseVisitorTests.java
@@ -388,39 +388,7 @@ class ReleaseVisitorTests {
                 .map(versions ->
                         versions.stream().map(v -> (String) v.getValue()).collect(Collectors.toList()))
                 .orElse(new ArrayList<String>());
-        var expectedNewCanonicalVersionParams = Arrays.asList(
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.6|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1063|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.360|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.120|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.362|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.528|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.408|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.409|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1469|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1866|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1906|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.480|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.481|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.761|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1223|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1182|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1181|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1184|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1601|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1600|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1603|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1602|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1082|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1439|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1436|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1435|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1446|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1438|2022-10-19");
-        assertEquals(expectedNewCanonicalVersionParams.size(), canonicalVersionParams.size());
-        for (final var expected : expectedNewCanonicalVersionParams) {
-            assertTrue(canonicalVersionParams.stream().anyMatch(p -> p.equals(expected)));
-        }
+        assertEquals(0, canonicalVersionParams.size());
     }
 
     @Test

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/ReleaseVisitorTests.java
@@ -376,14 +376,8 @@ class ReleaseVisitorTests {
 
         var expansionParameters =
                 new AdapterFactory().createLibrary(releasedLibrary).getExpansionParameters();
-        var systemVersionParams = expansionParameters
-                .map(p -> VisitorHelper.getListParameter("system-version", p, IPrimitiveType.class)
-                        .orElse(null))
-                .map(versions ->
-                        versions.stream().map(v -> (String) v.getValue()).collect(Collectors.toList()))
-                .orElse(new ArrayList<String>());
         var canonicalVersionParams = expansionParameters
-                .map(p -> VisitorHelper.getListParameter("canonical-version", p, IPrimitiveType.class)
+                .map(p -> VisitorHelper.getListParameter(Constants.CANONICAL_VERSION, p, IPrimitiveType.class)
                         .orElse(null))
                 .map(versions ->
                         versions.stream().map(v -> (String) v.getValue()).collect(Collectors.toList()))

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/ReleaseVisitorTests.java
@@ -389,39 +389,7 @@ class ReleaseVisitorTests {
                 .map(versions ->
                         versions.stream().map(v -> (String) v.getValue()).collect(Collectors.toList()))
                 .orElse(new ArrayList<String>());
-        var expectedNewCanonicalVersionParams = Arrays.asList(
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.6|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1063|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.360|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.120|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.362|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.528|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.408|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.409|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1469|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1866|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1906|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.480|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.481|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.761|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1223|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1182|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1181|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1184|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1601|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1600|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1603|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1602|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1082|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1439|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1436|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1435|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1446|2022-10-19",
-                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1438|2022-10-19");
-        assertEquals(expectedNewCanonicalVersionParams.size(), canonicalVersionParams.size());
-        for (final var expected : expectedNewCanonicalVersionParams) {
-            assertTrue(canonicalVersionParams.stream().anyMatch(p -> p.equals(expected)));
-        }
+        assertEquals(0, canonicalVersionParams.size());
     }
 
     @Test

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/ReleaseVisitorTests.java
@@ -377,14 +377,8 @@ class ReleaseVisitorTests {
 
         var expansionParameters =
                 new AdapterFactory().createLibrary(releasedLibrary).getExpansionParameters();
-        var systemVersionParams = expansionParameters
-                .map(p -> VisitorHelper.getListParameter("system-version", p, IPrimitiveType.class)
-                        .orElse(null))
-                .map(versions ->
-                        versions.stream().map(v -> (String) v.getValue()).collect(Collectors.toList()))
-                .orElse(new ArrayList<String>());
         var canonicalVersionParams = expansionParameters
-                .map(p -> VisitorHelper.getListParameter("canonical-version", p, IPrimitiveType.class)
+                .map(p -> VisitorHelper.getListParameter(Constants.CANONICAL_VERSION, p, IPrimitiveType.class)
                         .orElse(null))
                 .map(versions ->
                         versions.stream().map(v -> (String) v.getValue()).collect(Collectors.toList()))


### PR DESCRIPTION
[APHL-1067] filter out unsupported Expansion Parameters

[APHL-1067]: https://alphora.atlassian.net/browse/APHL-1067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ