### PR TITLE
Add check to naiveExpand for existence of compose codes

### DIFF
--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ValueSetAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ValueSetAdapter.java
@@ -150,16 +150,18 @@ public class ValueSetAdapter extends KnowledgeArtifactAdapter
 
     @Override
     public void naiveExpand() {
-        var expansion = newExpansion().addParameter(createNaiveParameter());
-
-        for (var code : getCodesInCompose(fhirContext, getValueSet())) {
-            expansion
-                    .addContains()
-                    .setCode(code.getCode())
-                    .setSystem(code.getSystem())
-                    .setVersion(code.getVersion())
-                    .setDisplay(code.getDisplay());
+        var codes = getCodesInCompose(fhirContext, getValueSet());
+        if (codes != null && !codes.isEmpty()) {
+            var expansion = newExpansion().addParameter(createNaiveParameter());
+            for (var code : codes) {
+                expansion
+                        .addContains()
+                        .setCode(code.getCode())
+                        .setSystem(code.getSystem())
+                        .setVersion(code.getVersion())
+                        .setDisplay(code.getDisplay());
+            }
+            getValueSet().setExpansion(expansion);
         }
-        getValueSet().setExpansion(expansion);
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/ValueSetAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/ValueSetAdapter.java
@@ -151,16 +151,18 @@ public class ValueSetAdapter extends KnowledgeArtifactAdapter
 
     @Override
     public void naiveExpand() {
-        var expansion = newExpansion().addParameter(createNaiveParameter());
-
-        for (var code : getCodesInCompose(fhirContext, getValueSet())) {
-            expansion
-                    .addContains()
-                    .setCode(code.getCode())
-                    .setSystem(code.getSystem())
-                    .setVersion(code.getVersion())
-                    .setDisplay(code.getDisplay());
+        var codes = getCodesInCompose(fhirContext, getValueSet());
+        if (codes != null && !codes.isEmpty()) {
+            var expansion = newExpansion().addParameter(createNaiveParameter());
+            for (var code : codes) {
+                expansion
+                        .addContains()
+                        .setCode(code.getCode())
+                        .setSystem(code.getSystem())
+                        .setVersion(code.getVersion())
+                        .setDisplay(code.getDisplay());
+            }
+            getValueSet().setExpansion(expansion);
         }
-        getValueSet().setExpansion(expansion);
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/ValueSetAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/ValueSetAdapter.java
@@ -150,16 +150,18 @@ public class ValueSetAdapter extends KnowledgeArtifactAdapter
 
     @Override
     public void naiveExpand() {
-        var expansion = newExpansion().addParameter(createNaiveParameter());
-
-        for (var code : getCodesInCompose(fhirContext, getValueSet())) {
-            expansion
-                    .addContains()
-                    .setCode(code.getCode())
-                    .setSystem(code.getSystem())
-                    .setVersion(code.getVersion())
-                    .setDisplay(code.getDisplay());
+        var codes = getCodesInCompose(fhirContext, getValueSet());
+        if (codes != null && !codes.isEmpty()) {
+            var expansion = newExpansion().addParameter(createNaiveParameter());
+            for (var code : codes) {
+                expansion
+                        .addContains()
+                        .setCode(code.getCode())
+                        .setSystem(code.getSystem())
+                        .setVersion(code.getVersion())
+                        .setDisplay(code.getDisplay());
+            }
+            getValueSet().setExpansion(expansion);
         }
-        getValueSet().setExpansion(expansion);
     }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/ExpandHelperTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/ExpandHelperTest.java
@@ -24,9 +24,9 @@ import org.hl7.fhir.r4.model.Endpoint;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
-import org.hl7.fhir.r4.model.ValueSet.ValueSetExpansionComponent;
 import org.hl7.fhir.r4.model.UriType;
 import org.hl7.fhir.r4.model.ValueSet;
+import org.hl7.fhir.r4.model.ValueSet.ValueSetExpansionComponent;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.opencds.cqf.fhir.api.Repository;
@@ -324,11 +324,26 @@ public class ExpandHelperTest {
         var expandHelper = new ExpandHelper(fhirContext, null);
         var dxtc = repository.read(ValueSet.class, new IdType("ValueSet", "dxtc"));
         var adapter = (ValueSetAdapter) factory.createKnowledgeArtifactAdapter(dxtc);
-        assertEquals(19797, ((ValueSetExpansionComponent) adapter.getExpansion()).getContains().size());
+        assertEquals(
+                19797,
+                ((ValueSetExpansionComponent) adapter.getExpansion())
+                        .getContains()
+                        .size());
         var adapters = new ArrayList<ValueSetAdapter>();
         var expandList = new ArrayList<String>();
-        expandHelper.expandValueSet(adapter, factory.createParameters(new Parameters()), Optional.empty(), adapters, expandList, repository, new Date());
-        assertEquals(28, ((ValueSetExpansionComponent) adapter.getExpansion()).getContains().size());
+        expandHelper.expandValueSet(
+                adapter,
+                factory.createParameters(new Parameters()),
+                Optional.empty(),
+                adapters,
+                expandList,
+                repository,
+                new Date());
+        assertEquals(
+                28,
+                ((ValueSetExpansionComponent) adapter.getExpansion())
+                        .getContains()
+                        .size());
     }
 
     ValueSet createLeafWithUrl(String url) {


### PR DESCRIPTION
The naiveExpand method on ValueSetAdapter will now only set the expansion if we have a compose with codes.