### PR TITLE
Fix $populate issue with missing responseItems for a null population context

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ApplyProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ApplyProcessor.java
@@ -127,7 +127,7 @@ public class ApplyProcessor implements IApplyProcessor {
         var version = request.resolvePathString(request.getPlanDefinition(), "version");
         if (version != null) {
             var subject = request.getSubjectId().getIdPart();
-            var formatter = new SimpleDateFormat("yyyy-MM-dd-hh.mm.ssZ");
+            var formatter = new SimpleDateFormat("yyyy-MM-dd-hh.mm.ss");
             request.getModelResolver()
                     .setValue(
                             questionnaire,

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessItemWithContext.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessItemWithContext.java
@@ -69,6 +69,7 @@ public class ProcessItemWithContext extends ProcessItem {
                                 return null;
                             }
                         })
+                        // filtering nulls here to prevent unnecessary duplicate responseItems
                         .filter(r -> nonNull(r))
                         .collect(Collectors.toList());
         if (populationContext.isEmpty()) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessItemWithContext.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessItemWithContext.java
@@ -71,6 +71,10 @@ public class ProcessItemWithContext extends ProcessItem {
                         })
                         .filter(r -> nonNull(r))
                         .collect(Collectors.toList());
+        if (populationContext.isEmpty()) {
+            // We always want to return a responseItem even if we have nothing to populate
+            populationContext.add(null);
+        }
         return populationContext.stream()
                 .map(context ->
                         processPopulationContext(request, item, contextExpression.getName(), context, profileAdapter))


### PR DESCRIPTION
When using the item population context extension, a responseItem should now always be returned even when there is no data to populate an answer.