### PR TITLE
Update Delete operation to include deletion of Artifact Comments

### DIFF
--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/ExpandHelper.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/ExpandHelper.java
@@ -73,8 +73,7 @@ public class ExpandHelper {
         // If terminologyEndpoint exists and we have no authoritativeSourceUrl or the authoritativeSourceUrl matches the
         // terminologyEndpoint address then we will use the terminologyEndpoint for expansion
         if (terminologyEndpoint.isPresent()
-                && authoritativeSourceUrl.equals(
-                                terminologyEndpoint.get().getAddress())) {
+                && authoritativeSourceUrl.equals(terminologyEndpoint.get().getAddress())) {
             try {
                 var expandedValueSet = (ValueSetAdapter) createAdapterForResource(
                         terminologyServerClient.expand(valueSet, terminologyEndpoint.get(), expansionParameters));

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/visitor/DeleteVisitor.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/visitor/DeleteVisitor.java
@@ -26,8 +26,14 @@ public class DeleteVisitor extends AbstractKnowledgeArtifactVisitor {
         var resToUpdate = new ArrayList<IDomainResource>();
         resToUpdate.add(rootAdapter.get());
 
-        var resourcesToUpdate = getComponents(rootAdapter, repository, resToUpdate);
+        findArtifactCommentsToUpdate(rootAdapter.get(), fhirVersion.getFhirVersionString(), repository)
+                .forEach(artifact -> {
+                    var approval = BundleHelper.getEntryResource(fhirVersion, artifact);
+                    var entry = PackageHelper.deleteEntry(approval);
+                    BundleHelper.addEntry(transactionBundle, entry);
+                });
 
+        var resourcesToUpdate = getComponents(rootAdapter, repository, resToUpdate);
         for (var res : resourcesToUpdate) {
             var entry = PackageHelper.deleteEntry(res);
             BundleHelper.addEntry(transactionBundle, entry);


### PR DESCRIPTION
Delete Operation must also delete the Basic resources which represent the comments/approvals of the specified artifact

Spotless also formatted unrelated file. 