### PR TITLE
Add null check to authoritativeSourceUrl

### DIFF
--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/ExpandHelper.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/ExpandHelper.java
@@ -73,7 +73,9 @@ public class ExpandHelper {
         // If terminologyEndpoint exists and we have no authoritativeSourceUrl or the authoritativeSourceUrl matches the
         // terminologyEndpoint address then we will use the terminologyEndpoint for expansion
         if (terminologyEndpoint.isPresent()
-                && authoritativeSourceUrl.equals(terminologyEndpoint.get().getAddress())) {
+                && (authoritativeSourceUrl == null
+                        || authoritativeSourceUrl.equals(
+                                terminologyEndpoint.get().getAddress()))) {
             try {
                 var expandedValueSet = (ValueSetAdapter) createAdapterForResource(
                         terminologyServerClient.expand(valueSet, terminologyEndpoint.get(), expansionParameters));

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/ExpandHelper.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/ExpandHelper.java
@@ -70,11 +70,11 @@ public class ExpandHelper {
                 .map(url -> ((IPrimitiveType<String>) url.getValue()).getValueAsString())
                 .map(url -> TerminologyServerClient.getAddressBase(url, fhirContext))
                 .orElse(null);
-        // If terminologyEndpoint exists and we have no authoritativeSourceUrl or the authoritativeSourceUrl matches the
+        // If terminologyEndpoint exists and we have an authoritativeSourceUrl that matches the
         // terminologyEndpoint address then we will use the terminologyEndpoint for expansion
         if (terminologyEndpoint.isPresent()
-                && (authoritativeSourceUrl == null
-                        || authoritativeSourceUrl.equals(
+                && (authoritativeSourceUrl != null
+                        && authoritativeSourceUrl.equals(
                                 terminologyEndpoint.get().getAddress()))) {
             try {
                 var expandedValueSet = (ValueSetAdapter) createAdapterForResource(


### PR DESCRIPTION
When exporting a Program in VSM, we are encountering the following error:

`java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because "authoritativeSourceUrl" is null
 at org.opencds.cqf.fhir.utility.ExpandHelper.expandValueSet(ExpandHelper.java:76)`
 
This change adds a null check for the authoritativeSourceUrl to to handle cases where the authoritativeSourceUrl is null but does not return true in these cases.