### PR TITLE
Fix multiple iterations of an artifact in ReleaseVisitor

### DIFF
--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/KnowledgeArtifactAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/KnowledgeArtifactAdapter.java
@@ -98,6 +98,17 @@ public interface KnowledgeArtifactAdapter extends ResourceAdapter {
         getModelResolver().setValue(get(), "version", newStringType(get().getStructureFhirVersionEnum(), version));
     }
 
+    /**
+     * Returns the url of the artifact appended with '|' version if the artifact has a version.
+     * @return
+     */
+    default String getCanonical() {
+        if (!hasUrl()) {
+            return getId().getValueAsString();
+        }
+        return getUrl().concat(hasVersion() ? String.format("|%s", getVersion()) : "");
+    }
+
     List<IDependencyInfo> getDependencies();
 
     default String getReferenceSource() {

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/visitor/ReleaseVisitor.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/visitor/ReleaseVisitor.java
@@ -202,55 +202,53 @@ public class ReleaseVisitor extends AbstractKnowledgeArtifactVisitor {
         var resourcesToUpdate = new ArrayList<IDomainResource>();
         if (releasedResources.contains(artifactAdapter.getCanonical())) {
             return resourcesToUpdate;
-        } else {
-            releasedResources.add(artifactAdapter.getCanonical());
-            // Step 1: Update the Date, version and propagate effectivePeriod if it doesn't exist
-            updateMetadata(artifactAdapter, version, rootEffectivePeriod, current);
-            // Step 2: add the resource to the list of released resources
-            resourcesToUpdate.add(artifactAdapter.get());
-            // Step 3 : Go through all the components, update them and recursively release them if Owned
-            for (var component : artifactAdapter.getComponents()) {
-                final var preReleaseReference = KnowledgeArtifactAdapter.getRelatedArtifactReference(component);
-                if (!StringUtils.isBlank(preReleaseReference)) {
-                    // For composed-of references, if a version is NOT specified in the reference
-                    // then the latest version of the referenced artifact should be used.
+        }
+        releasedResources.add(artifactAdapter.getCanonical());
+        // Step 1: Update the Date, version and propagate effectivePeriod if it doesn't exist
+        updateMetadata(artifactAdapter, version, rootEffectivePeriod, current);
+        // Step 2: add the resource to the list of released resources
+        resourcesToUpdate.add(artifactAdapter.get());
+        // Step 3 : Go through all the components, update them and recursively release them if Owned
+        for (var component : artifactAdapter.getComponents()) {
+            final var preReleaseReference = KnowledgeArtifactAdapter.getRelatedArtifactReference(component);
+            if (!StringUtils.isBlank(preReleaseReference)) {
+                // For composed-of references, if a version is NOT specified in the reference
+                // then the latest version of the referenced artifact should be used.
 
-                    //  If a version IS specified then `tryGetLatestVersion`
-                    //  will return that version.
-                    var alreadyUpdated = checkIfReferenceInList(preReleaseReference, resourcesToUpdate);
-                    if (KnowledgeArtifactAdapter.checkIfRelatedArtifactIsOwned(component)
-                            && !alreadyUpdated.isPresent()) {
-                        // get the latest version regardless of status because it's owned and we're releasing it
-                        var latest = VisitorHelper.tryGetLatestVersion(preReleaseReference, repository);
-                        if (latest.isPresent()) {
-                            checkNonExperimental(latest.get().get(), experimentalBehavior, repository);
-                            // release components recursively
-                            resourcesToUpdate.addAll(internalRelease(
-                                    latest.get(),
-                                    version,
-                                    rootEffectivePeriod,
-                                    latestFromTxServer,
-                                    experimentalBehavior,
-                                    repository,
-                                    current,
-                                    releasedResources));
-                        } else {
-                            // if missing throw because it's an owned resource
-                            throw new ResourceNotFoundException(String.format(
-                                    "Resource with URL '%s' is Owned by this repository and referenced by resource '%s', but no active version was found on the server.",
-                                    preReleaseReference, artifactAdapter.getUrl()));
-                        }
-                    } else if (!alreadyUpdated.isPresent()) {
-                        // if it's a not-owned component just try to get the latest active version
-                        VisitorHelper.tryGetLatestVersionWithStatus(preReleaseReference, repository, "active")
-                                .ifPresent(latestActive ->
-                                        // check if it's experimental
-                                        checkNonExperimental(latestActive.get(), experimentalBehavior, repository));
+                //  If a version IS specified then `tryGetLatestVersion`
+                //  will return that version.
+                var alreadyUpdated = checkIfReferenceInList(preReleaseReference, resourcesToUpdate);
+                if (KnowledgeArtifactAdapter.checkIfRelatedArtifactIsOwned(component) && !alreadyUpdated.isPresent()) {
+                    // get the latest version regardless of status because it's owned and we're releasing it
+                    var latest = VisitorHelper.tryGetLatestVersion(preReleaseReference, repository);
+                    if (latest.isPresent()) {
+                        checkNonExperimental(latest.get().get(), experimentalBehavior, repository);
+                        // release components recursively
+                        resourcesToUpdate.addAll(internalRelease(
+                                latest.get(),
+                                version,
+                                rootEffectivePeriod,
+                                latestFromTxServer,
+                                experimentalBehavior,
+                                repository,
+                                current,
+                                releasedResources));
+                    } else {
+                        // if missing throw because it's an owned resource
+                        throw new ResourceNotFoundException(String.format(
+                                "Resource with URL '%s' is Owned by this repository and referenced by resource '%s', but no active version was found on the server.",
+                                preReleaseReference, artifactAdapter.getUrl()));
                     }
+                } else if (!alreadyUpdated.isPresent()) {
+                    // if it's a not-owned component just try to get the latest active version
+                    VisitorHelper.tryGetLatestVersionWithStatus(preReleaseReference, repository, "active")
+                            .ifPresent(latestActive ->
+                                    // check if it's experimental
+                                    checkNonExperimental(latestActive.get(), experimentalBehavior, repository));
                 }
             }
-            return resourcesToUpdate;
         }
+        return resourcesToUpdate;
     }
 
     private void gatherDependencies(

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/ReleaseVisitorTests.java
@@ -737,12 +737,14 @@ class ReleaseVisitorTests {
                 .filter(entry -> entry.getResponse().getLocation().contains("Library/rctc"))
                 .findFirst();
         assertTrue(maybeRCTCLib.isPresent());
-        var releasedRCTCLibrary =
-                repo.read(Library.class, new IdType(maybeRCTCLib.get().getResponse().getLocation()));
-        assertEquals(2,releasedRCTCLibrary.getRelatedArtifact().size());
+        var releasedRCTCLibrary = repo.read(
+                Library.class, new IdType(maybeRCTCLib.get().getResponse().getLocation()));
+        assertEquals(2, releasedRCTCLibrary.getRelatedArtifact().size());
         // 1 component
-        assertTrue(releasedRCTCLibrary.getRelatedArtifact().stream().anyMatch(ra -> ra.getType() == RelatedArtifactType.DEPENDSON));
+        assertTrue(releasedRCTCLibrary.getRelatedArtifact().stream()
+                .anyMatch(ra -> ra.getType() == RelatedArtifactType.DEPENDSON));
         // 1 dependency
-        assertTrue(releasedRCTCLibrary.getRelatedArtifact().stream().anyMatch(ra -> ra.getType() == RelatedArtifactType.COMPOSEDOF));
+        assertTrue(releasedRCTCLibrary.getRelatedArtifact().stream()
+                .anyMatch(ra -> ra.getType() == RelatedArtifactType.COMPOSEDOF));
     }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/ReleaseVisitorTests.java
@@ -719,4 +719,30 @@ class ReleaseVisitorTests {
             });
         }
     }
+
+    @Test
+    void release_should_not_duplicate_components_as_dependencies() {
+        var bundle = (Bundle) jsonParser.parseResource(
+                ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
+        repo.transaction(bundle);
+        var releaseVisitor = new ReleaseVisitor();
+        var originalLibrary = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
+                .copy();
+        var testLibrary = originalLibrary.copy();
+        var libraryAdapter = new AdapterFactory().createLibrary(testLibrary);
+        var params =
+                parameters(part("version", new StringType("1.2.3")), part("versionBehavior", new CodeType("force")));
+        var returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
+        Optional<BundleEntryComponent> maybeRCTCLib = returnResource.getEntry().stream()
+                .filter(entry -> entry.getResponse().getLocation().contains("Library/rctc"))
+                .findFirst();
+        assertTrue(maybeRCTCLib.isPresent());
+        var releasedRCTCLibrary =
+                repo.read(Library.class, new IdType(maybeRCTCLib.get().getResponse().getLocation()));
+        assertEquals(2,releasedRCTCLibrary.getRelatedArtifact().size());
+        // 1 component
+        assertTrue(releasedRCTCLibrary.getRelatedArtifact().stream().anyMatch(ra -> ra.getType() == RelatedArtifactType.DEPENDSON));
+        // 1 dependency
+        assertTrue(releasedRCTCLibrary.getRelatedArtifact().stream().anyMatch(ra -> ra.getType() == RelatedArtifactType.COMPOSEDOF));
+    }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/ReleaseVisitorTests.java
@@ -698,4 +698,30 @@ class ReleaseVisitorTests {
             });
         }
     }
