### PR TITLE
Rev to latest CQL/HAPI

### DIFF
--- a/cqf-fhir-api/pom.xml
+++ b/cqf-fhir-api/pom.xml
@@ -5,14 +5,14 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-api</artifactId>
-  <version>3.12.0-SNAPSHOT</version>
+  <version>3.12.0</version>
   <name>FHIR Clinical Reasoning (APIs)</name>
   <description>FHIR Repository APIs used by this project. Implement these to incorporate clinical reasoning on your platform</description>
 
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.12.0-SNAPSHOT</version>
+    <version>3.12.0</version>
   </parent>
 
   <dependencies>

--- a/cqf-fhir-benchmark/pom.xml
+++ b/cqf-fhir-benchmark/pom.xml
@@ -5,26 +5,26 @@
 
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir-benchmark</artifactId>
-    <version>3.12.0-SNAPSHOT</version>
+    <version>3.12.0</version>
     <name>FHIR Clinical Reasoning (Benchmarks)</name>
     <description>Tests validating performance of FHIR Clinical Reasoning operations</description>
 
     <parent>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir</artifactId>
-        <version>3.12.0-SNAPSHOT</version>
+        <version>3.12.0</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>org.opencds.cqf.fhir</groupId>
             <artifactId>cqf-fhir-cr</artifactId>
-            <version>3.12.0-SNAPSHOT</version>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.opencds.cqf.fhir</groupId>
             <artifactId>cqf-fhir-test</artifactId>
-            <version>3.12.0-SNAPSHOT</version>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
@@ -34,14 +34,14 @@
         <dependency>
             <groupId>org.opencds.cqf.fhir</groupId>
             <artifactId>cqf-fhir-cr</artifactId>
-            <version>3.12.0-SNAPSHOT</version>
+            <version>3.12.0</version>
             <!--TODO: test-jars don't seem to work very well. Need to investigate some alternatives -->
             <type>test-jar</type>
         </dependency>
         <dependency>
             <groupId>org.opencds.cqf.fhir</groupId>
             <artifactId>cqf-fhir-jackson</artifactId>
-            <version>3.12.0-SNAPSHOT</version>
+            <version>3.12.0</version>
             <type>pom</type>
             <scope>test</scope>
         </dependency>

--- a/cqf-fhir-bom/pom.xml
+++ b/cqf-fhir-bom/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-bom</artifactId>
-  <version>3.12.0-SNAPSHOT</version>
+  <version>3.12.0</version>
   <packaging>pom</packaging>
   <name>FHIR Clinical Reasoning (Bill Of Materials)</name>
   <description>This bom can be used to simplify dependency management when using this project</description>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.12.0-SNAPSHOT</version>
+    <version>3.12.0</version>
   </parent>
 
   <dependencyManagement>
@@ -21,44 +21,44 @@
       <dependency>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir-api</artifactId>
-        <version>3.12.0-SNAPSHOT</version>
+        <version>3.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir-test</artifactId>
-        <version>3.12.0-SNAPSHOT</version>
+        <version>3.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir-utility</artifactId>
-        <version>3.12.0-SNAPSHOT</version>
+        <version>3.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir-cql</artifactId>
-        <version>3.12.0-SNAPSHOT</version>
+        <version>3.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir-jackson</artifactId>
-        <version>3.12.0-SNAPSHOT</version>
+        <version>3.12.0</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir-jaxb</artifactId>
-        <version>3.12.0-SNAPSHOT</version>
+        <version>3.12.0</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir-cr</artifactId>
-        <version>3.12.0-SNAPSHOT</version>
+        <version>3.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir-cr-cli</artifactId>
-        <version>3.12.0-SNAPSHOT</version>
+        <version>3.12.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/cqf-fhir-cql/pom.xml
+++ b/cqf-fhir-cql/pom.xml
@@ -5,26 +5,26 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-cql</artifactId>
-  <version>3.12.0-SNAPSHOT</version>
+  <version>3.12.0</version>
   <name>FHIR Clinical Reasoning (CQL)</name>
   <description>Tools, utilities, code gen to support CQL in FHIR Clinical Reasoning operations</description>
 
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.12.0-SNAPSHOT</version>
+    <version>3.12.0</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.12.0-SNAPSHOT</version>
+      <version>3.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-utility</artifactId>
-      <version>3.12.0-SNAPSHOT</version>
+      <version>3.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -62,13 +62,13 @@
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-test</artifactId>
-      <version>3.12.0-SNAPSHOT</version>
+      <version>3.12.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-jackson</artifactId>
-      <version>3.12.0-SNAPSHOT</version>
+      <version>3.12.0</version>
       <type>pom</type>
       <scope>test</scope>
     </dependency>

--- a/cqf-fhir-cr-cli/pom.xml
+++ b/cqf-fhir-cr-cli/pom.xml
@@ -6,36 +6,36 @@
 
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir-cr-cli</artifactId>
-    <version>3.12.0-SNAPSHOT</version>
+    <version>3.12.0</version>
     <name>FHIR Clinical Reasoning (CLI)</name>
     <description>CLI for running FHIR Clincial Reasoning operations</description>
 
     <parent>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir</artifactId>
