### PR TITLE
Remove Release extensions when creating a Draft of a Program

### DIFF
--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/DraftVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/dstu3/DraftVisitorTests.java
@@ -103,6 +103,8 @@ class DraftVisitorTests {
         MetadataResourceHelper.forEachMetadataResource(
                 returnedBundle.getEntry(),
                 resource -> {
+                    assertFalse(resource.hasExtension(KnowledgeArtifactAdapter.releaseDescriptionUrl));
+                    assertFalse(resource.hasExtension(KnowledgeArtifactAdapter.releaseLabelUrl));
                     List<RelatedArtifact> relatedArtifacts2 =
                             new org.opencds.cqf.fhir.utility.adapter.dstu3.KnowledgeArtifactAdapter(resource)
                                     .getRelatedArtifact();

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/DraftVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r4/DraftVisitorTests.java
@@ -101,6 +101,8 @@ class DraftVisitorTests {
         MetadataResourceHelper.forEachMetadataResource(
                 returnedBundle.getEntry(),
                 resource -> {
+                    assertFalse(resource.hasExtension(KnowledgeArtifactAdapter.releaseDescriptionUrl));
+                    assertFalse(resource.hasExtension(KnowledgeArtifactAdapter.releaseLabelUrl));
                     List<RelatedArtifact> relatedArtifacts2 =
                             new org.opencds.cqf.fhir.utility.adapter.r4.KnowledgeArtifactAdapter(resource)
                                     .getRelatedArtifact();

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/DraftVisitorTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/visitor/r5/DraftVisitorTests.java
@@ -101,6 +101,8 @@ class DraftVisitorTests {
         MetadataResourceHelper.forEachMetadataResource(
                 returnedBundle.getEntry(),
                 resource -> {
+                    assertFalse(resource.hasExtension(KnowledgeArtifactAdapter.releaseDescriptionUrl));
+                    assertFalse(resource.hasExtension(KnowledgeArtifactAdapter.releaseLabelUrl));
                     List<RelatedArtifact> relatedArtifacts2 =
                             new org.opencds.cqf.fhir.utility.adapter.r5.KnowledgeArtifactAdapter(resource)
                                     .getRelatedArtifact();

--- a/cqf-fhir-utility/src/test/resources/org/opencds/cqf/fhir/utility/visitor/dstu3/Bundle-ersd-example.json
+++ b/cqf-fhir-utility/src/test/resources/org/opencds/cqf/fhir/utility/visitor/dstu3/Bundle-ersd-example.json
@@ -2126,6 +2126,16 @@
                 "name": "Reportable_Condition_Trigger_Codes",
                 "title": "Reportable Condition Trigger Codes (RCTC) Example Library",
                 "status": "active",
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+                    "valueString": "Sample release label"
+                  },
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+                    "valueMarkdown": "Sample release description"
+                  }
+                ],
                 "experimental": true,
                 "type": {
                     "coding": [
@@ -2299,6 +2309,14 @@
                         "valueContactDetail": {
                             "name": "CSTE Steward"
                         }
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+                        "valueString": "Sample release label"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+                        "valueMarkdown": "Sample release description"
                     }
                 ],
                 "url": "http://hl7.org/fhir/us/ecr/ValueSet/dxtc",
@@ -2741,6 +2759,14 @@
                         "valueContactDetail": {
                             "name": "CSTE Steward"
                         }
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+                      "valueString": "Sample release label"
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+                      "valueMarkdown": "Sample release description"
                     }
                 ],
                 "url": "http://hl7.org/fhir/us/ecr/ValueSet/lotc",
@@ -2993,6 +3019,14 @@
                         "valueContactDetail": {
                             "name": "CSTE Steward"
                         }
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+                      "valueString": "Sample release label"
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+                      "valueMarkdown": "Sample release description"
                     }
                 ],
                 "url": "http://hl7.org/fhir/us/ecr/ValueSet/lrtc",
@@ -3825,6 +3859,14 @@
                         "valueContactDetail": {
                             "name": "CSTE Steward"
                         }
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+                      "valueString": "Sample release label"
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+                      "valueMarkdown": "Sample release description"
                     }
                 ],
                 "url": "http://hl7.org/fhir/us/ecr/ValueSet/mrtc",
@@ -4137,6 +4179,14 @@
                         "valueContactDetail": {
                             "name": "CSTE Steward"
                         }
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+                      "valueString": "Sample release label"
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+                      "valueMarkdown": "Sample release description"
                     }
                 ],
                 "url": "http://hl7.org/fhir/us/ecr/ValueSet/ostc",
@@ -4669,6 +4719,14 @@
                         "valueContactDetail": {
                             "name": "CSTE Steward"
                         }
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+                      "valueString": "Sample release label"
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+                      "valueMarkdown": "Sample release description"
                     }
                 ],
                 "url": "http://hl7.org/fhir/us/ecr/ValueSet/sdtc",

