### PR TITLE
Create an EvaluationSettingsBuilder

### DIFF
--- a/cqf-fhir-benchmark/src/test/java/org/opencds/cqf/fhir/benchmark/Measures.java
+++ b/cqf-fhir-benchmark/src/test/java/org/opencds/cqf/fhir/benchmark/Measures.java
@@ -32,16 +32,22 @@ public class Measures {
     @Setup(Level.Trial)
     public void setupTrial() throws Exception {
         var evaluationOptions = MeasureEvaluationOptions.defaultOptions();
-        evaluationOptions.getEvaluationSettings().setLibraryCache(new HashMap<>());
-        evaluationOptions
-                .getEvaluationSettings()
-                .getRetrieveSettings()
+
+        var retrieveSettings = evaluationOptions.getEvaluationSettings().getRetrieveSettings();
+        retrieveSettings
                 .setSearchParameterMode(SEARCH_FILTER_MODE.FILTER_IN_MEMORY)
                 .setTerminologyParameterMode(TERMINOLOGY_FILTER_MODE.FILTER_IN_MEMORY);
-        evaluationOptions
-                .getEvaluationSettings()
-                .getTerminologySettings()
-                .setValuesetExpansionMode(VALUESET_EXPANSION_MODE.PERFORM_NAIVE_EXPANSION);
+
+        var terminologySettings = evaluationOptions.getEvaluationSettings().getTerminologySettings();
+        terminologySettings.setValuesetExpansionMode(VALUESET_EXPANSION_MODE.PERFORM_NAIVE_EXPANSION);
+
+        var settingsBuilder = evaluationOptions.getEvaluationSettings().toBuilder();
+
+        settingsBuilder.libraryCache(new HashMap<>());
+        settingsBuilder.retrieveSettings(retrieveSettings);
+        settingsBuilder.terminologySettings(terminologySettings);
+
+        evaluationOptions.setEvaluationSettings(settingsBuilder.build());
 
         this.when = Measure.given()
                 .repositoryFor("CaseRepresentation101")

--- a/cqf-fhir-benchmark/src/test/java/org/opencds/cqf/fhir/benchmark/MeasuresAdditionalData.java
+++ b/cqf-fhir-benchmark/src/test/java/org/opencds/cqf/fhir/benchmark/MeasuresAdditionalData.java
@@ -34,16 +34,22 @@ public class MeasuresAdditionalData {
     @Setup(Level.Trial)
     public void setupTrial() throws Exception {
         var evaluationOptions = MeasureEvaluationOptions.defaultOptions();
-        evaluationOptions.getEvaluationSettings().setLibraryCache(new HashMap<>());
-        evaluationOptions
-                .getEvaluationSettings()
-                .getRetrieveSettings()
+
+        var retrieveSettings = evaluationOptions.getEvaluationSettings().getRetrieveSettings();
+        retrieveSettings
                 .setSearchParameterMode(SEARCH_FILTER_MODE.FILTER_IN_MEMORY)
                 .setTerminologyParameterMode(TERMINOLOGY_FILTER_MODE.FILTER_IN_MEMORY);
-        evaluationOptions
-                .getEvaluationSettings()
-                .getTerminologySettings()
-                .setValuesetExpansionMode(VALUESET_EXPANSION_MODE.PERFORM_NAIVE_EXPANSION);
+
+        var terminologySettings = evaluationOptions.getEvaluationSettings().getTerminologySettings();
+        terminologySettings.setValuesetExpansionMode(VALUESET_EXPANSION_MODE.PERFORM_NAIVE_EXPANSION);
+
+        var settingsBuilder = evaluationOptions.getEvaluationSettings().toBuilder();
+
+        settingsBuilder.libraryCache(new HashMap<>());
+        settingsBuilder.retrieveSettings(retrieveSettings);
+        settingsBuilder.terminologySettings(terminologySettings);
+
+        evaluationOptions.setEvaluationSettings(settingsBuilder.build());
 
         Bundle additionalData = (Bundle) FhirContext.forR4Cached()
                 .newJsonParser()

--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/EvaluationSettings.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/EvaluationSettings.java
@@ -7,122 +7,169 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.cqframework.cql.cql2elm.LibrarySourceProvider;
 import org.cqframework.cql.cql2elm.model.CompiledLibrary;
 import org.cqframework.cql.cql2elm.model.Model;
+import org.cqframework.fhir.npm.NpmProcessor;
 import org.hl7.cql.model.ModelIdentifier;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.opencds.cqf.cql.engine.runtime.Code;
 import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings;
 import org.opencds.cqf.fhir.cql.engine.terminology.TerminologySettings;
 
+/**
+ * This class contains settings used to set up CQL evaluation. This class is immutable once constructed.
+ * Use the Builder to create and instance of this class, and the "toBuilder()" function to create a
+ * new mutable builder to clone these settings if required.
+ */
 public class EvaluationSettings {
 
-    private Map<ModelIdentifier, Model> modelCache;
-    private Map<VersionedIdentifier, CompiledLibrary> libraryCache;
-    private Map<String, List<Code>> valueSetCache;
-    private List<LibrarySourceProvider> librarySourceProviders;
+    private final Map<ModelIdentifier, Model> modelCache;
+    private final Map<VersionedIdentifier, CompiledLibrary> libraryCache;
+    private final Map<String, List<Code>> valueSetCache;
+    private final List<LibrarySourceProvider> librarySourceProviders;
+    private final CqlOptions cqlOptions;
+    private final RetrieveSettings retrieveSettings;
+    private final TerminologySettings terminologySettings;
+    private final NpmProcessor npmProcessor;
 
-    private CqlOptions cqlOptions;
+    private EvaluationSettings(
+            Map<ModelIdentifier, Model> modelCache,
+            Map<VersionedIdentifier, CompiledLibrary> libraryCache,
+            Map<String, List<Code>> valueSetCache,
+            List<LibrarySourceProvider> librarySourceProviders,
+            CqlOptions cqlOptions,
+            RetrieveSettings retrieveSettings,
+            TerminologySettings terminologySettings,
+            NpmProcessor npmProcessor) {
+        this.modelCache = modelCache;
+        this.libraryCache = libraryCache;
+        this.valueSetCache = valueSetCache;
+        this.librarySourceProviders = librarySourceProviders;
+        this.cqlOptions = cqlOptions;
+        this.retrieveSettings = retrieveSettings;
+        this.terminologySettings = terminologySettings;
+        this.npmProcessor = npmProcessor;
+    }
 
-    private RetrieveSettings retrieveSettings;
-    private TerminologySettings terminologySettings;
+    public static EvaluationSettings.Builder builder() {
+        return new Builder();
+    }
+
+    public EvaluationSettings.Builder toBuilder() {
+        return new EvaluationSettings.Builder()
+                .cqlOptions(this.cqlOptions)
+                .modelCache(this.modelCache)
+                .libraryCache(this.libraryCache)
+                .valueSetCache(this.valueSetCache)
+                .retrieveSettings(this.retrieveSettings)
+                .terminologySettings(this.terminologySettings)
+                .librarySourceProviders(new ArrayList<>(this.librarySourceProviders))
+                .npmProcessor(this.npmProcessor);
+    }
 
     public static EvaluationSettings getDefault() {
-        EvaluationSettings settings = new EvaluationSettings();
-
         var options = CqlOptions.defaultOptions();
-        settings.setCqlOptions(options);
-        settings.setModelCache(new ConcurrentHashMap<>());
-        settings.setLibraryCache(new ConcurrentHashMap<>());
-        settings.setValueSetCache(new ConcurrentHashMap<>());
-        settings.setRetrieveSettings(new RetrieveSettings());
-        settings.setTerminologySettings(new TerminologySettings());
-        settings.withLibrarySourceProviders(new ArrayList<>());
-        return settings;
+        var builder = new EvaluationSettings.Builder()
+                .cqlOptions(options)
+                .modelCache(new ConcurrentHashMap<>())
+                .libraryCache(new ConcurrentHashMap<>())
+                .valueSetCache(new ConcurrentHashMap<>())
+                .retrieveSettings(new RetrieveSettings())
+                .terminologySettings(new TerminologySettings())
+                .librarySourceProviders(new ArrayList<>());
+        return builder.build();
     }
 
     public Map<ModelIdentifier, Model> getModelCache() {
         return this.modelCache;
     }
 
-    public void setModelCache(Map<ModelIdentifier, Model> modelCache) {
-        this.modelCache = modelCache;
-    }
-
-    public EvaluationSettings withModelCache(Map<ModelIdentifier, Model> modelCache) {
-        setModelCache(modelCache);
-        return this;
-    }
-
     public Map<VersionedIdentifier, CompiledLibrary> getLibraryCache() {
         return this.libraryCache;
-    }
-
-    public void setLibraryCache(Map<VersionedIdentifier, CompiledLibrary> libraryCache) {
-        this.libraryCache = libraryCache;
-    }
-
-    public EvaluationSettings withLibraryCache(Map<VersionedIdentifier, CompiledLibrary> libraryCache) {
-        setLibraryCache(libraryCache);
-        return this;
     }
 
     public Map<String, List<Code>> getValueSetCache() {
         return this.valueSetCache;
     }
 
-    public void setValueSetCache(Map<String, List<Code>> valueSetCache) {
-        this.valueSetCache = valueSetCache;
-    }
-
-    public EvaluationSettings withValueSetCache(Map<String, List<Code>> valueSetCache) {
-        setValueSetCache(valueSetCache);
-        return this;
-    }
-
     public CqlOptions getCqlOptions() {
         return this.cqlOptions;
-    }
-
-    public EvaluationSettings withCqlOptions(CqlOptions cqlOptions) {
-        setCqlOptions(cqlOptions);
-        return this;
-    }
-
-    public void setCqlOptions(CqlOptions cqlOptions) {
-        this.cqlOptions = cqlOptions;
     }
 
     public RetrieveSettings getRetrieveSettings() {
         return this.retrieveSettings;
     }
 
-    public EvaluationSettings withRetrieveSettings(RetrieveSettings retrieveSettings) {
-        setRetrieveSettings(retrieveSettings);
-        return this;
-    }
-
-    public void setRetrieveSettings(RetrieveSettings retrieveSettings) {
-        this.retrieveSettings = retrieveSettings;
-    }
-
     public TerminologySettings getTerminologySettings() {
         return this.terminologySettings;
     }
 
-    public EvaluationSettings withTerminologySettings(TerminologySettings terminologySettings) {
-        setTerminologySettings(terminologySettings);
-        return this;
-    }
-
-    public void setTerminologySettings(TerminologySettings terminologySettings) {
-        this.terminologySettings = terminologySettings;
-    }
-
-    public EvaluationSettings withLibrarySourceProviders(List<LibrarySourceProvider> librarySourceProviders) {
-        this.librarySourceProviders = librarySourceProviders;
-        return this;
-    }
-
     public List<LibrarySourceProvider> getLibrarySourceProviders() {
         return librarySourceProviders;
+    }
+
+    public NpmProcessor getNpmProcessor() {
+        return this.npmProcessor;
+    }
+
+    public static class Builder {
+        private Map<ModelIdentifier, Model> modelCache;
+        private Map<VersionedIdentifier, CompiledLibrary> libraryCache;
+        private Map<String, List<Code>> valueSetCache;
+        private List<LibrarySourceProvider> librarySourceProviders;
+        private CqlOptions cqlOptions;
+        private RetrieveSettings retrieveSettings;
+        private TerminologySettings terminologySettings;
+        private NpmProcessor npmProcessor;
+
+        public Builder modelCache(Map<ModelIdentifier, Model> modelCache) {
+            this.modelCache = modelCache;
+            return this;
+        }
+
+        public Builder libraryCache(Map<VersionedIdentifier, CompiledLibrary> libraryCache) {
+            this.libraryCache = libraryCache;
+            return this;
+        }
+
+        public Builder valueSetCache(Map<String, List<Code>> valueSetCache) {
+            this.valueSetCache = valueSetCache;
+            return this;
+        }
+
+        public Builder librarySourceProviders(List<LibrarySourceProvider> librarySourceProviders) {
+            this.librarySourceProviders = librarySourceProviders;
+            return this;
+        }
+
+        public Builder cqlOptions(CqlOptions cqlOptions) {
+            this.cqlOptions = cqlOptions;
+            return this;
+        }
+
+        public Builder retrieveSettings(RetrieveSettings retrieveSettings) {
+            this.retrieveSettings = retrieveSettings;
+            return this;
+        }
+
+        public Builder terminologySettings(TerminologySettings terminologySettings) {
+            this.terminologySettings = terminologySettings;
+            return this;
+        }
+
+        public Builder npmProcessor(NpmProcessor npmProcessor) {
+            this.npmProcessor = npmProcessor;
+            return this;
+        }
+
+        public EvaluationSettings build() {
+            return new EvaluationSettings(
+                    this.modelCache,
+                    this.libraryCache,
+                    this.valueSetCache,
+                    this.librarySourceProviders,
+                    this.cqlOptions,
+                    this.retrieveSettings,
+                    this.terminologySettings,
+                    this.npmProcessor);
+        }
     }
 }

--- a/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/LibraryEngineTests.java
+++ b/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/LibraryEngineTests.java
@@ -142,9 +142,11 @@ class LibraryEngineTests {
                 else return LibrarySourceProvider.super.getLibraryContent(libraryIdentifier, type);
             }
         });
-        var evaluationSettings = EvaluationSettings.getDefault().withLibrarySourceProviders(libraryResourceProvider);
+        var evaluationSettings = EvaluationSettings.getDefault().toBuilder()
+                .librarySourceProviders(libraryResourceProvider)
+                .build();
 
-        libraryEngine = new LibraryEngine(repository, evaluationSettings, null);
+        libraryEngine = new LibraryEngine(repository, evaluationSettings);
         repository.create(new Patient().addName(new HumanName().addGiven("me")).setId("Patient/Patient1"));
         var patientId = "Patient/Patient1";
         var expression =

--- a/cqf-fhir-cr-cli/src/main/java/org/opencds/cqf/fhir/cr/cli/command/CqlCommand.java
+++ b/cqf-fhir-cr-cli/src/main/java/org/opencds/cqf/fhir/cr/cli/command/CqlCommand.java
@@ -189,16 +189,16 @@ public class CqlCommand implements Callable<Integer> {
         retrieveSettings.setSearchParameterMode(SEARCH_FILTER_MODE.FILTER_IN_MEMORY);
         retrieveSettings.setProfileMode(PROFILE_MODE.DECLARED);
 
-        var evaluationSettings = EvaluationSettings.getDefault();
-        evaluationSettings.setCqlOptions(cqlOptions);
-        evaluationSettings.setTerminologySettings(terminologySettings);
-        evaluationSettings.setRetrieveSettings(retrieveSettings);
+        var settingsBuilder = EvaluationSettings.getDefault().toBuilder()
+                .cqlOptions(cqlOptions)
+                .terminologySettings(terminologySettings)
+                .retrieveSettings(retrieveSettings)
+                .npmProcessor(new NpmProcessor(igContext));
 
         for (LibraryParameter library : libraries) {
             var repository = createRepository(
                     fhirContext, library.terminologyUrl, library.model.modelUrl, library.context.contextValue);
-            var engine = Engines.forRepositoryAndSettings(
-                    evaluationSettings, repository, null, new NpmProcessor(igContext), true);
+            var engine = Engines.forRepository(repository, settingsBuilder.build());
 
             if (library.libraryUrl != null) {
                 var provider = new DefaultLibrarySourceProvider(Path.of(library.libraryUrl));

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureProcessorEvaluateTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureProcessorEvaluateTest.java
@@ -157,17 +157,22 @@ class MeasureProcessorEvaluateTest {
     @Test
     void with_custom_options() {
         var evaluationOptions = MeasureEvaluationOptions.defaultOptions();
-        evaluationOptions.getEvaluationSettings().setLibraryCache(new HashMap<>());
-        evaluationOptions
-                .getEvaluationSettings()
-                .getRetrieveSettings()
+
+        var retrieveSettings = evaluationOptions.getEvaluationSettings().getRetrieveSettings();
+        retrieveSettings
                 .setSearchParameterMode(SEARCH_FILTER_MODE.FILTER_IN_MEMORY)
                 .setTerminologyParameterMode(TERMINOLOGY_FILTER_MODE.FILTER_IN_MEMORY);
 
-        evaluationOptions
-                .getEvaluationSettings()
-                .getTerminologySettings()
-                .setValuesetExpansionMode(VALUESET_EXPANSION_MODE.PERFORM_NAIVE_EXPANSION);
+        var terminologySettings = evaluationOptions.getEvaluationSettings().getTerminologySettings();
+        terminologySettings.setValuesetExpansionMode(VALUESET_EXPANSION_MODE.PERFORM_NAIVE_EXPANSION);
+
+        var settingsBuilder = evaluationOptions.getEvaluationSettings().toBuilder();
+
+        settingsBuilder.libraryCache(new HashMap<>());
+        settingsBuilder.retrieveSettings(retrieveSettings);
+        settingsBuilder.terminologySettings(terminologySettings);
+
+        evaluationOptions.setEvaluationSettings(settingsBuilder.build());
 
         var when = Measure.given()
                 .repositoryFor("CaseRepresentation101")
@@ -189,17 +194,22 @@ class MeasureProcessorEvaluateTest {
     @Test
     void additional_data_with_custom_options() {
         var evaluationOptions = MeasureEvaluationOptions.defaultOptions();
-        evaluationOptions.getEvaluationSettings().setLibraryCache(new HashMap<>());
-        evaluationOptions
-                .getEvaluationSettings()
-                .getRetrieveSettings()
+
+        var retrieveSettings = evaluationOptions.getEvaluationSettings().getRetrieveSettings();
+        retrieveSettings
                 .setSearchParameterMode(SEARCH_FILTER_MODE.FILTER_IN_MEMORY)
                 .setTerminologyParameterMode(TERMINOLOGY_FILTER_MODE.FILTER_IN_MEMORY);
 
-        evaluationOptions
-                .getEvaluationSettings()
-                .getTerminologySettings()
-                .setValuesetExpansionMode(VALUESET_EXPANSION_MODE.PERFORM_NAIVE_EXPANSION);
+        var terminologySettings = evaluationOptions.getEvaluationSettings().getTerminologySettings();
+        terminologySettings.setValuesetExpansionMode(VALUESET_EXPANSION_MODE.PERFORM_NAIVE_EXPANSION);
+
+        var settingsBuilder = evaluationOptions.getEvaluationSettings().toBuilder();
+
+        settingsBuilder.libraryCache(new HashMap<>());
+        settingsBuilder.retrieveSettings(retrieveSettings);
+        settingsBuilder.terminologySettings(terminologySettings);
+
+        evaluationOptions.setEvaluationSettings(settingsBuilder.build());
 
         Bundle additionalData = (Bundle) FhirContext.forR4Cached()
                 .newJsonParser()


### PR DESCRIPTION
* Makes EvaluationSettings (shallowly) immutable
* Adds an EvaluationSettings.Builder to construct/clone EvaluationSettings instances
* Move NpmProcessor to EvaluationSettings, remove overloads for constructing with NpmProcessor
* Update LibraryEngine to use request-specific EvaluationSettings
* Update tests