### PR TITLE
Move transactionStub to transaction implementation for repository

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
         "activitydefinition",
         "aggregatable",
         "ANCDT",
+        "APIKEY",
         "Appender",
         "argfile",
         "aslp",
@@ -14,6 +15,7 @@
         "CODEABLECONCEPT",
         "CODESYSTEM",
         "codesystems",
+        "COMPOSEDOF",
         "Configurer",
         "connectathon",
         "CONTINUOUSVARIABLE",
@@ -27,6 +29,7 @@
         "DERIVEDFROM",
         "Dischargedon",
         "dstu",
+        "ecqm",
         "Eithers",
         "ersd",
         "Fhir",
@@ -66,6 +69,7 @@
         "qicore",
         "questionnaireitem",
         "questionnaireresponse",
+        "rctc",
         "RESOURCETYPE",
         "rethrown",
         "sdes",
@@ -83,7 +87,8 @@
         "uscore",
         "VALUESET",
         "valuesets",
-        "Versionless"
+        "Versionless",
+        "VSAC"
     ],
     "cSpell.enabledLanguageIds": [
         "java",

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/repository/InMemoryFhirRepository.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/repository/InMemoryFhirRepository.java
@@ -33,7 +33,6 @@ import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.utility.BundleHelper;
 import org.opencds.cqf.fhir.utility.Canonicals;
 import org.opencds.cqf.fhir.utility.Ids;
-import org.opencds.cqf.fhir.utility.SearchHelper;
 import org.opencds.cqf.fhir.utility.operation.OperationRegistry;
 
 public class InMemoryFhirRepository implements Repository {
@@ -205,23 +204,20 @@ public class InMemoryFhirRepository implements Repository {
 
     @Override
     public <B extends IBaseBundle> B transaction(B transaction, Map<String, String> headers) {
-        throw new NotImplementedOperationException("The transaction operation is not currently supported");
-    }
-
-    @SuppressWarnings("unchecked")
-    public static <B extends IBaseBundle> B transactionStub(B transaction, Repository repository) {
         var version = transaction.getStructureFhirVersionEnum();
+
+        @SuppressWarnings("unchecked")
         var returnBundle = (B) newBundle(version);
         BundleHelper.getEntry(transaction).forEach(e -> {
             if (BundleHelper.isEntryRequestPut(version, e)) {
-                var outcome = repository.update(BundleHelper.getEntryResource(version, e));
+                var outcome = this.update(BundleHelper.getEntryResource(version, e));
                 var location = outcome.getId().getValue();
                 BundleHelper.addEntry(
                         returnBundle,
                         BundleHelper.newEntryWithResponse(
                                 version, BundleHelper.newResponseWithLocation(version, location)));
             } else if (BundleHelper.isEntryRequestPost(version, e)) {
-                var outcome = repository.create(BundleHelper.getEntryResource(version, e));
+                var outcome = this.create(BundleHelper.getEntryResource(version, e));
                 var location = outcome.getId().getValue();
                 BundleHelper.addEntry(
                         returnBundle,
@@ -231,8 +227,9 @@ public class InMemoryFhirRepository implements Repository {
                 if (BundleHelper.getEntryRequestId(version, e).isPresent()) {
                     var resourceType = Canonicals.getResourceType(
                             ((BundleEntryComponent) e).getRequest().getUrl());
-                    var resourceClass = SearchHelper.getResourceClass(repository, resourceType);
-                    var res = repository.delete(
+                    var resourceClass =
+                            this.context.getResourceDefinition(resourceType).getImplementingClass();
+                    var res = this.delete(
                             resourceClass,
                             BundleHelper.getEntryRequestId(version, e).get().withResourceType(resourceType));
                     BundleHelper.addEntry(returnBundle, BundleHelper.newEntryWithResource(version, res.getResource()));
@@ -244,6 +241,7 @@ public class InMemoryFhirRepository implements Repository {
                 throw new NotImplementedOperationException("Transaction stub only supports PUT, POST or DELETE");
             }
         });
+
         return returnBundle;
     }
 

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/ApproveVisitorTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/ApproveVisitorTest.java
@@ -4,9 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
 import static org.opencds.cqf.fhir.utility.dstu3.Parameters.parameters;
 import static org.opencds.cqf.fhir.utility.dstu3.Parameters.part;
 
@@ -30,8 +27,6 @@ import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.dstu3.model.UriType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.utility.adapter.LibraryAdapter;
 import org.opencds.cqf.fhir.utility.adapter.dstu3.AdapterFactory;
@@ -41,24 +36,15 @@ import org.opencds.cqf.fhir.utility.visitor.ApproveVisitor;
 
 class ApproveVisitorTest {
     private final FhirContext fhirContext = FhirContext.forDstu3Cached();
-    private Repository spyRepository;
+    private Repository repo;
     private final IParser jsonParser = fhirContext.newJsonParser();
 
     @BeforeEach
     void setup() {
         var lib = (Library)
                 jsonParser.parseResource(ReleaseVisitorTests.class.getResourceAsStream("Library-ersd-active.json"));
-        spyRepository = spy(new InMemoryFhirRepository(fhirContext));
-        spyRepository.update(lib);
-        doAnswer(new Answer<Bundle>() {
-                    @Override
-                    public Bundle answer(InvocationOnMock a) throws Throwable {
-                        Bundle b = a.getArgument(0);
-                        return InMemoryFhirRepository.transactionStub(b, spyRepository);
-                    }
-                })
-                .when(spyRepository)
-                .transaction(any());
+        repo = new InMemoryFhirRepository(fhirContext);
+        repo.update(lib);
     }
 
     @Test
@@ -67,13 +53,12 @@ class ApproveVisitorTest {
         var params = parameters(part("artifactAssessmentTarget", new UriType(artifactAssessmentTarget)));
         UnprocessableEntityException maybeException = null;
         var releaseVisitor = new ApproveVisitor();
-        var lib = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        var lib = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         var libraryAdapter = new AdapterFactory().createLibrary(lib);
 
         try {
-            libraryAdapter.accept(releaseVisitor, spyRepository, params);
+            libraryAdapter.accept(releaseVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             maybeException = e;
         }
@@ -83,7 +68,7 @@ class ApproveVisitorTest {
         artifactAssessmentTarget = "http://hl7.org/fhir/us/ecr/Library/SpecificationLibrary|this-version-is-wrong";
         params = parameters(part("artifactAssessmentTarget", new UriType(artifactAssessmentTarget)));
         try {
-            libraryAdapter.accept(releaseVisitor, spyRepository, params);
+            libraryAdapter.accept(releaseVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             maybeException = e;
         }
@@ -97,13 +82,12 @@ class ApproveVisitorTest {
         Parameters params = parameters(part("artifactAssessmentType", new CodeType(artifactAssessmentType)));
         UnprocessableEntityException maybeException = null;
         ApproveVisitor releaseVisitor = new ApproveVisitor();
-        Library lib = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library lib = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(lib);
 
         try {
-            libraryAdapter.accept(releaseVisitor, spyRepository, params);
+            libraryAdapter.accept(releaseVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             maybeException = e;
         }
@@ -114,7 +98,7 @@ class ApproveVisitorTest {
     void approveOperation_test() {
         var practitioner = (Practitioner)
                 jsonParser.parseResource(ReleaseVisitorTests.class.getResourceAsStream("Practitioner-minimal.json"));
-        spyRepository.update(practitioner);
+        repo.update(practitioner);
         Date today = new Date();
         // get today's date in the form "2023-05-11"
         DateType approvalDate = new DateType(today, TemporalPrecisionEnum.DAY);
@@ -131,15 +115,13 @@ class ApproveVisitorTest {
                 part("artifactAssessmentRelatedArtifact", new UriType(artifactAssessmentRelatedArtifact)),
                 part("artifactAssessmentAuthor", new Reference(artifactAssessmentAuthor)));
         ApproveVisitor approveVisitor = new ApproveVisitor();
-        Library lib = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library lib = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(lib);
-        Bundle returnedResource = (Bundle) libraryAdapter.accept(approveVisitor, spyRepository, params);
+        Bundle returnedResource = (Bundle) libraryAdapter.accept(approveVisitor, repo, params);
 
         assertNotNull(returnedResource);
-        Library approvedLibrary = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library approvedLibrary = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         assertNotNull(approvedLibrary);
         // Ensure Approval Date matches input parameter
@@ -152,7 +134,7 @@ class ApproveVisitorTest {
                 .filter(entry -> entry.getResponse().getLocation().contains("Basic"))
                 .findAny();
         assertTrue(maybeArtifactAssessment.isPresent());
-        var basic = spyRepository.read(
+        var basic = repo.read(
                 Basic.class,
                 new IdType(maybeArtifactAssessment.get().getResponse().getLocation()));
         ArtifactAssessment artifactAssessment = new ArtifactAssessment();

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/PackageVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/PackageVisitorTests.java
@@ -4,9 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
 import static org.opencds.cqf.fhir.utility.dstu3.Parameters.parameters;
 import static org.opencds.cqf.fhir.utility.dstu3.Parameters.part;
 
@@ -38,8 +35,6 @@ import org.hl7.fhir.dstu3.model.ValueSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.adapter.LibraryAdapter;
@@ -50,35 +45,25 @@ import org.opencds.cqf.fhir.utility.visitor.PackageVisitor;
 class PackageVisitorTests {
     private final FhirContext fhirContext = FhirContext.forDstu3Cached();
     private final IParser jsonParser = fhirContext.newJsonParser();
-    private Repository spyRepository;
+    private Repository repo;
 
     @BeforeEach
     void setup() {
-        spyRepository = spy(new InMemoryFhirRepository(fhirContext));
-        doAnswer(new Answer<Bundle>() {
-                    @Override
-                    public Bundle answer(InvocationOnMock a) throws Throwable {
-                        Bundle b = a.getArgument(0);
-                        return InMemoryFhirRepository.transactionStub(b, spyRepository);
-                    }
-                })
-                .when(spyRepository)
-                .transaction(any());
+        repo = new InMemoryFhirRepository(fhirContext);
     }
 
     @Test
     void visitLibraryTest() {
         Bundle loadedBundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example-naive.json"));
-        spyRepository.transaction(loadedBundle);
+        repo.transaction(loadedBundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
 
-        Bundle packagedBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, params);
+        Bundle packagedBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, params);
         assertNotNull(packagedBundle);
         assertEquals(packagedBundle.getEntry().size(), loadedBundle.getEntry().size());
 
@@ -103,17 +88,16 @@ class PackageVisitorTests {
     void packageOperation_should_fail_no_credentials() {
         Bundle loadedBundle = (Bundle)
                 jsonParser.parseResource(PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
-        spyRepository.transaction(loadedBundle);
+        repo.transaction(loadedBundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
 
         UnprocessableEntityException maybeException = null;
         try {
-            libraryAdapter.accept(packageVisitor, spyRepository, params);
+            libraryAdapter.accept(packageVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             maybeException = e;
         }
@@ -125,10 +109,9 @@ class PackageVisitorTests {
     void packageOperation_should_fail_credentials_missing_username() {
         Bundle loadedBundle = (Bundle)
                 jsonParser.parseResource(PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
-        spyRepository.transaction(loadedBundle);
+        repo.transaction(loadedBundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
@@ -139,7 +122,7 @@ class PackageVisitorTests {
 
         UnprocessableEntityException maybeException = null;
         try {
-            libraryAdapter.accept(packageVisitor, spyRepository, params);
+            libraryAdapter.accept(packageVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             maybeException = e;
         }
@@ -151,10 +134,9 @@ class PackageVisitorTests {
     void packageOperation_should_fail_credentials_missing_apikey() {
         Bundle loadedBundle = (Bundle)
                 jsonParser.parseResource(PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
-        spyRepository.transaction(loadedBundle);
+        repo.transaction(loadedBundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
@@ -165,7 +147,7 @@ class PackageVisitorTests {
 
         UnprocessableEntityException maybeException = null;
         try {
-            libraryAdapter.accept(packageVisitor, spyRepository, params);
+            libraryAdapter.accept(packageVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             maybeException = e;
         }
@@ -177,10 +159,9 @@ class PackageVisitorTests {
     void packageOperation_should_fail_credentials_invalid() {
         Bundle loadedBundle = (Bundle)
                 jsonParser.parseResource(PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
-        spyRepository.transaction(loadedBundle);
+        repo.transaction(loadedBundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
@@ -191,7 +172,7 @@ class PackageVisitorTests {
 
         UnprocessableEntityException maybeException = null;
         try {
-            libraryAdapter.accept(packageVisitor, spyRepository, params);
+            libraryAdapter.accept(packageVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             maybeException = e;
         }
@@ -203,11 +184,10 @@ class PackageVisitorTests {
     void packageOperation_should_fail_non_matching_capability() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-package-capabilities.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         List<String> capabilities = Arrays.asList("computable", "publishable", "executable");
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         // the library contains all three capabilities
@@ -217,7 +197,7 @@ class PackageVisitorTests {
             Parameters params = parameters(part("capability", capability));
             PreconditionFailedException maybeException = null;
             try {
-                libraryAdapter.accept(packageVisitor, spyRepository, params);
+                libraryAdapter.accept(packageVisitor, repo, params);
             } catch (PreconditionFailedException e) {
                 maybeException = e;
             }
@@ -225,7 +205,7 @@ class PackageVisitorTests {
         }
         Parameters allParams = parameters(
                 part("capability", "computable"), part("capability", "publishable"), part("capability", "executable"));
-        Bundle packaged = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, allParams);
+        Bundle packaged = (Bundle) libraryAdapter.accept(packageVisitor, repo, allParams);
 
         // no error when running the operation with all
         // three capabilities
@@ -236,10 +216,9 @@ class PackageVisitorTests {
     void packageOperation_should_apply_check_force_canonicalVersions() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-active-no-versions.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         String versionToUpdateTo = "1.3.1.23";
@@ -251,7 +230,7 @@ class PackageVisitorTests {
                 part(
                         "artifactVersion",
                         new UriType("http://to-add-missing-version/ValueSet/dxtc|" + versionToUpdateTo)));
-        Bundle updatedCanonicalVersionPackage = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, params);
+        Bundle updatedCanonicalVersionPackage = (Bundle) libraryAdapter.accept(packageVisitor, repo, params);
 
         List<MetadataResource> updatedResources = updatedCanonicalVersionPackage.getEntry().stream()
                 .map(entry -> (MetadataResource) entry.getResource())
@@ -266,7 +245,7 @@ class PackageVisitorTests {
         String correctCheckVersion = "2022-10-19";
         PreconditionFailedException checkCanonicalThrewError = null;
         try {
-            libraryAdapter.accept(packageVisitor, spyRepository, params);
+            libraryAdapter.accept(packageVisitor, repo, params);
         } catch (PreconditionFailedException e) {
             checkCanonicalThrewError = e;
         }
@@ -274,7 +253,7 @@ class PackageVisitorTests {
         params = parameters(part(
                 "checkArtifactVersion",
                 new UriType("http://to-check-version/Library/SpecificationLibrary|" + correctCheckVersion)));
-        Bundle noErrorCheckCanonicalPackage = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, params);
+        Bundle noErrorCheckCanonicalPackage = (Bundle) libraryAdapter.accept(packageVisitor, repo, params);
         Optional<MetadataResource> checkedVersionResource = noErrorCheckCanonicalPackage.getEntry().stream()
                 .map(entry -> (MetadataResource) entry.getResource())
                 .filter(resource -> resource.getUrl().contains("to-check-version"))
@@ -284,7 +263,7 @@ class PackageVisitorTests {
         String versionToForceTo = "1.1.9.23";
         params = parameters(
                 part("forceArtifactVersion", new UriType("http://to-force-version/Library/rctc|" + versionToForceTo)));
-        Bundle forcedVersionPackage = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, params);
+        Bundle forcedVersionPackage = (Bundle) libraryAdapter.accept(packageVisitor, repo, params);
         Optional<MetadataResource> forcedVersionResource = forcedVersionPackage.getEntry().stream()
                 .map(entry -> (MetadataResource) entry.getResource())
                 .filter(resource -> resource.getUrl().contains("to-force-version"))
@@ -297,37 +276,36 @@ class PackageVisitorTests {
     void packageOperation_should_respect_count_offset() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters countZeroParams = parameters(part("count", new IntegerType(0)));
-        Bundle countZeroBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, countZeroParams);
+        Bundle countZeroBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, countZeroParams);
         // when count = 0 only show the total
         assertEquals(0, countZeroBundle.getEntry().size());
         assertEquals(6, countZeroBundle.getTotal());
         Parameters count2Params = parameters(part("count", new IntegerType(2)));
-        Bundle count2Bundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, count2Params);
+        Bundle count2Bundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, count2Params);
         assertEquals(2, count2Bundle.getEntry().size());
         Parameters count2Offset2Params =
                 parameters(part("count", new IntegerType(2)), part("offset", new IntegerType(2)));
-        Bundle count2Offset2Bundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, count2Offset2Params);
+        Bundle count2Offset2Bundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, count2Offset2Params);
         assertEquals(2, count2Offset2Bundle.getEntry().size());
         Parameters offset4Params = parameters(part("offset", new IntegerType(4)));
-        Bundle offset4Bundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, offset4Params);
+        Bundle offset4Bundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, offset4Params);
         assertEquals(offset4Bundle.getEntry().size(), (countZeroBundle.getTotal() - 4));
         assertTrue(offset4Bundle.getType() == BundleType.COLLECTION);
         assertFalse(offset4Bundle.hasTotal());
         Parameters offsetMaxParams = parameters(part("offset", new IntegerType(countZeroBundle.getTotal())));
-        Bundle offsetMaxBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, offsetMaxParams);
+        Bundle offsetMaxBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, offsetMaxParams);
         assertEquals(0, offsetMaxBundle.getEntry().size());
         Parameters offsetMaxRandomCountParams = parameters(
                 part("offset", new IntegerType(countZeroBundle.getTotal())),
                 part("count", new IntegerType(ThreadLocalRandom.current().nextInt(3, 20))));
         Bundle offsetMaxRandomCountBundle =
-                (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, offsetMaxRandomCountParams);
+                (Bundle) libraryAdapter.accept(packageVisitor, repo, offsetMaxRandomCountParams);
         assertEquals(0, offsetMaxRandomCountBundle.getEntry().size());
     }
 
@@ -335,26 +313,25 @@ class PackageVisitorTests {
     void packageOperation_different_bundle_types() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters countZeroParams = parameters(part("count", new IntegerType(0)));
-        Bundle countZeroBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, countZeroParams);
+        Bundle countZeroBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, countZeroParams);
         assertTrue(countZeroBundle.getType() == BundleType.SEARCHSET);
         Parameters countSevenParams = parameters(part("count", new IntegerType(7)));
-        Bundle countSevenBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, countSevenParams);
+        Bundle countSevenBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, countSevenParams);
         assertTrue(countSevenBundle.getType() == BundleType.TRANSACTION);
         Parameters countFourParams = parameters(part("count", new IntegerType(4)));
-        Bundle countFourBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, countFourParams);
+        Bundle countFourBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, countFourParams);
         assertTrue(countFourBundle.getType() == BundleType.COLLECTION);
         // these assertions test for Bundle base profile conformance when type = collection
         assertFalse(countFourBundle.getEntry().stream().anyMatch(entry -> entry.hasRequest()));
         assertFalse(countFourBundle.hasTotal());
         Parameters offsetOneParams = parameters(part("offset", new IntegerType(1)));
-        Bundle offsetOneBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, offsetOneParams);
+        Bundle offsetOneBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, offsetOneParams);
         assertTrue(offsetOneBundle.getType() == BundleType.COLLECTION);
         // these assertions test for Bundle base profile conformance when type = collection
         assertFalse(offsetOneBundle.getEntry().stream().anyMatch(entry -> entry.hasRequest()));
@@ -362,8 +339,7 @@ class PackageVisitorTests {
 
         Parameters countOneOffsetOneParams =
                 parameters(part("count", new IntegerType(1)), part("offset", new IntegerType(1)));
-        Bundle countOneOffsetOneBundle =
-                (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, countOneOffsetOneParams);
+        Bundle countOneOffsetOneBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, countOneOffsetOneParams);
         assertTrue(countOneOffsetOneBundle.getType() == BundleType.COLLECTION);
         // these assertions test for Bundle base profile conformance when type = collection
         assertFalse(countOneOffsetOneBundle.getEntry().stream().anyMatch(entry -> entry.hasRequest()));
@@ -374,14 +350,13 @@ class PackageVisitorTests {
     void packageOperation_should_conditionally_create() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters emptyParams = parameters();
-        Bundle packagedBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, emptyParams);
+        Bundle packagedBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, emptyParams);
         for (BundleEntryComponent component : packagedBundle.getEntry()) {
             String ifNoneExist = component.getRequest().getIfNoneExist();
             String url = ((MetadataResource) component.getResource()).getUrl();
@@ -394,10 +369,9 @@ class PackageVisitorTests {
     void packageOperation_should_respect_include() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Map<String, List<String>> includeOptions = new HashMap<String, List<String>>();
@@ -430,7 +404,7 @@ class PackageVisitorTests {
         includeOptions.put("examples", Arrays.asList());
         for (Entry<String, List<String>> includedTypeURLs : includeOptions.entrySet()) {
             Parameters params = parameters(part("include", includedTypeURLs.getKey()));
-            Bundle packaged = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, params);
+            Bundle packaged = (Bundle) libraryAdapter.accept(packageVisitor, repo, params);
             List<MetadataResource> resources = packaged.getEntry().stream()
                     .map(entry -> (MetadataResource) entry.getResource())
                     .collect(Collectors.toList());

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/ReleaseVisitorTests.java
@@ -3,9 +3,6 @@ package org.opencds.cqf.fhir.utility.visitor.dstu3;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
 import static org.opencds.cqf.fhir.utility.dstu3.Parameters.parameters;
 import static org.opencds.cqf.fhir.utility.dstu3.Parameters.part;
 
@@ -41,8 +38,6 @@ import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.utility.Canonicals;
 import org.opencds.cqf.fhir.utility.Constants;
@@ -57,7 +52,7 @@ import org.slf4j.event.Level;
 
 class ReleaseVisitorTests {
     private final FhirContext fhirContext = FhirContext.forDstu3Cached();
-    private Repository spyRepository;
+    private Repository repo;
     private final IParser jsonParser = fhirContext.newJsonParser();
     private final List<String> badVersionList = Arrays.asList(
             "11asd1",
@@ -81,26 +76,16 @@ class ReleaseVisitorTests {
     void setup() {
         SearchParameter sp = (SearchParameter) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("SearchParameter-artifactAssessment.json"));
-        spyRepository = spy(new InMemoryFhirRepository(fhirContext));
-        spyRepository.update(sp);
-        doAnswer(new Answer<Bundle>() {
-                    @Override
-                    public Bundle answer(InvocationOnMock a) throws Throwable {
-                        Bundle b = a.getArgument(0);
-                        return InMemoryFhirRepository.transactionStub(b, spyRepository);
-                    }
-                })
-                .when(spyRepository)
-                .transaction(any());
+        repo = new InMemoryFhirRepository(fhirContext);
+        repo.update(sp);
     }
 
     @Test
     void visitMeasureCollectionTest() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ecqm-qicore-2024-simplified.json"));
-        spyRepository.transaction(bundle);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
+        repo.transaction(bundle);
+        Library library = repo.read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
                 .copy();
 
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
@@ -114,14 +99,14 @@ class ReleaseVisitorTests {
         // Approval date is required to release an artifact
         library.setApprovalDateElement(new DateType("2024-04-23"));
         // Set the ID to Manifest-Release
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        Library releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         var dependenciesOnReleasedArtifact = releasedLibrary.getRelatedArtifact().stream()
                 .filter(ra -> ra.getType().equals(RelatedArtifact.RelatedArtifactType.DEPENDSON))
                 .collect(Collectors.toList());
@@ -175,14 +160,12 @@ class ReleaseVisitorTests {
     void visitMeasureEffectiveDataRequirementsTest() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ecqm-qicore-2024-simplified.json"));
-        spyRepository.transaction(bundle);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
+        repo.transaction(bundle);
+        Library library = repo.read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
                 .copy();
         Measure CervicalCancerScreeningFHIR =
-                spyRepository.read(Measure.class, new IdType("Measure/CervicalCancerScreeningFHIR"));
-        Measure BreastCancerScreeningFHIR =
-                spyRepository.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
+                repo.read(Measure.class, new IdType("Measure/CervicalCancerScreeningFHIR"));
+        Measure BreastCancerScreeningFHIR = repo.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
         var versionParam = params.addParameter();
@@ -195,18 +178,18 @@ class ReleaseVisitorTests {
         library.setApprovalDateElement(new DateType("2024-04-23"));
         // removing the effectiveDataRequirements changes the dependency count
         CervicalCancerScreeningFHIR.setContained(null);
-        spyRepository.update(CervicalCancerScreeningFHIR);
+        repo.update(CervicalCancerScreeningFHIR);
         BreastCancerScreeningFHIR.setContained(null);
-        spyRepository.update(BreastCancerScreeningFHIR);
+        repo.update(BreastCancerScreeningFHIR);
 
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        Library releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         var dependenciesOnReleasedArtifact = releasedLibrary.getRelatedArtifact().stream()
                 .filter(ra -> ra.getType().equals(RelatedArtifact.RelatedArtifactType.DEPENDSON))
                 .collect(Collectors.toList());
@@ -222,14 +205,12 @@ class ReleaseVisitorTests {
     void bothCRMIandCQFMEffectiveDataRequirementsTest() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ecqm-qicore-2024-simplified.json"));
-        spyRepository.transaction(bundle);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
+        repo.transaction(bundle);
+        Library library = repo.read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
                 .copy();
         Measure CervicalCancerScreeningFHIR =
-                spyRepository.read(Measure.class, new IdType("Measure/CervicalCancerScreeningFHIR"));
-        Measure BreastCancerScreeningFHIR =
-                spyRepository.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
+                repo.read(Measure.class, new IdType("Measure/CervicalCancerScreeningFHIR"));
+        Measure BreastCancerScreeningFHIR = repo.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
         params.addParameter().setName("version").setValue(new StringType("1.0.0"));
@@ -251,17 +232,17 @@ class ReleaseVisitorTests {
         crmiEDRBreastCancer.setId(crmiEDRId);
         BreastCancerScreeningFHIR.addContained(crmiEDRBreastCancer);
         BreastCancerScreeningFHIR.addExtension(crmiEDRExtension);
-        spyRepository.update(CervicalCancerScreeningFHIR);
-        spyRepository.update(BreastCancerScreeningFHIR);
+        repo.update(CervicalCancerScreeningFHIR);
+        repo.update(BreastCancerScreeningFHIR);
 
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        Library releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         var dependenciesOnReleasedArtifact = releasedLibrary.getRelatedArtifact().stream()
                 .filter(ra -> ra.getType().equals(RelatedArtifact.RelatedArtifactType.DEPENDSON))
                 .collect(Collectors.toList());
@@ -278,10 +259,9 @@ class ReleaseVisitorTests {
     void visitLibraryTest() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ersd-release-bundle.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/ReleaseSpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/ReleaseSpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         String version = "1.0.1";
@@ -292,14 +272,14 @@ class ReleaseVisitorTests {
         var versionBehaviorParam = params.addParameter();
         versionBehaviorParam.setName("versionBehavior").setValue(new CodeType("default"));
 
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        Library releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         // versionBehaviour == 'default' so version should be
         // existingVersion and not the new version provided in
         // the parameters
@@ -402,26 +382,25 @@ class ReleaseVisitorTests {
     void releaseResource_force_version() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         // Existing version should be "1.2.3";
         String newVersionToForce = "1.2.7";
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = parameters(
                 part("version", new StringType(newVersionToForce)), part("versionBehavior", new CodeType("force")));
 
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
 
         assertNotNull(returnResource);
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library/SpecificationLibrary"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        Library releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         assertEquals(releasedLibrary.getVersion(), newVersionToForce);
     }
 
@@ -430,11 +409,11 @@ class ReleaseVisitorTests {
         // SpecificationLibrary - root is experimental but HAS experimental children
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft-experimental.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         // SpecificationLibrary2 - root is NOT experimental but HAS experimental children
         Bundle bundle2 = (Bundle) jsonParser.parseResource(ReleaseVisitorTests.class.getResourceAsStream(
                 "Bundle-small-approved-draft-experimental-children.json"));
-        spyRepository.transaction(bundle2);
+        repo.transaction(bundle2);
         Parameters params = parameters(
                 part("version", new StringType("1.2.3")),
                 part("versionBehavior", new CodeType("default")),
@@ -442,24 +421,22 @@ class ReleaseVisitorTests {
         Exception notExpectingAnyException = null;
         // no Exception if root is experimental
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         try {
-            libraryAdapter.accept(releaseVisitor, spyRepository, params);
+            libraryAdapter.accept(releaseVisitor, repo, params);
         } catch (Exception e) {
             notExpectingAnyException = e;
         }
         assertTrue(notExpectingAnyException == null);
 
         UnprocessableEntityException nonExperimentalChildException = null;
-        Library library2 = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary2"))
+        Library library2 = repo.read(Library.class, new IdType("Library/SpecificationLibrary2"))
                 .copy();
         LibraryAdapter libraryAdapter2 = new AdapterFactory().createLibrary(library2);
         try {
-            libraryAdapter2.accept(releaseVisitor, spyRepository, params);
+            libraryAdapter2.accept(releaseVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             nonExperimentalChildException = e;
         }
@@ -472,18 +449,16 @@ class ReleaseVisitorTests {
         // SpecificationLibrary - root is experimental but HAS experimental children
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft-experimental.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         // SpecificationLibrary2 - root is NOT experimental but HAS experimental children
         Bundle bundle2 = (Bundle) jsonParser.parseResource(ReleaseVisitorTests.class.getResourceAsStream(
                 "Bundle-small-approved-draft-experimental-children.json"));
-        spyRepository.transaction(bundle2);
+        repo.transaction(bundle2);
 
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
-        Library library2 = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary2"))
+        Library library2 = repo.read(Library.class, new IdType("Library/SpecificationLibrary2"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         LibraryAdapter libraryAdapter2 = new AdapterFactory().createLibrary(library2);
@@ -496,11 +471,11 @@ class ReleaseVisitorTests {
         var logger = TestLoggerFactory.getTestLogger(ReleaseVisitor.class);
         logger.clear();
 
-        libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        libraryAdapter.accept(releaseVisitor, repo, params);
         // no warning if the root is Experimental
         assertEquals(0, logger.getLoggingEvents().size());
 
-        libraryAdapter2.accept(releaseVisitor, spyRepository, params);
+        libraryAdapter2.accept(releaseVisitor, repo, params);
 
         var warningMessages = logger.getLoggingEvents().stream()
                 .filter(event -> event.getLevel().equals(Level.WARN))
@@ -519,17 +494,16 @@ class ReleaseVisitorTests {
     void releaseResource_propagate_effective_period() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ersd-no-child-effective-period.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         String effectivePeriodToPropagate = "2020-12-11";
 
         Parameters params =
                 parameters(part("version", new StringType("1.2.7")), part("versionBehavior", new CodeType("default")));
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);
         MetadataResourceHelper.forEachMetadataResource(
                 returnResource.getEntry(),
@@ -548,14 +522,14 @@ class ReleaseVisitorTests {
                         assertEquals(startString, effectivePeriodToPropagate);
                     }
                 },
-                spyRepository);
+                repo);
     }
 
     @Test
     void releaseResource_latestFromTx_NotSupported_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
 
         String actualErrorMessage = "";
 
@@ -564,13 +538,12 @@ class ReleaseVisitorTests {
                 part("versionBehavior", new CodeType("default")),
                 part("latestFromTxServer", new BooleanType(true)));
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
 
         try {
-            libraryAdapter.accept(releaseVisitor, spyRepository, params);
+            libraryAdapter.accept(releaseVisitor, repo, params);
         } catch (Exception e) {
             actualErrorMessage = e.getMessage();
         }
@@ -581,19 +554,18 @@ class ReleaseVisitorTests {
     void release_missing_approvalDate_validation_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-release-missing-approvalDate.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
 
         String versionData = "1.2.3";
         String actualErrorMessage = "";
 
         Parameters params1 = parameters(part("version", versionData), part("versionBehavior", new CodeType("default")));
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/ReleaseSpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/ReleaseSpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         try {
-            libraryAdapter.accept(releaseVisitor, spyRepository, params1);
+            libraryAdapter.accept(releaseVisitor, repo, params1);
         } catch (Exception e) {
             actualErrorMessage = e.getMessage();
         }
@@ -604,10 +576,9 @@ class ReleaseVisitorTests {
     void release_version_format_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         for (String version : badVersionList) {
@@ -615,7 +586,7 @@ class ReleaseVisitorTests {
             Parameters params = parameters(
                     part("version", new StringType(version)), part("versionBehavior", new CodeType("force")));
             try {
-                libraryAdapter.accept(releaseVisitor, spyRepository, params);
+                libraryAdapter.accept(releaseVisitor, repo, params);
 
             } catch (UnprocessableEntityException e) {
                 maybeException = e;
@@ -628,25 +599,24 @@ class ReleaseVisitorTests {
     void release_releaseLabel_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         String releaseLabel = "release label test";
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = parameters(
                 part("releaseLabel", new StringType(releaseLabel)),
                 part("version", "1.2.3"),
                 part("versionBehavior", new CodeType("default")));
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
 
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library/SpecificationLibrary"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        Library releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         Optional<Extension> maybeReleaseLabel = releasedLibrary.getExtension().stream()
                 .filter(ext -> ext.getUrl().equals(KnowledgeArtifactAdapter.releaseLabelUrl))
                 .findFirst();
@@ -658,10 +628,9 @@ class ReleaseVisitorTests {
     void release_version_active_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
 
@@ -669,7 +638,7 @@ class ReleaseVisitorTests {
         Parameters params =
                 parameters(part("version", new StringType("1.2.3")), part("versionBehavior", new CodeType("force")));
         try {
-            libraryAdapter.accept(releaseVisitor, spyRepository, params);
+            libraryAdapter.accept(releaseVisitor, repo, params);
         } catch (PreconditionFailedException e) {
             maybeException = e;
         }
@@ -680,10 +649,9 @@ class ReleaseVisitorTests {
     void release_versionBehaviour_format_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         List<String> badVersionBehaviors = Arrays.asList("not-a-valid-option", null);
@@ -692,7 +660,7 @@ class ReleaseVisitorTests {
             Parameters params = parameters(
                     part("version", new StringType("1.2.3")), part("versionBehavior", new CodeType(versionBehaviour)));
             try {
-                libraryAdapter.accept(releaseVisitor, spyRepository, params);
+                libraryAdapter.accept(releaseVisitor, repo, params);
             } catch (FHIRException e) {
                 maybeException = e;
             } catch (UnprocessableEntityException e) {

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/ReleaseVisitorTests.java
@@ -163,9 +163,9 @@ class ReleaseVisitorTests {
         repo.transaction(bundle);
         Library library = repo.read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
                 .copy();
-        Measure CervicalCancerScreeningFHIR =
+        Measure cervicalCancerScreeningFHIR =
                 repo.read(Measure.class, new IdType("Measure/CervicalCancerScreeningFHIR"));
-        Measure BreastCancerScreeningFHIR = repo.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
+        Measure breastCancerScreeningFHIR = repo.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
         var versionParam = params.addParameter();
@@ -177,10 +177,10 @@ class ReleaseVisitorTests {
         // Approval date is required to release an artifact
         library.setApprovalDateElement(new DateType("2024-04-23"));
         // removing the effectiveDataRequirements changes the dependency count
-        CervicalCancerScreeningFHIR.setContained(null);
-        repo.update(CervicalCancerScreeningFHIR);
-        BreastCancerScreeningFHIR.setContained(null);
-        repo.update(BreastCancerScreeningFHIR);
+        cervicalCancerScreeningFHIR.setContained(null);
+        repo.update(cervicalCancerScreeningFHIR);
+        breastCancerScreeningFHIR.setContained(null);
+        repo.update(breastCancerScreeningFHIR);
 
         Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/ReleaseVisitorTests.java
@@ -208,9 +208,9 @@ class ReleaseVisitorTests {
         repo.transaction(bundle);
         Library library = repo.read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
                 .copy();
-        Measure CervicalCancerScreeningFHIR =
+        Measure cervicalCancerScreeningFHIR =
                 repo.read(Measure.class, new IdType("Measure/CervicalCancerScreeningFHIR"));
-        Measure BreastCancerScreeningFHIR = repo.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
+        Measure breastCancerScreeningFHIR = repo.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
         params.addParameter().setName("version").setValue(new StringType("1.0.0"));
@@ -223,17 +223,17 @@ class ReleaseVisitorTests {
         // Approval date is required to release an artifact
         library.setApprovalDateElement(new DateType("2024-04-23"));
         // if both cqfm and crmi effective data requirements are present then they will each be traced
-        var crmiEDRCervical = CervicalCancerScreeningFHIR.getContained().get(0).copy();
+        var crmiEDRCervical = cervicalCancerScreeningFHIR.getContained().get(0).copy();
         crmiEDRCervical.setId(crmiEDRId);
-        CervicalCancerScreeningFHIR.addContained(crmiEDRCervical);
-        CervicalCancerScreeningFHIR.addExtension(crmiEDRExtension);
+        cervicalCancerScreeningFHIR.addContained(crmiEDRCervical);
+        cervicalCancerScreeningFHIR.addExtension(crmiEDRExtension);
         var crmiEDRBreastCancer =
-                BreastCancerScreeningFHIR.getContained().get(0).copy();
+                breastCancerScreeningFHIR.getContained().get(0).copy();
         crmiEDRBreastCancer.setId(crmiEDRId);
-        BreastCancerScreeningFHIR.addContained(crmiEDRBreastCancer);
-        BreastCancerScreeningFHIR.addExtension(crmiEDRExtension);
-        repo.update(CervicalCancerScreeningFHIR);
-        repo.update(BreastCancerScreeningFHIR);
+        breastCancerScreeningFHIR.addContained(crmiEDRBreastCancer);
+        breastCancerScreeningFHIR.addExtension(crmiEDRExtension);
+        repo.update(cervicalCancerScreeningFHIR);
+        repo.update(breastCancerScreeningFHIR);
 
         Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/ApproveVisitorTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/ApproveVisitorTest.java
@@ -4,9 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
 import static org.opencds.cqf.fhir.utility.r4.Parameters.parameters;
 import static org.opencds.cqf.fhir.utility.r4.Parameters.part;
 
@@ -30,8 +27,6 @@ import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.Reference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.utility.adapter.LibraryAdapter;
 import org.opencds.cqf.fhir.utility.adapter.r4.AdapterFactory;
@@ -41,24 +36,15 @@ import org.opencds.cqf.fhir.utility.visitor.ApproveVisitor;
 
 class ApproveVisitorTest {
     private final FhirContext fhirContext = FhirContext.forR4Cached();
-    private Repository spyRepository;
+    private Repository repo;
     private final IParser jsonParser = fhirContext.newJsonParser();
 
     @BeforeEach
     void setup() {
         var lib = (Library)
                 jsonParser.parseResource(ReleaseVisitorTests.class.getResourceAsStream("Library-ersd-active.json"));
-        spyRepository = spy(new InMemoryFhirRepository(fhirContext));
-        spyRepository.update(lib);
-        doAnswer(new Answer<Bundle>() {
-                    @Override
-                    public Bundle answer(InvocationOnMock a) throws Throwable {
-                        Bundle b = a.getArgument(0);
-                        return InMemoryFhirRepository.transactionStub(b, spyRepository);
-                    }
-                })
-                .when(spyRepository)
-                .transaction(any());
+        repo = new InMemoryFhirRepository(fhirContext);
+        repo.update(lib);
     }
 
     @Test
@@ -67,13 +53,12 @@ class ApproveVisitorTest {
         var params = parameters(part("artifactAssessmentTarget", new CanonicalType(artifactAssessmentTarget)));
         UnprocessableEntityException maybeException = null;
         var releaseVisitor = new ApproveVisitor();
-        var lib = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        var lib = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         var libraryAdapter = new AdapterFactory().createLibrary(lib);
 
         try {
-            libraryAdapter.accept(releaseVisitor, spyRepository, params);
+            libraryAdapter.accept(releaseVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             maybeException = e;
         }
@@ -83,7 +68,7 @@ class ApproveVisitorTest {
         artifactAssessmentTarget = "http://hl7.org/fhir/us/ecr/Library/SpecificationLibrary|this-version-is-wrong";
         params = parameters(part("artifactAssessmentTarget", new CanonicalType(artifactAssessmentTarget)));
         try {
-            libraryAdapter.accept(releaseVisitor, spyRepository, params);
+            libraryAdapter.accept(releaseVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             maybeException = e;
         }
@@ -97,13 +82,12 @@ class ApproveVisitorTest {
         Parameters params = parameters(part("artifactAssessmentType", new CodeType(artifactAssessmentType)));
         UnprocessableEntityException maybeException = null;
         ApproveVisitor releaseVisitor = new ApproveVisitor();
-        Library lib = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library lib = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(lib);
 
         try {
-            libraryAdapter.accept(releaseVisitor, spyRepository, params);
+            libraryAdapter.accept(releaseVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             maybeException = e;
         }
@@ -114,7 +98,7 @@ class ApproveVisitorTest {
     void approveOperation_test() {
         var practitioner = (Practitioner)
                 jsonParser.parseResource(ReleaseVisitorTests.class.getResourceAsStream("Practitioner-minimal.json"));
-        spyRepository.update(practitioner);
+        repo.update(practitioner);
         Date today = new Date();
         // get today's date in the form "2023-05-11"
         DateType approvalDate = new DateType(today, TemporalPrecisionEnum.DAY);
@@ -131,15 +115,13 @@ class ApproveVisitorTest {
                 part("artifactAssessmentRelatedArtifact", new CanonicalType(artifactAssessmentRelatedArtifact)),
                 part("artifactAssessmentAuthor", new Reference(artifactAssessmentAuthor)));
         ApproveVisitor approveVisitor = new ApproveVisitor();
-        Library lib = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library lib = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(lib);
-        Bundle returnedResource = (Bundle) libraryAdapter.accept(approveVisitor, spyRepository, params);
+        Bundle returnedResource = (Bundle) libraryAdapter.accept(approveVisitor, repo, params);
 
         assertNotNull(returnedResource);
-        Library approvedLibrary = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library approvedLibrary = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         assertNotNull(approvedLibrary);
         // Ensure Approval Date matches input parameter
@@ -152,7 +134,7 @@ class ApproveVisitorTest {
                 .filter(entry -> entry.getResponse().getLocation().contains("Basic"))
                 .findAny();
         assertTrue(maybeArtifactAssessment.isPresent());
-        var basic = spyRepository.read(
+        var basic = repo.read(
                 Basic.class,
                 new IdType(maybeArtifactAssessment.get().getResponse().getLocation()));
         ArtifactAssessment artifactAssessment = new ArtifactAssessment();

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/DraftVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/DraftVisitorTests.java
@@ -4,12 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.notNull;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.opencds.cqf.fhir.utility.r4.Parameters.parameters;
 import static org.opencds.cqf.fhir.utility.r4.Parameters.part;
 
@@ -32,8 +26,6 @@ import org.hl7.fhir.r4.model.RelatedArtifact;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.utility.Canonicals;
 import org.opencds.cqf.fhir.utility.adapter.KnowledgeArtifactAdapter;
@@ -46,7 +38,7 @@ import org.opencds.cqf.fhir.utility.visitor.IKnowledgeArtifactVisitor;
 
 class DraftVisitorTests {
     private final FhirContext fhirContext = FhirContext.forR4Cached();
-    private Repository spyRepository;
+    private Repository repo;
     private final IParser jsonParser = fhirContext.newJsonParser();
     private final String specificationLibReference = "Library/SpecificationLibrary";
     private final List<String> badVersionList = Arrays.asList(
@@ -69,26 +61,16 @@ class DraftVisitorTests {
 
     @BeforeEach
     void setup() {
-        spyRepository = spy(new InMemoryFhirRepository(fhirContext));
-        doAnswer(new Answer<Bundle>() {
-                    @Override
-                    public Bundle answer(InvocationOnMock a) throws Throwable {
-                        Bundle b = a.getArgument(0);
-                        return InMemoryFhirRepository.transactionStub(b, spyRepository);
-                    }
-                })
-                .when(spyRepository)
-                .transaction(any());
+        repo = new InMemoryFhirRepository(fhirContext);
     }
 
     @Test
     void library_draft_test() {
         Bundle bundle = (Bundle)
                 jsonParser.parseResource(DraftVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         IKnowledgeArtifactVisitor draftVisitor = new DraftVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         String version = "1.0.1";
@@ -100,16 +82,14 @@ class DraftVisitorTests {
         assertTrue(library.hasExtension(KnowledgeArtifactAdapter.releaseDescriptionUrl));
         assertTrue(library.hasExtension(KnowledgeArtifactAdapter.releaseLabelUrl));
         assertTrue(library.hasApprovalDate());
-        Bundle returnedBundle = (Bundle) libraryAdapter.accept(draftVisitor, spyRepository, params);
-        // 1 time for setup
-        verify(spyRepository, times(2)).transaction(notNull());
+        Bundle returnedBundle = (Bundle) libraryAdapter.accept(draftVisitor, repo, params);
         assertNotNull(returnedBundle);
         Optional<BundleEntryComponent> maybeLib = returnedBundle.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library"))
                 .findAny();
         assertTrue(maybeLib.isPresent());
-        Library lib = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library lib =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         assertNotNull(lib);
         assertTrue(lib.getStatus() == Enumerations.PublicationStatus.DRAFT);
         assertEquals(lib.getVersion(), draftedVersion);
@@ -132,27 +112,26 @@ class DraftVisitorTests {
                         }
                     }
                 },
-                spyRepository);
+                repo);
     }
 
     @Test
     void draftOperation_no_effectivePeriod_test() {
         Bundle bundle = (Bundle)
                 jsonParser.parseResource(DraftVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
-        spyRepository.transaction(bundle);
-        Library baseLib = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        repo.transaction(bundle);
+        Library baseLib = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         assertTrue(baseLib.hasEffectivePeriod());
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(baseLib);
         IKnowledgeArtifactVisitor draftVisitor = new DraftVisitor();
-        PlanDefinition planDef = spyRepository
-                .read(PlanDefinition.class, new IdType("PlanDefinition/plandefinition-ersd-instance-example"))
+        PlanDefinition planDef = repo.read(
+                        PlanDefinition.class, new IdType("PlanDefinition/plandefinition-ersd-instance-example"))
                 .copy();
         assertTrue(planDef.hasEffectivePeriod());
         String version = "1.01.21";
         Parameters params = parameters(part("version", version));
-        Bundle returnedBundle = (Bundle) libraryAdapter.accept(draftVisitor, spyRepository, params);
+        Bundle returnedBundle = (Bundle) libraryAdapter.accept(draftVisitor, repo, params);
 
         MetadataResourceHelper.forEachMetadataResource(
                 returnedBundle.getEntry(),
@@ -161,7 +140,7 @@ class DraftVisitorTests {
                     assertFalse(((Period) adapter.getEffectivePeriod()).hasStart()
                             || ((Period) adapter.getEffectivePeriod()).hasEnd());
                 },
-                spyRepository);
+                repo);
     }
 
     @Test
@@ -170,18 +149,17 @@ class DraftVisitorTests {
                 jsonParser.parseResource(DraftVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
         Library versionConflictLibrary = (Library)
                 jsonParser.parseResource(DraftVisitorTests.class.getResourceAsStream("Library-version-conflict.json"));
-        spyRepository.transaction(bundle);
-        spyRepository.update(versionConflictLibrary);
+        repo.transaction(bundle);
+        repo.update(versionConflictLibrary);
         Parameters params = parameters(part("version", "1.0.0"));
         String maybeException = null;
-        Library baseLib = spyRepository
-                .read(Library.class, new IdType(specificationLibReference))
-                .copy();
+        Library baseLib =
+                repo.read(Library.class, new IdType(specificationLibReference)).copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(baseLib);
         IKnowledgeArtifactVisitor draftVisitor = new DraftVisitor();
 
         try {
-            libraryAdapter.accept(draftVisitor, spyRepository, params);
+            libraryAdapter.accept(draftVisitor, repo, params);
 
         } catch (Exception e) {
             maybeException = e.getMessage();
@@ -194,16 +172,15 @@ class DraftVisitorTests {
     void draftOperation_cannot_create_draft_of_draft_test() {
         Library versionConflictLibrary = (Library)
                 jsonParser.parseResource(DraftVisitorTests.class.getResourceAsStream("Library-version-conflict.json"));
-        spyRepository.update(versionConflictLibrary);
+        repo.update(versionConflictLibrary);
         Parameters params = parameters(part("version", "1.2.1"));
         String maybeException = "";
-        Library baseLib = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibraryDraftVersion-1-0-0"))
+        Library baseLib = repo.read(Library.class, new IdType("Library/SpecificationLibraryDraftVersion-1-0-0"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(baseLib);
         IKnowledgeArtifactVisitor draftVisitor = new DraftVisitor();
         try {
-            libraryAdapter.accept(draftVisitor, spyRepository, params);
+            libraryAdapter.accept(draftVisitor, repo, params);
         } catch (PreconditionFailedException e) {
             maybeException = e.getMessage();
         }
@@ -215,9 +192,8 @@ class DraftVisitorTests {
     void draftOperation_version_format_test() {
         Library versionConflictLibrary = (Library)
                 jsonParser.parseResource(DraftVisitorTests.class.getResourceAsStream("Library-version-conflict.json"));
-        spyRepository.update(versionConflictLibrary);
-        Library baseLib = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibraryDraftVersion-1-0-0"))
+        repo.update(versionConflictLibrary);
+        Library baseLib = repo.read(Library.class, new IdType("Library/SpecificationLibraryDraftVersion-1-0-0"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(baseLib);
         IKnowledgeArtifactVisitor draftVisitor = new DraftVisitor();
@@ -226,7 +202,7 @@ class DraftVisitorTests {
             UnprocessableEntityException maybeException = null;
             Parameters params = parameters(part("version", new StringType(version)));
             try {
-                libraryAdapter.accept(draftVisitor, spyRepository, params);
+                libraryAdapter.accept(draftVisitor, repo, params);
             } catch (UnprocessableEntityException e) {
                 maybeException = e;
             }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/PackageVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/PackageVisitorTests.java
@@ -4,9 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
 import static org.opencds.cqf.fhir.utility.r4.Parameters.parameters;
 import static org.opencds.cqf.fhir.utility.r4.Parameters.part;
 
@@ -38,8 +35,6 @@ import org.hl7.fhir.r4.model.ValueSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.adapter.LibraryAdapter;
@@ -50,35 +45,25 @@ import org.opencds.cqf.fhir.utility.visitor.PackageVisitor;
 class PackageVisitorTests {
     private final FhirContext fhirContext = FhirContext.forR4Cached();
     private final IParser jsonParser = fhirContext.newJsonParser();
-    private Repository spyRepository;
+    private Repository repo;
 
     @BeforeEach
     void setup() {
-        spyRepository = spy(new InMemoryFhirRepository(fhirContext));
-        doAnswer(new Answer<Bundle>() {
-                    @Override
-                    public Bundle answer(InvocationOnMock a) throws Throwable {
-                        Bundle b = a.getArgument(0);
-                        return InMemoryFhirRepository.transactionStub(b, spyRepository);
-                    }
-                })
-                .when(spyRepository)
-                .transaction(any());
+        repo = new InMemoryFhirRepository(fhirContext);
     }
 
     @Test
     void visitLibraryTest() {
         Bundle loadedBundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example-naive.json"));
-        spyRepository.transaction(loadedBundle);
+        repo.transaction(loadedBundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
 
-        Bundle packagedBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, params);
+        Bundle packagedBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, params);
         assertNotNull(packagedBundle);
         assertEquals(packagedBundle.getEntry().size(), loadedBundle.getEntry().size());
 
@@ -103,17 +88,16 @@ class PackageVisitorTests {
     void packageOperation_should_fail_no_credentials() {
         Bundle loadedBundle = (Bundle)
                 jsonParser.parseResource(PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
-        spyRepository.transaction(loadedBundle);
+        repo.transaction(loadedBundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = parameters();
 
         UnprocessableEntityException maybeException = null;
         try {
-            libraryAdapter.accept(packageVisitor, spyRepository, params);
+            libraryAdapter.accept(packageVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             maybeException = e;
         }
@@ -124,10 +108,9 @@ class PackageVisitorTests {
     void packageOperation_should_fail_credentials_missing_username() {
         Bundle loadedBundle = (Bundle)
                 jsonParser.parseResource(PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
-        spyRepository.transaction(loadedBundle);
+        repo.transaction(loadedBundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Endpoint terminologyEndpoint = new Endpoint();
@@ -137,7 +120,7 @@ class PackageVisitorTests {
 
         UnprocessableEntityException maybeException = null;
         try {
-            libraryAdapter.accept(packageVisitor, spyRepository, params);
+            libraryAdapter.accept(packageVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             maybeException = e;
         }
@@ -148,10 +131,9 @@ class PackageVisitorTests {
     void packageOperation_should_fail_credentials_missing_apikey() {
         Bundle loadedBundle = (Bundle)
                 jsonParser.parseResource(PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
-        spyRepository.transaction(loadedBundle);
+        repo.transaction(loadedBundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Endpoint terminologyEndpoint = new Endpoint();
@@ -161,7 +143,7 @@ class PackageVisitorTests {
 
         UnprocessableEntityException maybeException = null;
         try {
-            libraryAdapter.accept(packageVisitor, spyRepository, params);
+            libraryAdapter.accept(packageVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             maybeException = e;
         }
@@ -172,10 +154,9 @@ class PackageVisitorTests {
     void packageOperation_should_fail_credentials_invalid() {
         Bundle loadedBundle = (Bundle)
                 jsonParser.parseResource(PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
-        spyRepository.transaction(loadedBundle);
+        repo.transaction(loadedBundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Endpoint terminologyEndpoint = new Endpoint();
@@ -185,7 +166,7 @@ class PackageVisitorTests {
 
         UnprocessableEntityException maybeException = null;
         try {
-            libraryAdapter.accept(packageVisitor, spyRepository, params);
+            libraryAdapter.accept(packageVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             maybeException = e;
         }
@@ -196,11 +177,10 @@ class PackageVisitorTests {
     void packageOperation_should_fail_non_matching_capability() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-package-capabilities.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         List<String> capabilities = Arrays.asList("computable", "publishable", "executable");
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         // the library contains all three capabilities
@@ -210,7 +190,7 @@ class PackageVisitorTests {
             Parameters params = parameters(part("capability", capability));
             PreconditionFailedException maybeException = null;
             try {
-                libraryAdapter.accept(packageVisitor, spyRepository, params);
+                libraryAdapter.accept(packageVisitor, repo, params);
             } catch (PreconditionFailedException e) {
                 maybeException = e;
             }
@@ -218,7 +198,7 @@ class PackageVisitorTests {
         }
         Parameters allParams = parameters(
                 part("capability", "computable"), part("capability", "publishable"), part("capability", "executable"));
-        Bundle packaged = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, allParams);
+        Bundle packaged = (Bundle) libraryAdapter.accept(packageVisitor, repo, allParams);
 
         // no error when running the operation with all
         // three capabilities
@@ -229,10 +209,9 @@ class PackageVisitorTests {
     void packageOperation_should_apply_check_force_canonicalVersions() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-active-no-versions.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         String versionToUpdateTo = "1.3.1.23";
@@ -244,7 +223,7 @@ class PackageVisitorTests {
                 part(
                         "artifactVersion",
                         new CanonicalType("http://to-add-missing-version/ValueSet/dxtc|" + versionToUpdateTo)));
-        Bundle updatedCanonicalVersionPackage = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, params);
+        Bundle updatedCanonicalVersionPackage = (Bundle) libraryAdapter.accept(packageVisitor, repo, params);
 
         List<MetadataResource> updatedResources = updatedCanonicalVersionPackage.getEntry().stream()
                 .map(entry -> (MetadataResource) entry.getResource())
@@ -260,7 +239,7 @@ class PackageVisitorTests {
         String correctCheckVersion = "2022-10-19";
         PreconditionFailedException checkCanonicalThrewError = null;
         try {
-            libraryAdapter.accept(packageVisitor, spyRepository, params);
+            libraryAdapter.accept(packageVisitor, repo, params);
         } catch (PreconditionFailedException e) {
             checkCanonicalThrewError = e;
         }
@@ -268,7 +247,7 @@ class PackageVisitorTests {
         params = parameters(part(
                 "checkArtifactVersion",
                 new CanonicalType("http://to-check-version/Library/SpecificationLibrary|" + correctCheckVersion)));
-        Bundle noErrorCheckCanonicalPackage = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, params);
+        Bundle noErrorCheckCanonicalPackage = (Bundle) libraryAdapter.accept(packageVisitor, repo, params);
         Optional<MetadataResource> checkedVersionResource = noErrorCheckCanonicalPackage.getEntry().stream()
                 .map(entry -> (MetadataResource) entry.getResource())
                 .filter(resource -> resource.getUrl().contains("to-check-version"))
@@ -278,7 +257,7 @@ class PackageVisitorTests {
         String versionToForceTo = "1.1.9.23";
         params = parameters(part(
                 "forceArtifactVersion", new CanonicalType("http://to-force-version/Library/rctc|" + versionToForceTo)));
-        Bundle forcedVersionPackage = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, params);
+        Bundle forcedVersionPackage = (Bundle) libraryAdapter.accept(packageVisitor, repo, params);
         Optional<MetadataResource> forcedVersionResource = forcedVersionPackage.getEntry().stream()
                 .map(entry -> (MetadataResource) entry.getResource())
                 .filter(resource -> resource.getUrl().contains("to-force-version"))
@@ -291,37 +270,36 @@ class PackageVisitorTests {
     void packageOperation_should_respect_count_offset() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters countZeroParams = parameters(part("count", new IntegerType(0)));
-        Bundle countZeroBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, countZeroParams);
+        Bundle countZeroBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, countZeroParams);
         // when count = 0 only show the total
         assertEquals(0, countZeroBundle.getEntry().size());
         assertEquals(6, countZeroBundle.getTotal());
         Parameters count2Params = parameters(part("count", new IntegerType(2)));
-        Bundle count2Bundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, count2Params);
+        Bundle count2Bundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, count2Params);
         assertEquals(2, count2Bundle.getEntry().size());
         Parameters count2Offset2Params =
                 parameters(part("count", new IntegerType(2)), part("offset", new IntegerType(2)));
-        Bundle count2Offset2Bundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, count2Offset2Params);
+        Bundle count2Offset2Bundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, count2Offset2Params);
         assertEquals(2, count2Offset2Bundle.getEntry().size());
         Parameters offset4Params = parameters(part("offset", new IntegerType(4)));
-        Bundle offset4Bundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, offset4Params);
+        Bundle offset4Bundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, offset4Params);
         assertEquals(offset4Bundle.getEntry().size(), (countZeroBundle.getTotal() - 4));
         assertTrue(offset4Bundle.getType() == BundleType.COLLECTION);
         assertFalse(offset4Bundle.hasTotal());
         Parameters offsetMaxParams = parameters(part("offset", new IntegerType(countZeroBundle.getTotal())));
-        Bundle offsetMaxBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, offsetMaxParams);
+        Bundle offsetMaxBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, offsetMaxParams);
         assertEquals(0, offsetMaxBundle.getEntry().size());
         Parameters offsetMaxRandomCountParams = parameters(
                 part("offset", new IntegerType(countZeroBundle.getTotal())),
                 part("count", new IntegerType(ThreadLocalRandom.current().nextInt(3, 20))));
         Bundle offsetMaxRandomCountBundle =
-                (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, offsetMaxRandomCountParams);
+                (Bundle) libraryAdapter.accept(packageVisitor, repo, offsetMaxRandomCountParams);
         assertEquals(0, offsetMaxRandomCountBundle.getEntry().size());
     }
 
@@ -329,26 +307,25 @@ class PackageVisitorTests {
     void packageOperation_different_bundle_types() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters countZeroParams = parameters(part("count", new IntegerType(0)));
-        Bundle countZeroBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, countZeroParams);
+        Bundle countZeroBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, countZeroParams);
         assertTrue(countZeroBundle.getType() == BundleType.SEARCHSET);
         Parameters countSevenParams = parameters(part("count", new IntegerType(7)));
-        Bundle countSevenBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, countSevenParams);
+        Bundle countSevenBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, countSevenParams);
         assertTrue(countSevenBundle.getType() == BundleType.TRANSACTION);
         Parameters countFourParams = parameters(part("count", new IntegerType(4)));
-        Bundle countFourBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, countFourParams);
+        Bundle countFourBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, countFourParams);
         assertTrue(countFourBundle.getType() == BundleType.COLLECTION);
         // these assertions test for Bundle base profile conformance when type = collection
         assertFalse(countFourBundle.getEntry().stream().anyMatch(entry -> entry.hasRequest()));
         assertFalse(countFourBundle.hasTotal());
         Parameters offsetOneParams = parameters(part("offset", new IntegerType(1)));
-        Bundle offsetOneBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, offsetOneParams);
+        Bundle offsetOneBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, offsetOneParams);
         assertTrue(offsetOneBundle.getType() == BundleType.COLLECTION);
         // these assertions test for Bundle base profile conformance when type = collection
         assertFalse(offsetOneBundle.getEntry().stream().anyMatch(entry -> entry.hasRequest()));
@@ -356,8 +333,7 @@ class PackageVisitorTests {
 
         Parameters countOneOffsetOneParams =
                 parameters(part("count", new IntegerType(1)), part("offset", new IntegerType(1)));
-        Bundle countOneOffsetOneBundle =
-                (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, countOneOffsetOneParams);
+        Bundle countOneOffsetOneBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, countOneOffsetOneParams);
         assertTrue(countOneOffsetOneBundle.getType() == BundleType.COLLECTION);
         // these assertions test for Bundle base profile conformance when type = collection
         assertFalse(countOneOffsetOneBundle.getEntry().stream().anyMatch(entry -> entry.hasRequest()));
@@ -368,14 +344,13 @@ class PackageVisitorTests {
     void packageOperation_should_conditionally_create() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters emptyParams = parameters();
-        Bundle packagedBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, emptyParams);
+        Bundle packagedBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, emptyParams);
         for (BundleEntryComponent component : packagedBundle.getEntry()) {
             String ifNoneExist = component.getRequest().getIfNoneExist();
             String url = ((MetadataResource) component.getResource()).getUrl();
@@ -388,10 +363,9 @@ class PackageVisitorTests {
     void packageOperation_should_respect_include() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Map<String, List<String>> includeOptions = new HashMap<String, List<String>>();
@@ -424,7 +398,7 @@ class PackageVisitorTests {
         includeOptions.put("examples", Arrays.asList());
         for (Entry<String, List<String>> includedTypeURLs : includeOptions.entrySet()) {
             Parameters params = parameters(part("include", includedTypeURLs.getKey()));
-            Bundle packaged = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, params);
+            Bundle packaged = (Bundle) libraryAdapter.accept(packageVisitor, repo, params);
             List<MetadataResource> resources = packaged.getEntry().stream()
                     .map(entry -> (MetadataResource) entry.getResource())
                     .collect(Collectors.toList());

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/ReleaseVisitorTests.java
@@ -192,9 +192,9 @@ class ReleaseVisitorTests {
         repo.transaction(bundle);
         Library library = repo.read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
                 .copy();
-        Measure CervicalCancerScreeningFHIR =
+        Measure cervicalCancerScreeningFHIR =
                 repo.read(Measure.class, new IdType("Measure/CervicalCancerScreeningFHIR"));
-        Measure BreastCancerScreeningFHIR = repo.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
+        Measure breastCancerScreeningFHIR = repo.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
         params.addParameter("version", "1.0.0");
@@ -207,17 +207,17 @@ class ReleaseVisitorTests {
         // Approval date is required to release an artifact
         library.setApprovalDateElement(new DateType("2024-04-23"));
         // if both cqfm and crmi effective data requirements are present then they will each be traced
-        var crmiEDRCervical = CervicalCancerScreeningFHIR.getContained().get(0).copy();
+        var crmiEDRCervical = cervicalCancerScreeningFHIR.getContained().get(0).copy();
         crmiEDRCervical.setId(crmiEDRId);
-        CervicalCancerScreeningFHIR.addContained(crmiEDRCervical);
-        CervicalCancerScreeningFHIR.addExtension(crmiEDRExtension);
+        cervicalCancerScreeningFHIR.addContained(crmiEDRCervical);
+        cervicalCancerScreeningFHIR.addExtension(crmiEDRExtension);
         var crmiEDRBreastCancer =
-                BreastCancerScreeningFHIR.getContained().get(0).copy();
+                breastCancerScreeningFHIR.getContained().get(0).copy();
         crmiEDRBreastCancer.setId(crmiEDRId);
-        BreastCancerScreeningFHIR.addContained(crmiEDRBreastCancer);
-        BreastCancerScreeningFHIR.addExtension(crmiEDRExtension);
-        repo.update(CervicalCancerScreeningFHIR);
-        repo.update(BreastCancerScreeningFHIR);
+        breastCancerScreeningFHIR.addContained(crmiEDRBreastCancer);
+        breastCancerScreeningFHIR.addExtension(crmiEDRExtension);
+        repo.update(cervicalCancerScreeningFHIR);
+        repo.update(breastCancerScreeningFHIR);
 
         Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/ReleaseVisitorTests.java
@@ -149,9 +149,9 @@ class ReleaseVisitorTests {
         repo.transaction(bundle);
         Library library = repo.read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
                 .copy();
-        Measure CervicalCancerScreeningFHIR =
+        Measure cervicalCancerScreeningFHIR =
                 repo.read(Measure.class, new IdType("Measure/CervicalCancerScreeningFHIR"));
-        Measure BreastCancerScreeningFHIR = repo.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
+        Measure breastCancerScreeningFHIR = repo.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
         params.addParameter("version", "1.0.0");
@@ -161,10 +161,10 @@ class ReleaseVisitorTests {
         // Approval date is required to release an artifact
         library.setApprovalDateElement(new DateType("2024-04-23"));
         // removing the effectiveDataRequirements changes the dependency count
-        CervicalCancerScreeningFHIR.setContained(null);
-        repo.update(CervicalCancerScreeningFHIR);
-        BreastCancerScreeningFHIR.setContained(null);
-        repo.update(BreastCancerScreeningFHIR);
+        cervicalCancerScreeningFHIR.setContained(null);
+        repo.update(cervicalCancerScreeningFHIR);
+        breastCancerScreeningFHIR.setContained(null);
+        repo.update(breastCancerScreeningFHIR);
 
         Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/ReleaseVisitorTests.java
@@ -3,9 +3,6 @@ package org.opencds.cqf.fhir.utility.visitor.r4;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
 import static org.opencds.cqf.fhir.utility.r4.Parameters.parameters;
 import static org.opencds.cqf.fhir.utility.r4.Parameters.part;
 
@@ -41,8 +38,6 @@ import org.hl7.fhir.r4.model.SearchParameter;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.utility.Canonicals;
 import org.opencds.cqf.fhir.utility.Constants;
@@ -57,7 +52,7 @@ import org.slf4j.event.Level;
 
 class ReleaseVisitorTests {
     private final FhirContext fhirContext = FhirContext.forR4Cached();
-    private Repository spyRepository;
+    private Repository repo;
     private final IParser jsonParser = fhirContext.newJsonParser();
     private final List<String> badVersionList = Arrays.asList(
             "11asd1",
@@ -81,26 +76,16 @@ class ReleaseVisitorTests {
     void setup() {
         SearchParameter sp = (SearchParameter) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("SearchParameter-artifactAssessment.json"));
-        spyRepository = spy(new InMemoryFhirRepository(fhirContext));
-        spyRepository.update(sp);
-        doAnswer(new Answer<Bundle>() {
-                    @Override
-                    public Bundle answer(InvocationOnMock a) throws Throwable {
-                        Bundle b = a.getArgument(0);
-                        return InMemoryFhirRepository.transactionStub(b, spyRepository);
-                    }
-                })
-                .when(spyRepository)
-                .transaction(any());
+        repo = new InMemoryFhirRepository(fhirContext);
+        repo.update(sp);
     }
 
     @Test
     void visitMeasureCollectionTest() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ecqm-qicore-2024-simplified.json"));
-        spyRepository.transaction(bundle);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
+        repo.transaction(bundle);
+        Library library = repo.read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
                 .copy();
 
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
@@ -112,14 +97,14 @@ class ReleaseVisitorTests {
         // Approval date is required to release an artifact
         library.setApprovalDateElement(new DateType("2024-04-23"));
         // Set the ID to Manifest-Release
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        Library releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         var dependenciesOnReleasedArtifact = releasedLibrary.getRelatedArtifact().stream()
                 .filter(ra -> ra.getType().equals(RelatedArtifact.RelatedArtifactType.DEPENDSON))
                 .collect(Collectors.toList());
@@ -161,14 +146,12 @@ class ReleaseVisitorTests {
     void visitMeasureEffectiveDataRequirementsTest() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ecqm-qicore-2024-simplified.json"));
-        spyRepository.transaction(bundle);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
+        repo.transaction(bundle);
+        Library library = repo.read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
                 .copy();
         Measure CervicalCancerScreeningFHIR =
-                spyRepository.read(Measure.class, new IdType("Measure/CervicalCancerScreeningFHIR"));
-        Measure BreastCancerScreeningFHIR =
-                spyRepository.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
+                repo.read(Measure.class, new IdType("Measure/CervicalCancerScreeningFHIR"));
+        Measure BreastCancerScreeningFHIR = repo.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
         params.addParameter("version", "1.0.0");
@@ -179,18 +162,18 @@ class ReleaseVisitorTests {
         library.setApprovalDateElement(new DateType("2024-04-23"));
         // removing the effectiveDataRequirements changes the dependency count
         CervicalCancerScreeningFHIR.setContained(null);
-        spyRepository.update(CervicalCancerScreeningFHIR);
+        repo.update(CervicalCancerScreeningFHIR);
         BreastCancerScreeningFHIR.setContained(null);
-        spyRepository.update(BreastCancerScreeningFHIR);
+        repo.update(BreastCancerScreeningFHIR);
 
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        Library releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         var dependenciesOnReleasedArtifact = releasedLibrary.getRelatedArtifact().stream()
                 .filter(ra -> ra.getType().equals(RelatedArtifact.RelatedArtifactType.DEPENDSON))
                 .collect(Collectors.toList());
@@ -206,14 +189,12 @@ class ReleaseVisitorTests {
     void bothCRMIandCQFMEffectiveDataRequirementsTest() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ecqm-qicore-2024-simplified.json"));
-        spyRepository.transaction(bundle);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
+        repo.transaction(bundle);
+        Library library = repo.read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
                 .copy();
         Measure CervicalCancerScreeningFHIR =
-                spyRepository.read(Measure.class, new IdType("Measure/CervicalCancerScreeningFHIR"));
-        Measure BreastCancerScreeningFHIR =
-                spyRepository.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
+                repo.read(Measure.class, new IdType("Measure/CervicalCancerScreeningFHIR"));
+        Measure BreastCancerScreeningFHIR = repo.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
         params.addParameter("version", "1.0.0");
@@ -235,17 +216,17 @@ class ReleaseVisitorTests {
         crmiEDRBreastCancer.setId(crmiEDRId);
         BreastCancerScreeningFHIR.addContained(crmiEDRBreastCancer);
         BreastCancerScreeningFHIR.addExtension(crmiEDRExtension);
-        spyRepository.update(CervicalCancerScreeningFHIR);
-        spyRepository.update(BreastCancerScreeningFHIR);
+        repo.update(CervicalCancerScreeningFHIR);
+        repo.update(BreastCancerScreeningFHIR);
 
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        Library releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         var dependenciesOnReleasedArtifact = releasedLibrary.getRelatedArtifact().stream()
                 .filter(ra -> ra.getType().equals(RelatedArtifact.RelatedArtifactType.DEPENDSON))
                 .collect(Collectors.toList());
@@ -262,10 +243,9 @@ class ReleaseVisitorTests {
     void visitLibraryTest() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ersd-release-bundle.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/ReleaseSpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/ReleaseSpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         String version = "1.0.1";
@@ -274,14 +254,14 @@ class ReleaseVisitorTests {
         params.addParameter("version", version);
         params.addParameter("versionBehavior", new CodeType("default"));
 
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        Library releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         // versionBehaviour == 'default' so version should be
         // existingVersion and not the new version provided in
         // the parameters
@@ -386,26 +366,25 @@ class ReleaseVisitorTests {
     void releaseResource_force_version() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         // Existing version should be "1.2.3";
         String newVersionToForce = "1.2.7";
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = parameters(
                 part("version", new StringType(newVersionToForce)), part("versionBehavior", new CodeType("force")));
 
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
 
         assertNotNull(returnResource);
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library/SpecificationLibrary"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        Library releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         assertEquals(releasedLibrary.getVersion(), newVersionToForce);
     }
 
@@ -414,11 +393,11 @@ class ReleaseVisitorTests {
         // SpecificationLibrary - root is experimental but HAS experimental children
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft-experimental.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         // SpecificationLibrary2 - root is NOT experimental but HAS experimental children
         Bundle bundle2 = (Bundle) jsonParser.parseResource(ReleaseVisitorTests.class.getResourceAsStream(
                 "Bundle-small-approved-draft-experimental-children.json"));
-        spyRepository.transaction(bundle2);
+        repo.transaction(bundle2);
         Parameters params = parameters(
                 part("version", new StringType("1.2.3")),
                 part("versionBehavior", new CodeType("default")),
@@ -426,24 +405,22 @@ class ReleaseVisitorTests {
         Exception notExpectingAnyException = null;
         // no Exception if root is experimental
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         try {
-            libraryAdapter.accept(releaseVisitor, spyRepository, params);
+            libraryAdapter.accept(releaseVisitor, repo, params);
         } catch (Exception e) {
             notExpectingAnyException = e;
         }
         assertTrue(notExpectingAnyException == null);
 
         UnprocessableEntityException nonExperimentalChildException = null;
-        Library library2 = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary2"))
+        Library library2 = repo.read(Library.class, new IdType("Library/SpecificationLibrary2"))
                 .copy();
         LibraryAdapter libraryAdapter2 = new AdapterFactory().createLibrary(library2);
         try {
-            libraryAdapter2.accept(releaseVisitor, spyRepository, params);
+            libraryAdapter2.accept(releaseVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             nonExperimentalChildException = e;
         }
@@ -456,18 +433,16 @@ class ReleaseVisitorTests {
         // SpecificationLibrary - root is experimentalbut HAS experimental children
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft-experimental.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         // SpecificationLibrary2 - root is NOT experimental but HAS experimental children
         Bundle bundle2 = (Bundle) jsonParser.parseResource(ReleaseVisitorTests.class.getResourceAsStream(
                 "Bundle-small-approved-draft-experimental-children.json"));
-        spyRepository.transaction(bundle2);
+        repo.transaction(bundle2);
 
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
-        Library library2 = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary2"))
+        Library library2 = repo.read(Library.class, new IdType("Library/SpecificationLibrary2"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         LibraryAdapter libraryAdapter2 = new AdapterFactory().createLibrary(library2);
@@ -480,12 +455,12 @@ class ReleaseVisitorTests {
         var logger = TestLoggerFactory.getTestLogger(ReleaseVisitor.class);
         logger.clear();
 
-        libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        libraryAdapter.accept(releaseVisitor, repo, params);
 
         // no warning if the root is Experimental
         assertEquals(0, logger.getLoggingEvents().size());
 
-        libraryAdapter2.accept(releaseVisitor, spyRepository, params);
+        libraryAdapter2.accept(releaseVisitor, repo, params);
 
         var warningMessages = logger.getLoggingEvents().stream()
                 .filter(event -> event.getLevel().equals(Level.WARN))
@@ -504,17 +479,16 @@ class ReleaseVisitorTests {
     void releaseResource_propagate_effective_period() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ersd-no-child-effective-period.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         String effectivePeriodToPropagate = "2020-12-11";
 
         Parameters params =
                 parameters(part("version", new StringType("1.2.7")), part("versionBehavior", new CodeType("default")));
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);
         MetadataResourceHelper.forEachMetadataResource(
                 returnResource.getEntry(),
@@ -533,14 +507,14 @@ class ReleaseVisitorTests {
                         assertEquals(startString, effectivePeriodToPropagate);
                     }
                 },
-                spyRepository);
+                repo);
     }
 
     @Test
     void releaseResource_latestFromTx_NotSupported_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
 
         String actualErrorMessage = "";
 
@@ -549,13 +523,12 @@ class ReleaseVisitorTests {
                 part("versionBehavior", new CodeType("default")),
                 part("latestFromTxServer", new BooleanType(true)));
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
 
         try {
-            libraryAdapter.accept(releaseVisitor, spyRepository, params);
+            libraryAdapter.accept(releaseVisitor, repo, params);
         } catch (Exception e) {
             actualErrorMessage = e.getMessage();
         }
@@ -566,19 +539,18 @@ class ReleaseVisitorTests {
     void release_missing_approvalDate_validation_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-release-missing-approvalDate.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
 
         String versionData = "1.2.3";
         String actualErrorMessage = "";
 
         Parameters params1 = parameters(part("version", versionData), part("versionBehavior", new CodeType("default")));
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/ReleaseSpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/ReleaseSpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         try {
-            libraryAdapter.accept(releaseVisitor, spyRepository, params1);
+            libraryAdapter.accept(releaseVisitor, repo, params1);
         } catch (Exception e) {
             actualErrorMessage = e.getMessage();
         }
@@ -589,10 +561,9 @@ class ReleaseVisitorTests {
     void release_version_format_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         for (String version : badVersionList) {
@@ -600,7 +571,7 @@ class ReleaseVisitorTests {
             Parameters params = parameters(
                     part("version", new StringType(version)), part("versionBehavior", new CodeType("force")));
             try {
-                libraryAdapter.accept(releaseVisitor, spyRepository, params);
+                libraryAdapter.accept(releaseVisitor, repo, params);
 
             } catch (UnprocessableEntityException e) {
                 maybeException = e;
@@ -613,25 +584,24 @@ class ReleaseVisitorTests {
     void release_releaseLabel_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         String releaseLabel = "release label test";
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = parameters(
                 part("releaseLabel", new StringType(releaseLabel)),
                 part("version", "1.2.3"),
                 part("versionBehavior", new CodeType("default")));
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
 
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library/SpecificationLibrary"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        Library releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         Optional<Extension> maybeReleaseLabel = releasedLibrary.getExtension().stream()
                 .filter(ext -> ext.getUrl().equals(KnowledgeArtifactAdapter.releaseLabelUrl))
                 .findFirst();
@@ -643,10 +613,9 @@ class ReleaseVisitorTests {
     void release_version_active_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
 
@@ -654,7 +623,7 @@ class ReleaseVisitorTests {
         Parameters params =
                 parameters(part("version", new StringType("1.2.3")), part("versionBehavior", new CodeType("force")));
         try {
-            libraryAdapter.accept(releaseVisitor, spyRepository, params);
+            libraryAdapter.accept(releaseVisitor, repo, params);
         } catch (PreconditionFailedException e) {
             maybeException = e;
         }
@@ -665,10 +634,9 @@ class ReleaseVisitorTests {
     void release_versionBehaviour_format_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         List<String> badVersionBehaviors = Arrays.asList("not-a-valid-option", null);
@@ -677,7 +645,7 @@ class ReleaseVisitorTests {
             Parameters params = parameters(
                     part("version", new StringType("1.2.3")), part("versionBehavior", new CodeType(versionBehaviour)));
             try {
-                libraryAdapter.accept(releaseVisitor, spyRepository, params);
+                libraryAdapter.accept(releaseVisitor, repo, params);
             } catch (FHIRException e) {
                 maybeException = e;
             } catch (UnprocessableEntityException e) {
@@ -691,22 +659,21 @@ class ReleaseVisitorTests {
     void release_preserves_extensions() {
         var bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         var releaseVisitor = new ReleaseVisitor();
-        var originalLibrary = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        var originalLibrary = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         var testLibrary = originalLibrary.copy();
         var libraryAdapter = new AdapterFactory().createLibrary(testLibrary);
         var params =
                 parameters(part("version", new StringType("1.2.3")), part("versionBehavior", new CodeType("force")));
-        var returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        var returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library/SpecificationLibrary"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        var releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        var releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         for (final var originalRelatedArtifact : originalLibrary.getRelatedArtifact()) {
             releasedLibrary.getRelatedArtifact().forEach(releasedRelatedArtifact -> {
                 if (Canonicals.getUrl(releasedRelatedArtifact.getResource())

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/RetireVisitorTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/RetireVisitorTest.java
@@ -1,9 +1,6 @@
 package org.opencds.cqf.fhir.utility.visitor.r4;
 
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
 import static org.opencds.cqf.fhir.utility.r4.Parameters.parameters;
 import static org.opencds.cqf.fhir.utility.r4.Parameters.part;
 
@@ -22,8 +19,6 @@ import org.hl7.fhir.r4.model.SearchParameter;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.utility.adapter.LibraryAdapter;
 import org.opencds.cqf.fhir.utility.adapter.r4.AdapterFactory;
@@ -34,57 +29,46 @@ import org.opencds.cqf.fhir.utility.visitor.RetireVisitor;
 public class RetireVisitorTest {
 
     private final FhirContext fhirContext = FhirContext.forR4Cached();
-    private Repository spyRepository;
+    private Repository repo;
     private final IParser jsonParser = fhirContext.newJsonParser();
 
     @BeforeEach
     void setup() {
         SearchParameter sp = (SearchParameter) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("SearchParameter-artifactAssessment.json"));
-        spyRepository = spy(new InMemoryFhirRepository(fhirContext));
-        spyRepository.update(sp);
-        doAnswer(new Answer<Bundle>() {
-                    @Override
-                    public Bundle answer(InvocationOnMock a) throws Throwable {
-                        Bundle b = a.getArgument(0);
-                        return InMemoryFhirRepository.transactionStub(b, spyRepository);
-                    }
-                })
-                .when(spyRepository)
-                .transaction(any());
+        repo = new InMemoryFhirRepository(fhirContext);
+        repo.update(sp);
     }
 
     @Test
     void library_retire_test() {
         Bundle bundle =
                 (Bundle) jsonParser.parseResource(WithdrawVisitorTests.class.getResourceAsStream("Bundle-retire.json"));
-        Bundle tsBundle = spyRepository.transaction(bundle);
+        Bundle tsBundle = repo.transaction(bundle);
         // Resource is uploaded using POST - need to get id like this
         String id = tsBundle.getEntry().get(0).getResponse().getLocation();
         String version = "1.1.0";
-        Library library = spyRepository.read(Library.class, new IdType(id)).copy();
+        Library library = repo.read(Library.class, new IdType(id)).copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         IKnowledgeArtifactVisitor retireVisitor = new RetireVisitor();
         Parameters params = parameters(part("version", version));
-        Bundle returnedBundle = (Bundle) libraryAdapter.accept(retireVisitor, spyRepository, params);
+        Bundle returnedBundle = (Bundle) libraryAdapter.accept(retireVisitor, repo, params);
 
         var res = returnedBundle.getEntry();
 
         assert (res.size() == 9);
-        var libraries = spyRepository.search(Bundle.class, Library.class, new HashMap()).getEntry().stream()
+        var libraries = repo.search(Bundle.class, Library.class, new HashMap()).getEntry().stream()
                 .filter(x -> ((Library) x.getResource()).getStatus().equals(Enumerations.PublicationStatus.RETIRED))
                 .collect(Collectors.toList());
 
-        var valueSets = spyRepository.search(Bundle.class, ValueSet.class, new HashMap()).getEntry().stream()
+        var valueSets = repo.search(Bundle.class, ValueSet.class, new HashMap()).getEntry().stream()
                 .filter(x -> ((ValueSet) x.getResource()).getStatus().equals(Enumerations.PublicationStatus.RETIRED))
                 .collect(Collectors.toList());
 
-        var planDefinitions =
-                spyRepository.search(Bundle.class, PlanDefinition.class, new HashMap()).getEntry().stream()
-                        .filter(x -> ((PlanDefinition) x.getResource())
-                                .getStatus()
-                                .equals(Enumerations.PublicationStatus.RETIRED))
-                        .collect(Collectors.toList());
+        var planDefinitions = repo.search(Bundle.class, PlanDefinition.class, new HashMap()).getEntry().stream()
+                .filter(x ->
+                        ((PlanDefinition) x.getResource()).getStatus().equals(Enumerations.PublicationStatus.RETIRED))
+                .collect(Collectors.toList());
 
         assert (libraries.size() == 2);
         assert (valueSets.size() == 6);
@@ -96,15 +80,14 @@ public class RetireVisitorTest {
         try {
             Bundle bundle = (Bundle) jsonParser.parseResource(
                     WithdrawVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
-            spyRepository.transaction(bundle);
+            repo.transaction(bundle);
             String version = "1.01.21";
-            Library library = spyRepository
-                    .read(Library.class, new IdType("Library/SpecificationLibrary"))
+            Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                     .copy();
             LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
             IKnowledgeArtifactVisitor retireVisitor = new RetireVisitor();
             Parameters params = parameters(part("version", version));
-            libraryAdapter.accept(retireVisitor, spyRepository, params);
+            libraryAdapter.accept(retireVisitor, repo, params);
 
             fail("Trying to withdraw an active Library should throw an Exception");
         } catch (PreconditionFailedException e) {

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/DraftVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/DraftVisitorTests.java
@@ -4,12 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.notNull;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.opencds.cqf.fhir.utility.r5.Parameters.parameters;
 import static org.opencds.cqf.fhir.utility.r5.Parameters.part;
 
@@ -32,8 +26,6 @@ import org.hl7.fhir.r5.model.RelatedArtifact;
 import org.hl7.fhir.r5.model.StringType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.utility.Canonicals;
 import org.opencds.cqf.fhir.utility.adapter.KnowledgeArtifactAdapter;
@@ -46,7 +38,7 @@ import org.opencds.cqf.fhir.utility.visitor.IKnowledgeArtifactVisitor;
 
 class DraftVisitorTests {
     private final FhirContext fhirContext = FhirContext.forR5Cached();
-    private Repository spyRepository;
+    private Repository repo;
     private final IParser jsonParser = fhirContext.newJsonParser();
     private final String specificationLibReference = "Library/SpecificationLibrary";
     private final List<String> badVersionList = Arrays.asList(
@@ -69,26 +61,16 @@ class DraftVisitorTests {
 
     @BeforeEach
     void setup() {
-        spyRepository = spy(new InMemoryFhirRepository(fhirContext));
-        doAnswer(new Answer<Bundle>() {
-                    @Override
-                    public Bundle answer(InvocationOnMock a) throws Throwable {
-                        Bundle b = a.getArgument(0);
-                        return InMemoryFhirRepository.transactionStub(b, spyRepository);
-                    }
-                })
-                .when(spyRepository)
-                .transaction(any());
+        repo = new InMemoryFhirRepository(fhirContext);
     }
 
     @Test
     void library_draft_test() {
         Bundle bundle = (Bundle)
                 jsonParser.parseResource(DraftVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         IKnowledgeArtifactVisitor draftVisitor = new DraftVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         String version = "1.0.1";
@@ -100,16 +82,14 @@ class DraftVisitorTests {
         assertTrue(library.hasExtension(KnowledgeArtifactAdapter.releaseDescriptionUrl));
         assertTrue(library.hasExtension(KnowledgeArtifactAdapter.releaseLabelUrl));
         assertTrue(library.hasApprovalDate());
-        Bundle returnedBundle = (Bundle) libraryAdapter.accept(draftVisitor, spyRepository, params);
-        // 1 time for setup
-        verify(spyRepository, times(2)).transaction(notNull());
+        Bundle returnedBundle = (Bundle) libraryAdapter.accept(draftVisitor, repo, params);
         assertNotNull(returnedBundle);
         Optional<BundleEntryComponent> maybeLib = returnedBundle.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library"))
                 .findAny();
         assertTrue(maybeLib.isPresent());
-        Library lib = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library lib =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         assertNotNull(lib);
         assertTrue(lib.getStatus() == Enumerations.PublicationStatus.DRAFT);
         assertEquals(lib.getVersion(), draftedVersion);
@@ -132,27 +112,26 @@ class DraftVisitorTests {
                         }
                     }
                 },
-                spyRepository);
+                repo);
     }
 
     @Test
     void draftOperation_no_effectivePeriod_test() {
         Bundle bundle = (Bundle)
                 jsonParser.parseResource(DraftVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
-        spyRepository.transaction(bundle);
-        Library baseLib = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        repo.transaction(bundle);
+        Library baseLib = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         assertTrue(baseLib.hasEffectivePeriod());
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(baseLib);
         IKnowledgeArtifactVisitor draftVisitor = new DraftVisitor();
-        PlanDefinition planDef = spyRepository
-                .read(PlanDefinition.class, new IdType("PlanDefinition/plandefinition-ersd-instance-example"))
+        PlanDefinition planDef = repo.read(
+                        PlanDefinition.class, new IdType("PlanDefinition/plandefinition-ersd-instance-example"))
                 .copy();
         assertTrue(planDef.hasEffectivePeriod());
         String version = "1.01.21";
         Parameters params = parameters(part("version", version));
-        Bundle returnedBundle = (Bundle) libraryAdapter.accept(draftVisitor, spyRepository, params);
+        Bundle returnedBundle = (Bundle) libraryAdapter.accept(draftVisitor, repo, params);
 
         MetadataResourceHelper.forEachMetadataResource(
                 returnedBundle.getEntry(),
@@ -161,7 +140,7 @@ class DraftVisitorTests {
                     assertFalse(((Period) adapter.getEffectivePeriod()).hasStart()
                             || ((Period) adapter.getEffectivePeriod()).hasEnd());
                 },
-                spyRepository);
+                repo);
     }
 
     @Test
@@ -170,18 +149,17 @@ class DraftVisitorTests {
                 jsonParser.parseResource(DraftVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
         Library versionConflictLibrary = (Library)
                 jsonParser.parseResource(DraftVisitorTests.class.getResourceAsStream("Library-version-conflict.json"));
-        spyRepository.transaction(bundle);
-        spyRepository.update(versionConflictLibrary);
+        repo.transaction(bundle);
+        repo.update(versionConflictLibrary);
         Parameters params = parameters(part("version", "1.0.0"));
         String maybeException = null;
-        Library baseLib = spyRepository
-                .read(Library.class, new IdType(specificationLibReference))
-                .copy();
+        Library baseLib =
+                repo.read(Library.class, new IdType(specificationLibReference)).copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(baseLib);
         IKnowledgeArtifactVisitor draftVisitor = new DraftVisitor();
 
         try {
-            libraryAdapter.accept(draftVisitor, spyRepository, params);
+            libraryAdapter.accept(draftVisitor, repo, params);
 
         } catch (Exception e) {
             maybeException = e.getMessage();
@@ -194,16 +172,15 @@ class DraftVisitorTests {
     void draftOperation_cannot_create_draft_of_draft_test() {
         Library versionConflictLibrary = (Library)
                 jsonParser.parseResource(DraftVisitorTests.class.getResourceAsStream("Library-version-conflict.json"));
-        spyRepository.update(versionConflictLibrary);
+        repo.update(versionConflictLibrary);
         Parameters params = parameters(part("version", "1.2.1"));
         String maybeException = "";
-        Library baseLib = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibraryDraftVersion-1-0-0-23"))
+        Library baseLib = repo.read(Library.class, new IdType("Library/SpecificationLibraryDraftVersion-1-0-0-23"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(baseLib);
         IKnowledgeArtifactVisitor draftVisitor = new DraftVisitor();
         try {
-            libraryAdapter.accept(draftVisitor, spyRepository, params);
+            libraryAdapter.accept(draftVisitor, repo, params);
         } catch (PreconditionFailedException e) {
             maybeException = e.getMessage();
         }
@@ -215,9 +192,8 @@ class DraftVisitorTests {
     void draftOperation_version_format_test() {
         Library versionConflictLibrary = (Library)
                 jsonParser.parseResource(DraftVisitorTests.class.getResourceAsStream("Library-version-conflict.json"));
-        spyRepository.update(versionConflictLibrary);
-        Library baseLib = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibraryDraftVersion-1-0-0-23"))
+        repo.update(versionConflictLibrary);
+        Library baseLib = repo.read(Library.class, new IdType("Library/SpecificationLibraryDraftVersion-1-0-0-23"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(baseLib);
         IKnowledgeArtifactVisitor draftVisitor = new DraftVisitor();
@@ -226,7 +202,7 @@ class DraftVisitorTests {
             UnprocessableEntityException maybeException = null;
             Parameters params = parameters(part("version", new StringType(version)));
             try {
-                libraryAdapter.accept(draftVisitor, spyRepository, params);
+                libraryAdapter.accept(draftVisitor, repo, params);
             } catch (UnprocessableEntityException e) {
                 maybeException = e;
             }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/PackageVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/PackageVisitorTests.java
@@ -4,9 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
 import static org.opencds.cqf.fhir.utility.r5.Parameters.parameters;
 import static org.opencds.cqf.fhir.utility.r5.Parameters.part;
 
@@ -38,8 +35,6 @@ import org.hl7.fhir.r5.model.ValueSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.adapter.LibraryAdapter;
@@ -50,35 +45,25 @@ import org.opencds.cqf.fhir.utility.visitor.PackageVisitor;
 class PackageVisitorTests {
     private final FhirContext fhirContext = FhirContext.forR5Cached();
     private final IParser jsonParser = fhirContext.newJsonParser();
-    private Repository spyRepository;
+    private Repository repo;
 
     @BeforeEach
     void setup() {
-        spyRepository = spy(new InMemoryFhirRepository(fhirContext));
-        doAnswer(new Answer<Bundle>() {
-                    @Override
-                    public Bundle answer(InvocationOnMock a) throws Throwable {
-                        Bundle b = a.getArgument(0);
-                        return InMemoryFhirRepository.transactionStub(b, spyRepository);
-                    }
-                })
-                .when(spyRepository)
-                .transaction(any());
+        repo = new InMemoryFhirRepository(fhirContext);
     }
 
     @Test
     void visitLibraryTest() {
         Bundle loadedBundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example-naive.json"));
-        spyRepository.transaction(loadedBundle);
+        repo.transaction(loadedBundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
 
-        Bundle packagedBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, params);
+        Bundle packagedBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, params);
         assertNotNull(packagedBundle);
         assertEquals(packagedBundle.getEntry().size(), loadedBundle.getEntry().size());
 
@@ -103,17 +88,16 @@ class PackageVisitorTests {
     void packageOperation_should_fail_no_credentials() {
         Bundle loadedBundle = (Bundle)
                 jsonParser.parseResource(PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
-        spyRepository.transaction(loadedBundle);
+        repo.transaction(loadedBundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
 
         UnprocessableEntityException maybeException = null;
         try {
-            libraryAdapter.accept(packageVisitor, spyRepository, params);
+            libraryAdapter.accept(packageVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             maybeException = e;
         }
@@ -125,10 +109,9 @@ class PackageVisitorTests {
     void packageOperation_should_fail_credentials_missing_username() {
         Bundle loadedBundle = (Bundle)
                 jsonParser.parseResource(PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
-        spyRepository.transaction(loadedBundle);
+        repo.transaction(loadedBundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
@@ -139,7 +122,7 @@ class PackageVisitorTests {
 
         UnprocessableEntityException maybeException = null;
         try {
-            libraryAdapter.accept(packageVisitor, spyRepository, params);
+            libraryAdapter.accept(packageVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             maybeException = e;
         }
@@ -151,10 +134,9 @@ class PackageVisitorTests {
     void packageOperation_should_fail_credentials_missing_apikey() {
         Bundle loadedBundle = (Bundle)
                 jsonParser.parseResource(PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
-        spyRepository.transaction(loadedBundle);
+        repo.transaction(loadedBundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
@@ -165,7 +147,7 @@ class PackageVisitorTests {
 
         UnprocessableEntityException maybeException = null;
         try {
-            libraryAdapter.accept(packageVisitor, spyRepository, params);
+            libraryAdapter.accept(packageVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             maybeException = e;
         }
@@ -177,10 +159,9 @@ class PackageVisitorTests {
     void packageOperation_should_fail_credentials_invalid() {
         Bundle loadedBundle = (Bundle)
                 jsonParser.parseResource(PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-example.json"));
-        spyRepository.transaction(loadedBundle);
+        repo.transaction(loadedBundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
@@ -191,7 +172,7 @@ class PackageVisitorTests {
 
         UnprocessableEntityException maybeException = null;
         try {
-            libraryAdapter.accept(packageVisitor, spyRepository, params);
+            libraryAdapter.accept(packageVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             maybeException = e;
         }
@@ -203,11 +184,10 @@ class PackageVisitorTests {
     void packageOperation_should_fail_non_matching_capability() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-package-capabilities.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         List<String> capabilities = Arrays.asList("computable", "publishable", "executable");
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         // the library contains all three capabilities
@@ -217,7 +197,7 @@ class PackageVisitorTests {
             Parameters params = parameters(part("capability", capability));
             PreconditionFailedException maybeException = null;
             try {
-                libraryAdapter.accept(packageVisitor, spyRepository, params);
+                libraryAdapter.accept(packageVisitor, repo, params);
             } catch (PreconditionFailedException e) {
                 maybeException = e;
             }
@@ -225,7 +205,7 @@ class PackageVisitorTests {
         }
         Parameters allParams = parameters(
                 part("capability", "computable"), part("capability", "publishable"), part("capability", "executable"));
-        Bundle packaged = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, allParams);
+        Bundle packaged = (Bundle) libraryAdapter.accept(packageVisitor, repo, allParams);
 
         // no error when running the operation with all
         // three capabilities
@@ -236,10 +216,9 @@ class PackageVisitorTests {
     void packageOperation_should_apply_check_force_canonicalVersions() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-active-no-versions.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         String versionToUpdateTo = "1.3.1.23";
@@ -251,7 +230,7 @@ class PackageVisitorTests {
                 part(
                         "artifactVersion",
                         new CanonicalType("http://to-add-missing-version/ValueSet/dxtc|" + versionToUpdateTo)));
-        Bundle updatedCanonicalVersionPackage = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, params);
+        Bundle updatedCanonicalVersionPackage = (Bundle) libraryAdapter.accept(packageVisitor, repo, params);
 
         List<MetadataResource> updatedResources = updatedCanonicalVersionPackage.getEntry().stream()
                 .map(entry -> (MetadataResource) entry.getResource())
@@ -267,7 +246,7 @@ class PackageVisitorTests {
         String correctCheckVersion = "2022-10-19";
         PreconditionFailedException checkCanonicalThrewError = null;
         try {
-            libraryAdapter.accept(packageVisitor, spyRepository, params);
+            libraryAdapter.accept(packageVisitor, repo, params);
         } catch (PreconditionFailedException e) {
             checkCanonicalThrewError = e;
         }
@@ -275,7 +254,7 @@ class PackageVisitorTests {
         params = parameters(part(
                 "checkArtifactVersion",
                 new CanonicalType("http://to-check-version/Library/SpecificationLibrary|" + correctCheckVersion)));
-        Bundle noErrorCheckCanonicalPackage = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, params);
+        Bundle noErrorCheckCanonicalPackage = (Bundle) libraryAdapter.accept(packageVisitor, repo, params);
         Optional<MetadataResource> checkedVersionResource = noErrorCheckCanonicalPackage.getEntry().stream()
                 .map(entry -> (MetadataResource) entry.getResource())
                 .filter(resource -> resource.getUrl().contains("to-check-version"))
@@ -285,7 +264,7 @@ class PackageVisitorTests {
         String versionToForceTo = "1.1.9.23";
         params = parameters(part(
                 "forceArtifactVersion", new CanonicalType("http://to-force-version/Library/rctc|" + versionToForceTo)));
-        Bundle forcedVersionPackage = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, params);
+        Bundle forcedVersionPackage = (Bundle) libraryAdapter.accept(packageVisitor, repo, params);
         Optional<MetadataResource> forcedVersionResource = forcedVersionPackage.getEntry().stream()
                 .map(entry -> (MetadataResource) entry.getResource())
                 .filter(resource -> resource.getUrl().contains("to-force-version"))
@@ -298,37 +277,36 @@ class PackageVisitorTests {
     void packageOperation_should_respect_count_offset() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters countZeroParams = parameters(part("count", new IntegerType(0)));
-        Bundle countZeroBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, countZeroParams);
+        Bundle countZeroBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, countZeroParams);
         // when count = 0 only show the total
         assertEquals(0, countZeroBundle.getEntry().size());
         assertEquals(6, countZeroBundle.getTotal());
         Parameters count2Params = parameters(part("count", new IntegerType(2)));
-        Bundle count2Bundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, count2Params);
+        Bundle count2Bundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, count2Params);
         assertEquals(2, count2Bundle.getEntry().size());
         Parameters count2Offset2Params =
                 parameters(part("count", new IntegerType(2)), part("offset", new IntegerType(2)));
-        Bundle count2Offset2Bundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, count2Offset2Params);
+        Bundle count2Offset2Bundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, count2Offset2Params);
         assertEquals(2, count2Offset2Bundle.getEntry().size());
         Parameters offset4Params = parameters(part("offset", new IntegerType(4)));
-        Bundle offset4Bundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, offset4Params);
+        Bundle offset4Bundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, offset4Params);
         assertEquals(offset4Bundle.getEntry().size(), (countZeroBundle.getTotal() - 4));
         assertTrue(offset4Bundle.getType() == BundleType.COLLECTION);
         assertFalse(offset4Bundle.hasTotal());
         Parameters offsetMaxParams = parameters(part("offset", new IntegerType(countZeroBundle.getTotal())));
-        Bundle offsetMaxBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, offsetMaxParams);
+        Bundle offsetMaxBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, offsetMaxParams);
         assertEquals(0, offsetMaxBundle.getEntry().size());
         Parameters offsetMaxRandomCountParams = parameters(
                 part("offset", new IntegerType(countZeroBundle.getTotal())),
                 part("count", new IntegerType(ThreadLocalRandom.current().nextInt(3, 20))));
         Bundle offsetMaxRandomCountBundle =
-                (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, offsetMaxRandomCountParams);
+                (Bundle) libraryAdapter.accept(packageVisitor, repo, offsetMaxRandomCountParams);
         assertEquals(0, offsetMaxRandomCountBundle.getEntry().size());
     }
 
@@ -336,26 +314,25 @@ class PackageVisitorTests {
     void packageOperation_different_bundle_types() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters countZeroParams = parameters(part("count", new IntegerType(0)));
-        Bundle countZeroBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, countZeroParams);
+        Bundle countZeroBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, countZeroParams);
         assertTrue(countZeroBundle.getType() == BundleType.SEARCHSET);
         Parameters countSevenParams = parameters(part("count", new IntegerType(7)));
-        Bundle countSevenBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, countSevenParams);
+        Bundle countSevenBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, countSevenParams);
         assertTrue(countSevenBundle.getType() == BundleType.TRANSACTION);
         Parameters countFourParams = parameters(part("count", new IntegerType(4)));
-        Bundle countFourBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, countFourParams);
+        Bundle countFourBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, countFourParams);
         assertTrue(countFourBundle.getType() == BundleType.COLLECTION);
         // these assertions test for Bundle base profile conformance when type = collection
         assertFalse(countFourBundle.getEntry().stream().anyMatch(entry -> entry.hasRequest()));
         assertFalse(countFourBundle.hasTotal());
         Parameters offsetOneParams = parameters(part("offset", new IntegerType(1)));
-        Bundle offsetOneBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, offsetOneParams);
+        Bundle offsetOneBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, offsetOneParams);
         assertTrue(offsetOneBundle.getType() == BundleType.COLLECTION);
         // these assertions test for Bundle base profile conformance when type = collection
         assertFalse(offsetOneBundle.getEntry().stream().anyMatch(entry -> entry.hasRequest()));
@@ -363,8 +340,7 @@ class PackageVisitorTests {
 
         Parameters countOneOffsetOneParams =
                 parameters(part("count", new IntegerType(1)), part("offset", new IntegerType(1)));
-        Bundle countOneOffsetOneBundle =
-                (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, countOneOffsetOneParams);
+        Bundle countOneOffsetOneBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, countOneOffsetOneParams);
         assertTrue(countOneOffsetOneBundle.getType() == BundleType.COLLECTION);
         // these assertions test for Bundle base profile conformance when type = collection
         assertFalse(countOneOffsetOneBundle.getEntry().stream().anyMatch(entry -> entry.hasRequest()));
@@ -375,14 +351,13 @@ class PackageVisitorTests {
     void packageOperation_should_conditionally_create() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters emptyParams = parameters();
-        Bundle packagedBundle = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, emptyParams);
+        Bundle packagedBundle = (Bundle) libraryAdapter.accept(packageVisitor, repo, emptyParams);
         for (BundleEntryComponent component : packagedBundle.getEntry()) {
             String ifNoneExist = component.getRequest().getIfNoneExist();
             String url = ((MetadataResource) component.getResource()).getUrl();
@@ -395,10 +370,9 @@ class PackageVisitorTests {
     void packageOperation_should_respect_include() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 PackageVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         PackageVisitor packageVisitor = new PackageVisitor(fhirContext);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Map<String, List<String>> includeOptions = new HashMap<String, List<String>>();
@@ -431,7 +405,7 @@ class PackageVisitorTests {
         includeOptions.put("examples", Arrays.asList());
         for (Entry<String, List<String>> includedTypeURLs : includeOptions.entrySet()) {
             Parameters params = parameters(part("include", includedTypeURLs.getKey()));
-            Bundle packaged = (Bundle) libraryAdapter.accept(packageVisitor, spyRepository, params);
+            Bundle packaged = (Bundle) libraryAdapter.accept(packageVisitor, repo, params);
             List<MetadataResource> resources = packaged.getEntry().stream()
                     .map(entry -> (MetadataResource) entry.getResource())
                     .collect(Collectors.toList());

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/ReleaseVisitorTests.java
@@ -192,9 +192,9 @@ class ReleaseVisitorTests {
         repo.transaction(bundle);
         Library library = repo.read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
                 .copy();
-        Measure CervicalCancerScreeningFHIR =
+        Measure cervicalCancerScreeningFHIR =
                 repo.read(Measure.class, new IdType("Measure/CervicalCancerScreeningFHIR"));
-        Measure BreastCancerScreeningFHIR = repo.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
+        Measure breastCancerScreeningFHIR = repo.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
         params.addParameter("version", "1.0.0");
@@ -207,17 +207,17 @@ class ReleaseVisitorTests {
         // Approval date is required to release an artifact
         library.setApprovalDateElement(new DateType("2024-04-23"));
         // if both cqfm and crmi effective data requirements are present then they will each be traced
-        var crmiEDRCervical = CervicalCancerScreeningFHIR.getContained().get(0).copy();
+        var crmiEDRCervical = cervicalCancerScreeningFHIR.getContained().get(0).copy();
         crmiEDRCervical.setId(crmiEDRId);
-        CervicalCancerScreeningFHIR.addContained(crmiEDRCervical);
-        CervicalCancerScreeningFHIR.addExtension(crmiEDRExtension);
+        cervicalCancerScreeningFHIR.addContained(crmiEDRCervical);
+        cervicalCancerScreeningFHIR.addExtension(crmiEDRExtension);
         var crmiEDRBreastCancer =
-                BreastCancerScreeningFHIR.getContained().get(0).copy();
+                breastCancerScreeningFHIR.getContained().get(0).copy();
         crmiEDRBreastCancer.setId(crmiEDRId);
-        BreastCancerScreeningFHIR.addContained(crmiEDRBreastCancer);
-        BreastCancerScreeningFHIR.addExtension(crmiEDRExtension);
-        repo.update(CervicalCancerScreeningFHIR);
-        repo.update(BreastCancerScreeningFHIR);
+        breastCancerScreeningFHIR.addContained(crmiEDRBreastCancer);
+        breastCancerScreeningFHIR.addExtension(crmiEDRExtension);
+        repo.update(cervicalCancerScreeningFHIR);
+        repo.update(breastCancerScreeningFHIR);
 
         Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/ReleaseVisitorTests.java
@@ -3,9 +3,6 @@ package org.opencds.cqf.fhir.utility.visitor.r5;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
 import static org.opencds.cqf.fhir.utility.r5.Parameters.parameters;
 import static org.opencds.cqf.fhir.utility.r5.Parameters.part;
 
@@ -41,8 +38,6 @@ import org.hl7.fhir.r5.model.SearchParameter;
 import org.hl7.fhir.r5.model.StringType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.opencds.cqf.fhir.api.Repository;
 import org.opencds.cqf.fhir.utility.Canonicals;
 import org.opencds.cqf.fhir.utility.Constants;
@@ -57,7 +52,7 @@ import org.slf4j.event.Level;
 
 class ReleaseVisitorTests {
     private final FhirContext fhirContext = FhirContext.forR5Cached();
-    private Repository spyRepository;
+    private Repository repo;
     private final IParser jsonParser = fhirContext.newJsonParser();
     private final List<String> badVersionList = Arrays.asList(
             "11asd1",
@@ -81,26 +76,16 @@ class ReleaseVisitorTests {
     void setup() {
         SearchParameter sp = (SearchParameter) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("SearchParameter-artifactAssessment.json"));
-        spyRepository = spy(new InMemoryFhirRepository(fhirContext));
-        spyRepository.update(sp);
-        doAnswer(new Answer<Bundle>() {
-                    @Override
-                    public Bundle answer(InvocationOnMock a) throws Throwable {
-                        Bundle b = a.getArgument(0);
-                        return InMemoryFhirRepository.transactionStub(b, spyRepository);
-                    }
-                })
-                .when(spyRepository)
-                .transaction(any());
+        repo = new InMemoryFhirRepository(fhirContext);
+        repo.update(sp);
     }
 
     @Test
     void visitMeasureCollectionTest() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ecqm-qicore-2024-simplified.json"));
-        spyRepository.transaction(bundle);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
+        repo.transaction(bundle);
+        Library library = repo.read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
                 .copy();
 
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
@@ -112,14 +97,14 @@ class ReleaseVisitorTests {
         // Approval date is required to release an artifact
         library.setApprovalDateElement(new DateType("2024-04-23"));
         // Set the ID to Manifest-Release
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        Library releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         var dependenciesOnReleasedArtifact = releasedLibrary.getRelatedArtifact().stream()
                 .filter(ra -> ra.getType().equals(RelatedArtifact.RelatedArtifactType.DEPENDSON))
                 .collect(Collectors.toList());
@@ -161,14 +146,12 @@ class ReleaseVisitorTests {
     void visitMeasureEffectiveDataRequirementsTest() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ecqm-qicore-2024-simplified.json"));
-        spyRepository.transaction(bundle);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
+        repo.transaction(bundle);
+        Library library = repo.read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
                 .copy();
         Measure CervicalCancerScreeningFHIR =
-                spyRepository.read(Measure.class, new IdType("Measure/CervicalCancerScreeningFHIR"));
-        Measure BreastCancerScreeningFHIR =
-                spyRepository.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
+                repo.read(Measure.class, new IdType("Measure/CervicalCancerScreeningFHIR"));
+        Measure BreastCancerScreeningFHIR = repo.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
         params.addParameter("version", "1.0.0");
@@ -179,18 +162,18 @@ class ReleaseVisitorTests {
         library.setApprovalDateElement(new DateType("2024-04-23"));
         // removing the effectiveDataRequirements changes the dependency count
         CervicalCancerScreeningFHIR.setContained(null);
-        spyRepository.update(CervicalCancerScreeningFHIR);
+        repo.update(CervicalCancerScreeningFHIR);
         BreastCancerScreeningFHIR.setContained(null);
-        spyRepository.update(BreastCancerScreeningFHIR);
+        repo.update(BreastCancerScreeningFHIR);
 
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        Library releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         var dependenciesOnReleasedArtifact = releasedLibrary.getRelatedArtifact().stream()
                 .filter(ra -> ra.getType().equals(RelatedArtifact.RelatedArtifactType.DEPENDSON))
                 .collect(Collectors.toList());
@@ -206,14 +189,12 @@ class ReleaseVisitorTests {
     void bothCRMIandCQFMEffectiveDataRequirementsTest() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ecqm-qicore-2024-simplified.json"));
-        spyRepository.transaction(bundle);
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
+        repo.transaction(bundle);
+        Library library = repo.read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
                 .copy();
         Measure CervicalCancerScreeningFHIR =
-                spyRepository.read(Measure.class, new IdType("Measure/CervicalCancerScreeningFHIR"));
-        Measure BreastCancerScreeningFHIR =
-                spyRepository.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
+                repo.read(Measure.class, new IdType("Measure/CervicalCancerScreeningFHIR"));
+        Measure BreastCancerScreeningFHIR = repo.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
         params.addParameter("version", "1.0.0");
@@ -235,17 +216,17 @@ class ReleaseVisitorTests {
         crmiEDRBreastCancer.setId(crmiEDRId);
         BreastCancerScreeningFHIR.addContained(crmiEDRBreastCancer);
         BreastCancerScreeningFHIR.addExtension(crmiEDRExtension);
-        spyRepository.update(CervicalCancerScreeningFHIR);
-        spyRepository.update(BreastCancerScreeningFHIR);
+        repo.update(CervicalCancerScreeningFHIR);
+        repo.update(BreastCancerScreeningFHIR);
 
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        Library releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         var dependenciesOnReleasedArtifact = releasedLibrary.getRelatedArtifact().stream()
                 .filter(ra -> ra.getType().equals(RelatedArtifact.RelatedArtifactType.DEPENDSON))
                 .collect(Collectors.toList());
@@ -262,10 +243,9 @@ class ReleaseVisitorTests {
     void visitLibraryTest() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ersd-release-bundle.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/ReleaseSpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/ReleaseSpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         String version = "1.0.1";
@@ -274,14 +254,14 @@ class ReleaseVisitorTests {
         params.addParameter("version", version);
         params.addParameter("versionBehavior", new CodeType("default"));
 
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        Library releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         // versionBehaviour == 'default' so version should be
         // existingVersion and not the new version provided in
         // the parameters
@@ -387,26 +367,25 @@ class ReleaseVisitorTests {
     void releaseResource_force_version() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         // Existing version should be "1.2.3";
         String newVersionToForce = "1.2.7";
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = parameters(
                 part("version", new StringType(newVersionToForce)), part("versionBehavior", new CodeType("force")));
 
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
 
         assertNotNull(returnResource);
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library/SpecificationLibrary"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        Library releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         assertEquals(releasedLibrary.getVersion(), newVersionToForce);
     }
 
@@ -415,11 +394,11 @@ class ReleaseVisitorTests {
         // SpecificationLibrary - root is experimental but HAS experimental children
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft-experimental.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         // SpecificationLibrary2 - root is NOT experimental but HAS experimental children
         Bundle bundle2 = (Bundle) jsonParser.parseResource(ReleaseVisitorTests.class.getResourceAsStream(
                 "Bundle-small-approved-draft-experimental-children.json"));
-        spyRepository.transaction(bundle2);
+        repo.transaction(bundle2);
         Parameters params = parameters(
                 part("version", new StringType("1.2.3")),
                 part("versionBehavior", new CodeType("default")),
@@ -427,24 +406,22 @@ class ReleaseVisitorTests {
         Exception notExpectingAnyException = null;
         // no Exception if root is experimental
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         try {
-            libraryAdapter.accept(releaseVisitor, spyRepository, params);
+            libraryAdapter.accept(releaseVisitor, repo, params);
         } catch (Exception e) {
             notExpectingAnyException = e;
         }
         assertTrue(notExpectingAnyException == null);
 
         UnprocessableEntityException nonExperimentalChildException = null;
-        Library library2 = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary2"))
+        Library library2 = repo.read(Library.class, new IdType("Library/SpecificationLibrary2"))
                 .copy();
         LibraryAdapter libraryAdapter2 = new AdapterFactory().createLibrary(library2);
         try {
-            libraryAdapter2.accept(releaseVisitor, spyRepository, params);
+            libraryAdapter2.accept(releaseVisitor, repo, params);
         } catch (UnprocessableEntityException e) {
             nonExperimentalChildException = e;
         }
@@ -454,21 +431,19 @@ class ReleaseVisitorTests {
 
     @Test
     void releaseResource_require_non_experimental_warn() {
-        // SpecificationLibrary - root is experimentalbut HAS experimental children
+        // SpecificationLibrary - root is experimental but HAS experimental children
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft-experimental.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         // SpecificationLibrary2 - root is NOT experimental but HAS experimental children
         Bundle bundle2 = (Bundle) jsonParser.parseResource(ReleaseVisitorTests.class.getResourceAsStream(
                 "Bundle-small-approved-draft-experimental-children.json"));
-        spyRepository.transaction(bundle2);
+        repo.transaction(bundle2);
 
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
-        Library library2 = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary2"))
+        Library library2 = repo.read(Library.class, new IdType("Library/SpecificationLibrary2"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         LibraryAdapter libraryAdapter2 = new AdapterFactory().createLibrary(library2);
@@ -481,11 +456,11 @@ class ReleaseVisitorTests {
         var logger = TestLoggerFactory.getTestLogger(ReleaseVisitor.class);
         logger.clear();
 
-        libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        libraryAdapter.accept(releaseVisitor, repo, params);
         // no warning if the root is Experimental
         assertEquals(0, logger.getLoggingEvents().size());
 
-        libraryAdapter2.accept(releaseVisitor, spyRepository, params);
+        libraryAdapter2.accept(releaseVisitor, repo, params);
 
         var warningMessages = logger.getLoggingEvents().stream()
                 .filter(event -> event.getLevel().equals(Level.WARN))
@@ -504,17 +479,16 @@ class ReleaseVisitorTests {
     void releaseResource_propagate_effective_period() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ersd-no-child-effective-period.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         String effectivePeriodToPropagate = "2020-12-11";
 
         Parameters params =
                 parameters(part("version", new StringType("1.2.7")), part("versionBehavior", new CodeType("default")));
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);
         MetadataResourceHelper.forEachMetadataResource(
                 returnResource.getEntry(),
@@ -533,14 +507,14 @@ class ReleaseVisitorTests {
                         assertEquals(startString, effectivePeriodToPropagate);
                     }
                 },
-                spyRepository);
+                repo);
     }
 
     @Test
     void releaseResource_latestFromTx_NotSupported_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
 
         String actualErrorMessage = "";
 
@@ -549,13 +523,12 @@ class ReleaseVisitorTests {
                 part("versionBehavior", new CodeType("default")),
                 part("latestFromTxServer", new BooleanType(true)));
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
 
         try {
-            libraryAdapter.accept(releaseVisitor, spyRepository, params);
+            libraryAdapter.accept(releaseVisitor, repo, params);
         } catch (Exception e) {
             actualErrorMessage = e.getMessage();
         }
@@ -566,19 +539,18 @@ class ReleaseVisitorTests {
     void release_missing_approvalDate_validation_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-release-missing-approvalDate.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
 
         String versionData = "1.2.3";
         String actualErrorMessage = "";
 
         Parameters params1 = parameters(part("version", versionData), part("versionBehavior", new CodeType("default")));
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/ReleaseSpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/ReleaseSpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         try {
-            libraryAdapter.accept(releaseVisitor, spyRepository, params1);
+            libraryAdapter.accept(releaseVisitor, repo, params1);
         } catch (Exception e) {
             actualErrorMessage = e.getMessage();
         }
@@ -589,10 +561,9 @@ class ReleaseVisitorTests {
     void release_version_format_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         for (String version : badVersionList) {
@@ -600,7 +571,7 @@ class ReleaseVisitorTests {
             Parameters params = parameters(
                     part("version", new StringType(version)), part("versionBehavior", new CodeType("force")));
             try {
-                libraryAdapter.accept(releaseVisitor, spyRepository, params);
+                libraryAdapter.accept(releaseVisitor, repo, params);
 
             } catch (UnprocessableEntityException e) {
                 maybeException = e;
@@ -613,25 +584,24 @@ class ReleaseVisitorTests {
     void release_releaseLabel_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         String releaseLabel = "release label test";
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = parameters(
                 part("releaseLabel", new StringType(releaseLabel)),
                 part("version", "1.2.3"),
                 part("versionBehavior", new CodeType("default")));
-        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, spyRepository, params);
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
 
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
                 .filter(entry -> entry.getResponse().getLocation().contains("Library/SpecificationLibrary"))
                 .findFirst();
         assertTrue(maybeLib.isPresent());
-        Library releasedLibrary = spyRepository.read(
-                Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         Optional<Extension> maybeReleaseLabel = releasedLibrary.getExtension().stream()
                 .filter(ext -> ext.getUrl().equals(KnowledgeArtifactAdapter.releaseLabelUrl))
                 .findFirst();
@@ -643,10 +613,9 @@ class ReleaseVisitorTests {
     void release_version_active_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
 
@@ -654,7 +623,7 @@ class ReleaseVisitorTests {
         Parameters params =
                 parameters(part("version", new StringType("1.2.3")), part("versionBehavior", new CodeType("force")));
         try {
-            libraryAdapter.accept(releaseVisitor, spyRepository, params);
+            libraryAdapter.accept(releaseVisitor, repo, params);
         } catch (PreconditionFailedException e) {
             maybeException = e;
         }
@@ -665,10 +634,9 @@ class ReleaseVisitorTests {
     void release_versionBehaviour_format_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
-        spyRepository.transaction(bundle);
+        repo.transaction(bundle);
         ReleaseVisitor releaseVisitor = new ReleaseVisitor();
-        Library library = spyRepository
-                .read(Library.class, new IdType("Library/SpecificationLibrary"))
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
                 .copy();
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         List<String> badVersionBehaviors = Arrays.asList("not-a-valid-option", null);
@@ -677,7 +645,7 @@ class ReleaseVisitorTests {
             Parameters params = parameters(
                     part("version", new StringType("1.2.3")), part("versionBehavior", new CodeType(versionBehaviour)));
             try {
-                libraryAdapter.accept(releaseVisitor, spyRepository, params);
+                libraryAdapter.accept(releaseVisitor, repo, params);
             } catch (FHIRException e) {
                 maybeException = e;
             } catch (UnprocessableEntityException e) {

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/ReleaseVisitorTests.java
@@ -149,9 +149,9 @@ class ReleaseVisitorTests {
         repo.transaction(bundle);
         Library library = repo.read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
                 .copy();
-        Measure CervicalCancerScreeningFHIR =
+        Measure cervicalCancerScreeningFHIR =
                 repo.read(Measure.class, new IdType("Measure/CervicalCancerScreeningFHIR"));
-        Measure BreastCancerScreeningFHIR = repo.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
+        Measure breastCancerScreeningFHIR = repo.read(Measure.class, new IdType("Measure/BreastCancerScreeningFHIR"));
         LibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
         Parameters params = new Parameters();
         params.addParameter("version", "1.0.0");
@@ -161,10 +161,10 @@ class ReleaseVisitorTests {
         // Approval date is required to release an artifact
         library.setApprovalDateElement(new DateType("2024-04-23"));
         // removing the effectiveDataRequirements changes the dependency count
-        CervicalCancerScreeningFHIR.setContained(null);
-        repo.update(CervicalCancerScreeningFHIR);
-        BreastCancerScreeningFHIR.setContained(null);
-        repo.update(BreastCancerScreeningFHIR);
+        cervicalCancerScreeningFHIR.setContained(null);
+        repo.update(cervicalCancerScreeningFHIR);
+        breastCancerScreeningFHIR.setContained(null);
+        repo.update(breastCancerScreeningFHIR);
 
         Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
         assertNotNull(returnResource);


### PR DESCRIPTION
* Move the transaction stub implementation into transaction
  * This allows the InMemoryRepository to be used as a "fake" rather than a "mock"
* Update all tests using that stub  