-        <version>3.12.0-SNAPSHOT</version>
+        <version>3.12.0</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>org.opencds.cqf.fhir</groupId>
             <artifactId>cqf-fhir-api</artifactId>
-            <version>3.12.0-SNAPSHOT</version>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.opencds.cqf.fhir</groupId>
             <artifactId>cqf-fhir-utility</artifactId>
-            <version>3.12.0-SNAPSHOT</version>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.opencds.cqf.fhir</groupId>
             <artifactId>cqf-fhir-cql</artifactId>
-            <version>3.12.0-SNAPSHOT</version>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.opencds.cqf.fhir</groupId>
             <artifactId>cqf-fhir-jackson</artifactId>
-            <version>3.12.0-SNAPSHOT</version>
+            <version>3.12.0</version>
             <type>pom</type>
         </dependency>
         <dependency>
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.opencds.cqf.fhir</groupId>
             <artifactId>cqf-fhir-test</artifactId>
-            <version>3.12.0-SNAPSHOT</version>
+            <version>3.12.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/cqf-fhir-cr-spring/pom.xml
+++ b/cqf-fhir-cr-spring/pom.xml
@@ -7,21 +7,21 @@
 
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir-cr-spring</artifactId>
-    <version>3.12.0-SNAPSHOT</version>
+    <version>3.12.0</version>
     <name>FHIR Clinical Reasoning (Spring)</name>
     <description>Spring configurations for FHIR Clinical Reasoning</description>
 
     <parent>
         <groupId>org.opencds.cqf.fhir</groupId>
         <artifactId>cqf-fhir</artifactId>
-        <version>3.12.0-SNAPSHOT</version>
+        <version>3.12.0</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>org.opencds.cqf.fhir</groupId>
             <artifactId>cqf-fhir-cr</artifactId>
-            <version>3.12.0-SNAPSHOT</version>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/cqf-fhir-cr/pom.xml
+++ b/cqf-fhir-cr/pom.xml
@@ -5,45 +5,45 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-cr</artifactId>
-  <version>3.12.0-SNAPSHOT</version>
+  <version>3.12.0</version>
   <name>FHIR Clinical Reasoning (Operations)</name>
   <description>Implementations of clinical reasoning operations</description>
 
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.12.0-SNAPSHOT</version>
+    <version>3.12.0</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.12.0-SNAPSHOT</version>
+      <version>3.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-cql</artifactId>
-      <version>3.12.0-SNAPSHOT</version>
+      <version>3.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-utility</artifactId>
-      <version>3.12.0-SNAPSHOT</version>
+      <version>3.12.0</version>
     </dependency>
 
     <!-- test dependencies-->
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-jackson</artifactId>
-      <version>3.12.0-SNAPSHOT</version>
+      <version>3.12.0</version>
       <type>pom</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-test</artifactId>
-      <version>3.12.0-SNAPSHOT</version>
+      <version>3.12.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/dstu3/Dstu3MeasureEvaluationTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/dstu3/Dstu3MeasureEvaluationTest.java
@@ -94,7 +94,7 @@ class Dstu3MeasureEvaluationTest extends BaseMeasureEvaluationTest {
                         any()))
                 .thenReturn(Arrays.asList(patient));
 
-        String cql = cql_with_dateTime() + sde_race() + "define InitialPopulation: 'Doe' in Patient.name.family";
+        String cql = cql_with_dateTime() + sde_race() + "define InitialPopulation: 'Doe' in Patient.name.family.value";
 
         Measure measure = cohort_measure();
 