+
+    @Test
+    void release_should_not_duplicate_components_as_dependencies() {
+        var bundle = (Bundle) jsonParser.parseResource(
+                ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
+        repo.transaction(bundle);
+        var releaseVisitor = new ReleaseVisitor();
+        var originalLibrary = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
+                .copy();
+        var testLibrary = originalLibrary.copy();
+        var libraryAdapter = new AdapterFactory().createLibrary(testLibrary);
+        var params =
+                parameters(part("version", new StringType("1.2.3")), part("versionBehavior", new CodeType("force")));
+        var returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
+        Optional<BundleEntryComponent> maybeRCTCLib = returnResource.getEntry().stream()
+                .filter(entry -> entry.getResponse().getLocation().contains("Library/rctc"))
+                .findFirst();
+        assertTrue(maybeRCTCLib.isPresent());
+        var releasedRCTCLibrary =
+                repo.read(Library.class, new IdType(maybeRCTCLib.get().getResponse().getLocation()));
+        assertEquals(2,releasedRCTCLibrary.getRelatedArtifact().size());
+        // 1 component
+        assertTrue(releasedRCTCLibrary.getRelatedArtifact().stream().anyMatch(ra -> ra.getType() == RelatedArtifactType.DEPENDSON));
+        // 1 dependency
+        assertTrue(releasedRCTCLibrary.getRelatedArtifact().stream().anyMatch(ra -> ra.getType() == RelatedArtifactType.COMPOSEDOF));
+    }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/ReleaseVisitorTests.java
@@ -716,12 +716,14 @@ class ReleaseVisitorTests {
                 .filter(entry -> entry.getResponse().getLocation().contains("Library/rctc"))
                 .findFirst();
         assertTrue(maybeRCTCLib.isPresent());
-        var releasedRCTCLibrary =
-                repo.read(Library.class, new IdType(maybeRCTCLib.get().getResponse().getLocation()));
-        assertEquals(2,releasedRCTCLibrary.getRelatedArtifact().size());
+        var releasedRCTCLibrary = repo.read(
+                Library.class, new IdType(maybeRCTCLib.get().getResponse().getLocation()));
+        assertEquals(2, releasedRCTCLibrary.getRelatedArtifact().size());
         // 1 component
-        assertTrue(releasedRCTCLibrary.getRelatedArtifact().stream().anyMatch(ra -> ra.getType() == RelatedArtifactType.DEPENDSON));
+        assertTrue(releasedRCTCLibrary.getRelatedArtifact().stream()
+                .anyMatch(ra -> ra.getType() == RelatedArtifactType.DEPENDSON));
         // 1 dependency
-        assertTrue(releasedRCTCLibrary.getRelatedArtifact().stream().anyMatch(ra -> ra.getType() == RelatedArtifactType.COMPOSEDOF));
+        assertTrue(releasedRCTCLibrary.getRelatedArtifact().stream()
+                .anyMatch(ra -> ra.getType() == RelatedArtifactType.COMPOSEDOF));
     }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/ReleaseVisitorTests.java
@@ -698,7 +698,7 @@ class ReleaseVisitorTests {
             });
         }
     }
