### PR TITLE
Dependency updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: '36 15 * * 1'
+
+jobs:
+  CodeQLBuild:
+    runs-on: 'ubuntu-latest'
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+        cache: 'maven'
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: java-kotlin
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:java-kotlin"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,7 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: java-kotlin
+        build-mode: auto-build
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: java-kotlin
-        build-mode: auto-build
+        build-mode: autobuild
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       with:

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.5/apache-maven-3.9.5-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar

--- a/cqf-fhir-cr-cli/pom.xml
+++ b/cqf-fhir-cr-cli/pom.xml
@@ -138,7 +138,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>1.6.0</version>
+                    <version>3.5.0</version>
                     <executions>
                         <execution>
                             <goals>
@@ -153,7 +153,7 @@
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
-                    <version>2.7.2</version>
+                    <version>3.3.5</version>
                     <executions>
                         <execution>
                             <goals>

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/Measure.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/Measure.java
@@ -57,7 +57,6 @@ import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.TERMINOLOGY_FIL
 import org.opencds.cqf.fhir.cql.engine.terminology.TerminologySettings.VALUESET_EXPANSION_MODE;
 import org.opencds.cqf.fhir.cr.measure.MeasureEvaluationOptions;
 import org.opencds.cqf.fhir.cr.measure.common.MeasurePeriodValidator;
-import org.opencds.cqf.fhir.cr.measure.r4.Measure.SelectedGroup.SelectedPopulation;
 import org.opencds.cqf.fhir.cr.measure.r4.Measure.SelectedGroup.SelectedReference;
 import org.opencds.cqf.fhir.utility.monad.Eithers;
 import org.opencds.cqf.fhir.utility.r4.ContainedHelper;

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>3.15.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>FHIR Clinical Reasoning</name>
-    <description>FHIR Clinical Reasoning Im mentations</description>
+    <description>FHIR Clinical Reasoning Implentations</description>
     <url>https://github.com/cqframework/clinical-reasoning/tree/master</url>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>
 
         <junit.version>5.10.2</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>3.15.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>FHIR Clinical Reasoning</name>
-    <description>FHIR Clinical Reasoning Implentations</description>
+    <description>FHIR Clinical Reasoning Implementations</description>
     <url>https://github.com/cqframework/clinical-reasoning/tree/master</url>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>3.15.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>FHIR Clinical Reasoning</name>
-    <description>FHIR Clinical Reasoning Implementations</description>
+    <description>FHIR Clinical Reasoning Im mentations</description>
     <url>https://github.com/cqframework/clinical-reasoning/tree/master</url>
 
 
@@ -18,15 +18,15 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>17</maven.compiler.release>
 
-        <junit.version>5.9.1</junit.version>
+        <junit.version>5.10.2</junit.version>
         <slf4j.version>2.0.4</slf4j.version>
         <cql.version>3.18.0</cql.version>
         <jmh.version>1.36</jmh.version>
-        <spring.version>5.3.39</spring.version>
+        <spring.version>6.1.14</spring.version>
         <hapi.version>7.4.5</hapi.version>
         <picocli.version>4.6.1</picocli.version>
         <guava.version>33.2.1-jre</guava.version>
-        <error-prone.version>2.24.1</error-prone.version>
+        <error-prone.version>2.35.1</error-prone.version>
         <checkstyle.version>10.12.7</checkstyle.version>
     </properties>
 
@@ -422,7 +422,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.11.0</version>
+                    <version>3.13.0</version>
                     <configuration>
                         <failOnWarning>true</failOnWarning>
                         <showWarnings>true</showWarnings>


### PR DESCRIPTION
* Update Maven to 3.3.9
* Fix CodeQL scanning (default scanning is only compatible with Java 11, so switched to advanced mode)
* Update latest versions of Junit and Error Prone
* Update Maven build plugins to latest versions