--- a/cqf-fhir-utility/src/test/resources/org/opencds/cqf/fhir/utility/visitor/r4/Bundle-ersd-example.json
+++ b/cqf-fhir-utility/src/test/resources/org/opencds/cqf/fhir/utility/visitor/r4/Bundle-ersd-example.json
@@ -2038,6 +2038,16 @@
         "name": "Reportable_Condition_Trigger_Codes",
         "title": "Reportable Condition Trigger Codes (RCTC) Example Library",
         "status": "active",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+            "valueString": "Sample release label"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+            "valueMarkdown": "Sample release description"
+          }
+        ],
         "experimental": true,
         "type": {
           "coding": [
@@ -2197,6 +2207,14 @@
             "valueContactDetail": {
               "name": "CSTE Steward"
             }
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+            "valueString": "Sample release label"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+            "valueMarkdown": "Sample release description"
           }
         ],
         "url": "http://hl7.org/fhir/us/ecr/ValueSet/dxtc",
@@ -2639,6 +2657,14 @@
             "valueContactDetail": {
               "name": "CSTE Steward"
             }
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+            "valueString": "Sample release label"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+            "valueMarkdown": "Sample release description"
           }
         ],
         "url": "http://hl7.org/fhir/us/ecr/ValueSet/lotc",
@@ -2891,6 +2917,14 @@
             "valueContactDetail": {
               "name": "CSTE Steward"
             }
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+            "valueString": "Sample release label"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+            "valueMarkdown": "Sample release description"
           }
         ],
         "url": "http://hl7.org/fhir/us/ecr/ValueSet/lrtc",
@@ -3723,6 +3757,14 @@
             "valueContactDetail": {
               "name": "CSTE Steward"
             }
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+            "valueString": "Sample release label"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+            "valueMarkdown": "Sample release description"
           }
         ],
         "url": "http://hl7.org/fhir/us/ecr/ValueSet/mrtc",
@@ -4035,6 +4077,14 @@
             "valueContactDetail": {
               "name": "CSTE Steward"
             }
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+            "valueString": "Sample release label"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+            "valueMarkdown": "Sample release description"
           }
         ],
         "url": "http://hl7.org/fhir/us/ecr/ValueSet/ostc",
@@ -4567,6 +4617,14 @@
             "valueContactDetail": {
               "name": "CSTE Steward"
             }
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+            "valueString": "Sample release label"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+            "valueMarkdown": "Sample release description"
           }
         ],
         "url": "http://hl7.org/fhir/us/ecr/ValueSet/sdtc",

--- a/cqf-fhir-utility/src/test/resources/org/opencds/cqf/fhir/utility/visitor/r5/Bundle-ersd-example.json
+++ b/cqf-fhir-utility/src/test/resources/org/opencds/cqf/fhir/utility/visitor/r5/Bundle-ersd-example.json
@@ -2038,6 +2038,16 @@
         "name": "Reportable_Condition_Trigger_Codes",
         "title": "Reportable Condition Trigger Codes (RCTC) Example Library",
         "status": "active",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+            "valueString": "Sample release label"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+            "valueMarkdown": "Sample release description"
+          }
+        ],
         "experimental": true,
         "type": {
           "coding": [
@@ -2197,6 +2207,14 @@
             "valueContactDetail": {
               "name": "CSTE Steward"
             }
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+            "valueString": "Sample release label"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+            "valueMarkdown": "Sample release description"
           }
         ],
         "url": "http://hl7.org/fhir/us/ecr/ValueSet/dxtc",
@@ -2639,6 +2657,14 @@
             "valueContactDetail": {
               "name": "CSTE Steward"
             }
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+            "valueString": "Sample release label"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+            "valueMarkdown": "Sample release description"
           }
         ],
         "url": "http://hl7.org/fhir/us/ecr/ValueSet/lotc",
@@ -2891,6 +2917,14 @@
             "valueContactDetail": {
               "name": "CSTE Steward"
             }
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+            "valueString": "Sample release label"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+            "valueMarkdown": "Sample release description"
           }
         ],
         "url": "http://hl7.org/fhir/us/ecr/ValueSet/lrtc",
@@ -3723,6 +3757,14 @@
             "valueContactDetail": {
               "name": "CSTE Steward"
             }
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+            "valueString": "Sample release label"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+            "valueMarkdown": "Sample release description"
           }
         ],
         "url": "http://hl7.org/fhir/us/ecr/ValueSet/mrtc",
@@ -4035,6 +4077,14 @@
             "valueContactDetail": {
               "name": "CSTE Steward"
             }
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+            "valueString": "Sample release label"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+            "valueMarkdown": "Sample release description"
           }
         ],
         "url": "http://hl7.org/fhir/us/ecr/ValueSet/ostc",
@@ -4567,6 +4617,14 @@
             "valueContactDetail": {
               "name": "CSTE Steward"
             }
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseLabel",
+            "valueString": "Sample release label"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/artifact-releaseDescription",
+            "valueMarkdown": "Sample release description"
           }
         ],
         "url": "http://hl7.org/fhir/us/ecr/ValueSet/sdtc",


### PR DESCRIPTION
When creating a draft of a program, the newly-created drafts owned resource artifacts still have a releaseLabel & releaseDescription extensions and they should not - they’re drafts and haven’t yet been released. 

This PR:
-removes 'releaseLabel' & 'releaseDescription' extensions from owned resources when creating a new Draft Program 
-update test data and assertions to reflect and validate