-    
+
     @Test
     void release_should_not_duplicate_components_as_dependencies() {
         var bundle = (Bundle) jsonParser.parseResource(
@@ -716,12 +716,14 @@ class ReleaseVisitorTests {
                 .filter(entry -> entry.getResponse().getLocation().contains("Library/rctc"))
                 .findFirst();
         assertTrue(maybeRCTCLib.isPresent());
-        var releasedRCTCLibrary =
-                repo.read(Library.class, new IdType(maybeRCTCLib.get().getResponse().getLocation()));
-        assertEquals(2,releasedRCTCLibrary.getRelatedArtifact().size());
+        var releasedRCTCLibrary = repo.read(
+                Library.class, new IdType(maybeRCTCLib.get().getResponse().getLocation()));
+        assertEquals(2, releasedRCTCLibrary.getRelatedArtifact().size());
         // 1 component
-        assertTrue(releasedRCTCLibrary.getRelatedArtifact().stream().anyMatch(ra -> ra.getType() == RelatedArtifactType.DEPENDSON));
+        assertTrue(releasedRCTCLibrary.getRelatedArtifact().stream()
+                .anyMatch(ra -> ra.getType() == RelatedArtifactType.DEPENDSON));
         // 1 dependency
-        assertTrue(releasedRCTCLibrary.getRelatedArtifact().stream().anyMatch(ra -> ra.getType() == RelatedArtifactType.COMPOSEDOF));
+        assertTrue(releasedRCTCLibrary.getRelatedArtifact().stream()
+                .anyMatch(ra -> ra.getType() == RelatedArtifactType.COMPOSEDOF));
     }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/ReleaseVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/ReleaseVisitorTests.java
@@ -698,4 +698,30 @@ class ReleaseVisitorTests {
             });
         }
     }