@@ -124,8 +124,8 @@ class Dstu3MeasureEvaluationTest extends BaseMeasureEvaluationTest {
                 .thenReturn(Arrays.asList(patient));
 
         String cql = cql_with_dateTime() + sde_race()
-                + "define InitialPopulation: 'Doe' in Patient.name.family\n"
-                + "define Denominator: 'John' in Patient.name.given\n"
+                + "define InitialPopulation: 'Doe' in Patient.name.family.value\n"
+                + "define Denominator: 'John' in Patient.name.given.value\n"
                 + "define Numerator: Patient.birthDate > @1970-01-01\n";
 
         Measure measure = proportion_measure();
@@ -155,7 +155,7 @@ class Dstu3MeasureEvaluationTest extends BaseMeasureEvaluationTest {
                 .thenReturn(Arrays.asList(patient));
 
         String cql = cql_with_dateTime() + sde_race()
-                + "define InitialPopulation: 'Doe' in Patient.name.family\n"
+                + "define InitialPopulation: 'Doe' in Patient.name.family.value\n"
                 + "define MeasurePopulation: Patient.birthDate > @1970-01-01\n";
 
         Measure measure = continuous_variable_measure();
@@ -211,8 +211,8 @@ class Dstu3MeasureEvaluationTest extends BaseMeasureEvaluationTest {
                 .thenReturn(Arrays.asList(jane_doe()));
 
         String cql = cql_with_dateTime() + sde_race()
-                + "define InitialPopulation: 'Doe' in Patient.name.family\n"
-                + "define Denominator: 'John' in Patient.name.given\n"
+                + "define InitialPopulation: 'Doe' in Patient.name.family.value\n"
+                + "define Denominator: 'John' in Patient.name.given.value\n"
                 + "define Numerator: Patient.birthDate > @1970-01-01\n" + "define Gender: Patient.gender\n";
 
         Measure measure = stratified_measure();

--- a/cqf-fhir-jackson/pom.xml
+++ b/cqf-fhir-jackson/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-jackson</artifactId>
-  <version>3.12.0-SNAPSHOT</version>
+  <version>3.12.0</version>
   <packaging>pom</packaging>
   <name>FHIR Clinical Reasoning (Jackson)</name>
   <description>Aggregator module for Jackson dependencies</description>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.12.0-SNAPSHOT</version>
+    <version>3.12.0</version>
   </parent>
 
   <dependencies>

--- a/cqf-fhir-jaxb/pom.xml
+++ b/cqf-fhir-jaxb/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-jaxb</artifactId>
-  <version>3.12.0-SNAPSHOT</version>
+  <version>3.12.0</version>
   <packaging>pom</packaging>
   <name>FHIR Clinical Reasoning (JAXB)</name>
   <description>Aggregator module for JAXB dependencies</description>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.12.0-SNAPSHOT</version>
+    <version>3.12.0</version>
   </parent>
 
   <dependencies>

--- a/cqf-fhir-test/pom.xml
+++ b/cqf-fhir-test/pom.xml
@@ -5,21 +5,21 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-test</artifactId>
-  <version>3.12.0-SNAPSHOT</version>
+  <version>3.12.0</version>
   <name>FHIR Clinical Reasoning (Test Utilities)</name>
   <description>Utilities to support unit testing clinical reasoning operations</description>
 
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.12.0-SNAPSHOT</version>
+    <version>3.12.0</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.12.0-SNAPSHOT</version>
+      <version>3.12.0</version>
     </dependency>
     <dependency>
         <groupId>ca.uhn.hapi.fhir</groupId>

--- a/cqf-fhir-utility/pom.xml
+++ b/cqf-fhir-utility/pom.xml
@@ -5,21 +5,21 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>cqf-fhir-utility</artifactId>
-  <version>3.12.0-SNAPSHOT</version>
+  <version>3.12.0</version>
   <name>FHIR Clinical Reasoning (Utilities)</name>
   <description>Utilities to help develop clinical reasoning operations</description>
 
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.12.0-SNAPSHOT</version>
+    <version>3.12.0</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-api</artifactId>
-      <version>3.12.0-SNAPSHOT</version>
+      <version>3.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.opencds.cqf.fhir</groupId>
       <artifactId>cqf-fhir-test</artifactId>
-      <version>3.12.0-SNAPSHOT</version>
+      <version>3.12.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencds.cqf.fhir</groupId>
   <artifactId>docs</artifactId>
-  <version>3.12.0-SNAPSHOT</version>
+  <version>3.12.0</version>
 
   <name>FHIR Clinical Reasoning (Documentation)</name>
   <description>Documentation website for FHIR Clinical Reasoning</description>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.12.0-SNAPSHOT</version>
+    <version>3.12.0</version>
   </parent>
 
   <dependencyManagement>
@@ -23,7 +23,7 @@
         <artifactId>cqf-fhir-bom</artifactId>
         <type>pom</type>
         <scope>import</scope>
-        <version>3.12.0-SNAPSHOT</version>
+        <version>3.12.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.opencds.cqf.fhir</groupId>
     <artifactId>cqf-fhir</artifactId>
-    <version>3.12.0-SNAPSHOT</version>
+    <version>3.12.0</version>
     <packaging>pom</packaging>
     <name>FHIR Clinical Reasoning</name>
     <description>FHIR Clinical Reasoning Implementations</description>
@@ -20,10 +20,10 @@
 
         <junit.version>5.9.1</junit.version>
         <slf4j.version>2.0.4</slf4j.version>
-        <cql.version>3.15.0</cql.version>
+        <cql.version>3.16.0</cql.version>
         <jmh.version>1.36</jmh.version>
         <spring.version>5.3.39</spring.version>
-        <hapi.version>7.4.0</hapi.version>
+        <hapi.version>7.4.2</hapi.version>
         <picocli.version>4.6.1</picocli.version>
         <guava.version>32.1.2-jre</guava.version>
         <error-prone.version>2.24.1</error-prone.version>


### PR DESCRIPTION
* Update to version 3.12.0
* Update to latest HAPI/CQL
* Fix failing tests
  * The latest CQL compile is more strict about function resolution. This breaks the implicit conversions specified in older versions of FHIRHelpers used for FHIR DSTU3 support.