+    
+    @Test
+    void release_should_not_duplicate_components_as_dependencies() {
+        var bundle = (Bundle) jsonParser.parseResource(
+                ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
+        repo.transaction(bundle);
+        var releaseVisitor = new ReleaseVisitor();
+        var originalLibrary = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
+                .copy();
+        var testLibrary = originalLibrary.copy();
+        var libraryAdapter = new AdapterFactory().createLibrary(testLibrary);
+        var params =
+                parameters(part("version", new StringType("1.2.3")), part("versionBehavior", new CodeType("force")));
+        var returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, repo, params);
+        Optional<BundleEntryComponent> maybeRCTCLib = returnResource.getEntry().stream()
+                .filter(entry -> entry.getResponse().getLocation().contains("Library/rctc"))
+                .findFirst();
+        assertTrue(maybeRCTCLib.isPresent());
+        var releasedRCTCLibrary =
+                repo.read(Library.class, new IdType(maybeRCTCLib.get().getResponse().getLocation()));
+        assertEquals(2,releasedRCTCLibrary.getRelatedArtifact().size());
+        // 1 component
+        assertTrue(releasedRCTCLibrary.getRelatedArtifact().stream().anyMatch(ra -> ra.getType() == RelatedArtifactType.DEPENDSON));
+        // 1 dependency
+        assertTrue(releasedRCTCLibrary.getRelatedArtifact().stream().anyMatch(ra -> ra.getType() == RelatedArtifactType.COMPOSEDOF));
+    }
 }


### PR DESCRIPTION
Added a check to prevent the same artifact from being iterated through multiple times in the ReleaseVisitor if that artifact is referenced by multiple artifacts.