### PR TITLE
Eliminate total denominator and total numerator extensions as well as all related code in favour of denominator and numerator

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -100,8 +100,6 @@
         "SUBJECTLIST",
         "SUPPLEMENTALDATA",
         "testng",
-        "TOTALDENOMINATOR",
-        "TOTALNUMERATOR",
         "unsignedint",
         "Unvalidated",
         "unversioned",

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureEvaluator.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureEvaluator.java
@@ -10,8 +10,6 @@ import static org.opencds.cqf.fhir.cr.measure.common.MeasurePopulationType.MEASU
 import static org.opencds.cqf.fhir.cr.measure.common.MeasurePopulationType.MEASUREPOPULATIONEXCLUSION;
 import static org.opencds.cqf.fhir.cr.measure.common.MeasurePopulationType.NUMERATOR;
 import static org.opencds.cqf.fhir.cr.measure.common.MeasurePopulationType.NUMERATOREXCLUSION;
-import static org.opencds.cqf.fhir.cr.measure.common.MeasurePopulationType.TOTALDENOMINATOR;
-import static org.opencds.cqf.fhir.cr.measure.common.MeasurePopulationType.TOTALNUMERATOR;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -434,8 +432,6 @@ public class MeasureEvaluator {
             // Evaluate Population Expressions
             denominator = evaluatePopulationMembership(subjectType, subjectId, denominator, evaluationResult);
             numerator = evaluatePopulationMembership(subjectType, subjectId, numerator, evaluationResult);
-            var totalDenominator = groupDef.getSingle(TOTALDENOMINATOR);
-            var totalNumerator = groupDef.getSingle(TOTALNUMERATOR);
 
             // Evaluate Exclusions and Exception Populations
             if (denominatorExclusion != null) {
@@ -471,8 +467,6 @@ public class MeasureEvaluator {
                     denominator.getSubjects().removeAll(denominatorException.getSubjects());
                     denominator.getResources().removeAll(denominatorException.getResources());
                 }
-                totalDenominator.getSubjects().addAll(denominator.getSubjects());
-                totalNumerator.getSubjects().addAll(numerator.getSubjects());
             } else {
                 // Remove Only Resource Exclusions
                 // * Multiple resources can be from one subject and represented in multiple populations
@@ -490,9 +484,6 @@ public class MeasureEvaluator {
                     // Remove Resources in Denominator that are not in Numerator
                     denominator.getResources().removeAll(denominatorException.getResources());
                 }
-                // TODO: Evaluate validity of TotalDenominator & TotalDenominator
-                totalDenominator.getResources().addAll(denominator.getResources());
-                totalNumerator.getResources().addAll(numerator.getResources());
             }
             if (reportType.equals(MeasureReportType.INDIVIDUAL) && populationSize == 1 && dateOfCompliance != null) {
                 var doc = evaluateDateOfCompliance(dateOfCompliance);

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasurePopulationType.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasurePopulationType.java
@@ -49,11 +49,15 @@ public enum MeasurePopulationType {
             "Measure Observation",
             "Defines the individual observation to be performed for each patient or event in the measure population. Measure observations for each case in the population are aggregated to determine the overall measure score for the population"),
 
+    // LUKETODO:
+    @Deprecated
     TOTALDENOMINATOR(
             "total-denominator",
             "Total Denominator",
             "The calculated denominator value used to calculate the measure score from Denominator, Denominator-Exclusion, Denominator-Exception and Numerator values"),
 
+    // LUKETODO:
+    @Deprecated
     TOTALNUMERATOR(
             "total-numerator",
             "Total Numerator",

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasurePopulationType.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasurePopulationType.java
@@ -49,21 +49,6 @@ public enum MeasurePopulationType {
             "Measure Observation",
             "Defines the individual observation to be performed for each patient or event in the measure population. Measure observations for each case in the population are aggregated to determine the overall measure score for the population"),
 
-    // LUKETODO:
-    //    @Deprecated
-    //    TOTALDENOMINATOR(
-    //            "total-denominator",
-    //            "Total Denominator",
-    //            "The calculated denominator value used to calculate the measure score from Denominator,
-    // Denominator-Exclusion, Denominator-Exception and Numerator values"),
-
-    // LUKETODO:
-    //    @Deprecated
-    //    TOTALNUMERATOR(
-    //            "total-numerator",
-    //            "Total Numerator",
-    //            "The calculated numerator value used to calculate the measure score from Numerator and
-    // Numerator-Exclusion values"),
     DATEOFCOMPLIANCE(
             "date-compliance",
             "Date of Compliance",

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasurePopulationType.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasurePopulationType.java
@@ -50,18 +50,20 @@ public enum MeasurePopulationType {
             "Defines the individual observation to be performed for each patient or event in the measure population. Measure observations for each case in the population are aggregated to determine the overall measure score for the population"),
 
     // LUKETODO:
-    @Deprecated
-    TOTALDENOMINATOR(
-            "total-denominator",
-            "Total Denominator",
-            "The calculated denominator value used to calculate the measure score from Denominator, Denominator-Exclusion, Denominator-Exception and Numerator values"),
+    //    @Deprecated
+    //    TOTALDENOMINATOR(
+    //            "total-denominator",
+    //            "Total Denominator",
+    //            "The calculated denominator value used to calculate the measure score from Denominator,
+    // Denominator-Exclusion, Denominator-Exception and Numerator values"),
 
     // LUKETODO:
-    @Deprecated
-    TOTALNUMERATOR(
-            "total-numerator",
-            "Total Numerator",
-            "The calculated numerator value used to calculate the measure score from Numerator and Numerator-Exclusion values"),
+    //    @Deprecated
+    //    TOTALNUMERATOR(
+    //            "total-numerator",
+    //            "Total Numerator",
+    //            "The calculated numerator value used to calculate the measure score from Numerator and
+    // Numerator-Exclusion values"),
     DATEOFCOMPLIANCE(
             "date-compliance",
             "Date of Compliance",

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/constant/MeasureConstants.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/constant/MeasureConstants.java
@@ -43,8 +43,13 @@ public class MeasureConstants {
     public static final String FHIR_ALL_TYPES_SYSTEM_URL = "http://hl7.org/fhir/fhir-types";
     public static final String POPULATION_BASIS_URL =
             "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis";
+
+    // LUKETODO: get rid of this
+    @Deprecated
     public static final String EXT_TOTAL_DENOMINATOR_URL =
             "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-denominator-membership";
+
+    @Deprecated
     public static final String EXT_TOTAL_NUMERATOR_URL =
             "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-numerator-membership";
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/constant/MeasureConstants.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/constant/MeasureConstants.java
@@ -43,13 +43,4 @@ public class MeasureConstants {
     public static final String FHIR_ALL_TYPES_SYSTEM_URL = "http://hl7.org/fhir/fhir-types";
     public static final String POPULATION_BASIS_URL =
             "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis";
-
-    // LUKETODO: get rid of this
-    @Deprecated
-    public static final String EXT_TOTAL_DENOMINATOR_URL =
-            "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-denominator-membership";
-
-    @Deprecated
-    public static final String EXT_TOTAL_NUMERATOR_URL =
-            "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-numerator-membership";
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/dstu3/Dstu3MeasureDefBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/dstu3/Dstu3MeasureDefBuilder.java
@@ -1,7 +1,5 @@
 package org.opencds.cqf.fhir.cr.measure.dstu3;
 
-import static org.opencds.cqf.fhir.cr.measure.common.MeasurePopulationType.TOTALDENOMINATOR;
-import static org.opencds.cqf.fhir.cr.measure.common.MeasurePopulationType.TOTALNUMERATOR;
 import static org.opencds.cqf.fhir.cr.measure.constant.MeasureConstants.FHIR_ALL_TYPES_SYSTEM_URL;
 import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.IMPROVEMENT_NOTATION_SYSTEM_DECREASE;
 import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.IMPROVEMENT_NOTATION_SYSTEM_INCREASE;
@@ -76,18 +74,20 @@ public class Dstu3MeasureDefBuilder implements MeasureDefBuilder<Measure> {
                 populations.add(new PopulationDef(
                         pop.getId(), conceptToConceptDef(pop.getCode()), populationType, pop.getCriteria()));
             }
+            // LUKETODO:
             // total Denominator/Numerator Def Builder
             // validate population is not in Def
-            if (checkPopulationForCode(populations, TOTALDENOMINATOR) == null) {
-                // add to definition
-                populations.add(new PopulationDef(
-                        "totalDenominator", totalConceptDefCreator(TOTALDENOMINATOR), TOTALDENOMINATOR, null));
-            }
-            if (checkPopulationForCode(populations, TOTALNUMERATOR) == null) {
-                // add to definition
-                populations.add(new PopulationDef(
-                        "totalNumerator", totalConceptDefCreator(TOTALNUMERATOR), TOTALNUMERATOR, null));
-            }
+            //            if (checkPopulationForCode(populations, TOTALDENOMINATOR) == null) {
+            //                // add to definition
+            //                populations.add(new PopulationDef(
+            //                        "totalDenominator", totalConceptDefCreator(TOTALDENOMINATOR), TOTALDENOMINATOR,
+            // null));
+            //            }
+            //            if (checkPopulationForCode(populations, TOTALNUMERATOR) == null) {
+            //                // add to definition
+            //                populations.add(new PopulationDef(
+            //                        "totalNumerator", totalConceptDefCreator(TOTALNUMERATOR), TOTALNUMERATOR, null));
+            //            }
 
             // Stratifiers
             List<StratifierDef> stratifiers = new ArrayList<>();

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/dstu3/Dstu3MeasureDefBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/dstu3/Dstu3MeasureDefBuilder.java
@@ -74,20 +74,6 @@ public class Dstu3MeasureDefBuilder implements MeasureDefBuilder<Measure> {
                 populations.add(new PopulationDef(
                         pop.getId(), conceptToConceptDef(pop.getCode()), populationType, pop.getCriteria()));
             }
-            // LUKETODO:
-            // total Denominator/Numerator Def Builder
-            // validate population is not in Def
-            //            if (checkPopulationForCode(populations, TOTALDENOMINATOR) == null) {
-            //                // add to definition
-            //                populations.add(new PopulationDef(
-            //                        "totalDenominator", totalConceptDefCreator(TOTALDENOMINATOR), TOTALDENOMINATOR,
-            // null));
-            //            }
-            //            if (checkPopulationForCode(populations, TOTALNUMERATOR) == null) {
-            //                // add to definition
-            //                populations.add(new PopulationDef(
-            //                        "totalNumerator", totalConceptDefCreator(TOTALNUMERATOR), TOTALNUMERATOR, null));
-            //            }
 
             // Stratifiers
             List<StratifierDef> stratifiers = new ArrayList<>();

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/dstu3/Dstu3MeasureReportBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/dstu3/Dstu3MeasureReportBuilder.java
@@ -134,10 +134,7 @@ public class Dstu3MeasureReportBuilder implements MeasureReportBuilder<Measure, 
             MeasureGroupComponent measureGroup,
             MeasureReportGroupComponent reportGroup,
             GroupDef groupDef) {
-        // groupDef contains populations/stratifier components not defined in measureGroup (TOTAL-NUMERATOR &
-        // TOTAL-DENOMINATOR), and will not be added to group populations.
-        // Subtracting '2' from groupDef to balance with Measure defined Groups
-        if (measureGroup.getPopulation().size() != (groupDef.populations().size() - 2)) {
+        if (measureGroup.getPopulation().size() != (groupDef.populations().size())) {
             throw new IllegalArgumentException(
                     "The MeasureGroup has a different number of populations defined than the GroupDef");
         }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureDefBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureDefBuilder.java
@@ -91,11 +91,13 @@ public class R4MeasureDefBuilder implements MeasureDefBuilder<Measure> {
             }
             // total Denominator/Numerator Def Builder
             // validate population is not in Def
+            // LUKETODO:
             if (checkPopulationForCode(populations, TOTALDENOMINATOR) == null) {
                 // add to definition
                 populations.add(new PopulationDef(
                         "totalDenominator", totalConceptDefCreator(TOTALDENOMINATOR), TOTALDENOMINATOR, null));
             }
+            // LUKETODO:
             if (checkPopulationForCode(populations, TOTALNUMERATOR) == null) {
                 // add to definition
                 populations.add(new PopulationDef(

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureDefBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureDefBuilder.java
@@ -87,21 +87,7 @@ public class R4MeasureDefBuilder implements MeasureDefBuilder<Measure> {
                         populationType,
                         pop.getCriteria().getExpression()));
             }
-            // total Denominator/Numerator Def Builder
-            // validate population is not in Def
-            //            // LUKETODO:
-            //            if (checkPopulationForCode(populations, TOTALDENOMINATOR) == null) {
-            //                // add to definition
-            //                populations.add(new PopulationDef(
-            //                        "totalDenominator", totalConceptDefCreator(TOTALDENOMINATOR), TOTALDENOMINATOR,
-            // null));
-            //            }
-            //            // LUKETODO:
-            //            if (checkPopulationForCode(populations, TOTALNUMERATOR) == null) {
-            //                // add to definition
-            //                populations.add(new PopulationDef(
-            //                        "totalNumerator", totalConceptDefCreator(TOTALNUMERATOR), TOTALNUMERATOR, null));
-            //            }
+
             if (group.getExtensionByUrl(CQFM_CARE_GAP_DATE_OF_COMPLIANCE_EXT_URL) != null
                     && checkPopulationForCode(populations, DATEOFCOMPLIANCE) == null) {
                 // add to definition

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureDefBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureDefBuilder.java
@@ -1,8 +1,6 @@
 package org.opencds.cqf.fhir.cr.measure.r4;
 
 import static org.opencds.cqf.fhir.cr.measure.common.MeasurePopulationType.DATEOFCOMPLIANCE;
-import static org.opencds.cqf.fhir.cr.measure.common.MeasurePopulationType.TOTALDENOMINATOR;
-import static org.opencds.cqf.fhir.cr.measure.common.MeasurePopulationType.TOTALNUMERATOR;
 import static org.opencds.cqf.fhir.cr.measure.constant.MeasureConstants.CQFM_CARE_GAP_DATE_OF_COMPLIANCE_EXT_URL;
 import static org.opencds.cqf.fhir.cr.measure.constant.MeasureConstants.CQFM_SCORING_EXT_URL;
 import static org.opencds.cqf.fhir.cr.measure.constant.MeasureConstants.FHIR_ALL_TYPES_SYSTEM_URL;
@@ -91,18 +89,19 @@ public class R4MeasureDefBuilder implements MeasureDefBuilder<Measure> {
             }
             // total Denominator/Numerator Def Builder
             // validate population is not in Def
-            // LUKETODO:
-            if (checkPopulationForCode(populations, TOTALDENOMINATOR) == null) {
-                // add to definition
-                populations.add(new PopulationDef(
-                        "totalDenominator", totalConceptDefCreator(TOTALDENOMINATOR), TOTALDENOMINATOR, null));
-            }
-            // LUKETODO:
-            if (checkPopulationForCode(populations, TOTALNUMERATOR) == null) {
-                // add to definition
-                populations.add(new PopulationDef(
-                        "totalNumerator", totalConceptDefCreator(TOTALNUMERATOR), TOTALNUMERATOR, null));
-            }
+            //            // LUKETODO:
+            //            if (checkPopulationForCode(populations, TOTALDENOMINATOR) == null) {
+            //                // add to definition
+            //                populations.add(new PopulationDef(
+            //                        "totalDenominator", totalConceptDefCreator(TOTALDENOMINATOR), TOTALDENOMINATOR,
+            // null));
+            //            }
+            //            // LUKETODO:
+            //            if (checkPopulationForCode(populations, TOTALNUMERATOR) == null) {
+            //                // add to definition
+            //                populations.add(new PopulationDef(
+            //                        "totalNumerator", totalConceptDefCreator(TOTALNUMERATOR), TOTALNUMERATOR, null));
+            //            }
             if (group.getExtensionByUrl(CQFM_CARE_GAP_DATE_OF_COMPLIANCE_EXT_URL) != null
                     && checkPopulationForCode(populations, DATEOFCOMPLIANCE) == null) {
                 // add to definition

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportBuilder.java
@@ -346,11 +346,15 @@ public class R4MeasureReportBuilder implements MeasureReportBuilder<Measure, Mea
             }
 
             if (groupDef.isBooleanBasis()) {
+                // LUKETODO: 602 why doesn't this consider exclusions?
+                // LUKETODO: 602 do we add this WITH or WITHOUT exclusions? my guess is WITHOUT
                 addExtension(
                         reportGroup, EXT_TOTAL_DENOMINATOR_URL, getReportPopulation(groupDef, TOTALDENOMINATOR), true);
                 addExtension(reportGroup, EXT_TOTAL_NUMERATOR_URL, getReportPopulation(groupDef, TOTALNUMERATOR), true);
 
             } else {
+                // LUKETODO: 602 why doesn't this consider exclusions?
+                // LUKETODO: 602 do we add this WITH or WITHOUT exclusions? my guess is WITHOUT
                 addExtension(
                         reportGroup, EXT_TOTAL_DENOMINATOR_URL, getReportPopulation(groupDef, TOTALDENOMINATOR), false);
                 addExtension(
@@ -369,13 +373,21 @@ public class R4MeasureReportBuilder implements MeasureReportBuilder<Measure, Mea
             MeasureReportGroupComponent group, String extUrl, PopulationDef populationDef, boolean useSubjects) {
         int count;
         if (useSubjects) {
+            // LUKETODO:  in the test case, this will be 6, same as the population "denominator"
+            // LUKETODO:  in the test case, this will be 3, same as the population "numerator"
             count = populationDef.getSubjects().size();
+            System.out.println(String.format("useSubjects YES: populationDef: %s, count: %s", extUrl, count));
         } else {
+            // LUKETODO:  in the test case, this will be 2, same as the population "denominator"
+            // LUKETODO:  in the test case, this will be 1, same as the population "numerator"
             count = populationDef.getResources().size();
+            System.out.println(String.format("useSubjects NO: populationDef: %s count: %s", extUrl, count));
         }
 
         group.addExtension().setUrl(extUrl).setValue(new StringType(Integer.toString(count)));
     }
+
+    // LUKETODO: 602 is there such a thing as validation for group population basis?
 
     /**
      *
@@ -390,6 +402,7 @@ public class R4MeasureReportBuilder implements MeasureReportBuilder<Measure, Mea
                     .filter(x -> x.rawValue() instanceof Resource)
                     .collect(Collectors.toList());
             if (list.size() != subjectValues.values().size()) {
+                // LUKETODO:  602 this is the stratifier case
                 throw new IllegalArgumentException(
                         "stratifier expression criteria results must match the same type as population.");
             }
@@ -497,6 +510,7 @@ public class R4MeasureReportBuilder implements MeasureReportBuilder<Measure, Mea
         }
 
         // add totalDenominator and totalNumerator extensions
+        // LUKETODO: 602
         buildStratumExtPopulation(groupDef, TOTALDENOMINATOR, subjectIds, stratum, EXT_TOTAL_DENOMINATOR_URL);
         buildStratumExtPopulation(groupDef, TOTALNUMERATOR, subjectIds, stratum, EXT_TOTAL_NUMERATOR_URL);
     }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportBuilder.java
@@ -359,7 +359,6 @@ public class R4MeasureReportBuilder implements MeasureReportBuilder<Measure, Mea
                     .filter(x -> x.rawValue() instanceof Resource)
                     .collect(Collectors.toList());
             if (list.size() != subjectValues.values().size()) {
-                // LUKETODO:  602 this is the stratifier case
                 throw new IllegalArgumentException(
                         "stratifier expression criteria results must match the same type as population.");
             }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportBuilder.java
@@ -270,17 +270,14 @@ public class R4MeasureReportBuilder implements MeasureReportBuilder<Measure, Mea
             MeasureReportGroupComponent reportGroup,
             GroupDef groupDef) {
 
-        // groupDef contains populations/stratifier components not defined in measureGroup (TOTAL-NUMERATOR &
-        // TOTAL-DENOMINATOR), and will not be added to group populations.
-        // Subtracting '2' from groupDef to balance with Measure defined Groups
-        var groupDefSizeDiff = 2;
+        var groupDefSizeDiff = 0;
         if (groupDef.populations().stream()
                         .filter(x -> x.type().equals(MeasurePopulationType.DATEOFCOMPLIANCE))
                         .findFirst()
                         .orElse(null)
                 != null) {
             // dateOfNonCompliance is another population not calculated
-            groupDefSizeDiff = 3;
+            groupDefSizeDiff = 1;
         }
 
         if ((measureGroup.getPopulation().size()) != (groupDef.populations().size() - groupDefSizeDiff)) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureScoringTypePopulations.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureScoringTypePopulations.java
@@ -15,9 +15,12 @@ public class R4MeasureScoringTypePopulations {
         DENOMINATOREXCEPTION(MeasurePopulationType.DENOMINATOREXCEPTION),
         NUMERATOREXCLUSION(MeasurePopulationType.NUMERATOREXCLUSION),
         NUMERATOR(MeasurePopulationType.NUMERATOR),
-        DATEOFCOMPLIANCE(MeasurePopulationType.DATEOFCOMPLIANCE),
-        TOTALDENOMINATOR(MeasurePopulationType.TOTALDENOMINATOR),
-        TOTALNUMERATOR(MeasurePopulationType.TOTALNUMERATOR);
+        DATEOFCOMPLIANCE(MeasurePopulationType.DATEOFCOMPLIANCE)
+    // LUKETODO:
+    //        ,
+    //        TOTALDENOMINATOR(MeasurePopulationType.TOTALDENOMINATOR),
+    //        TOTALNUMERATOR(MeasurePopulationType.TOTALNUMERATOR)
+    ;
 
         private final MeasurePopulationType measurePopulationType;
 
@@ -82,9 +85,11 @@ public class R4MeasureScoringTypePopulations {
         DENOMINATOREXCLUSION(MeasurePopulationType.DENOMINATOREXCLUSION),
         NUMERATOREXCLUSION(MeasurePopulationType.NUMERATOREXCLUSION),
         NUMERATOR(MeasurePopulationType.NUMERATOR),
-        DATEOFCOMPLIANCE(MeasurePopulationType.DATEOFCOMPLIANCE),
-        TOTALDENOMINATOR(MeasurePopulationType.TOTALDENOMINATOR),
-        TOTALNUMERATOR(MeasurePopulationType.TOTALNUMERATOR);
+        DATEOFCOMPLIANCE(MeasurePopulationType.DATEOFCOMPLIANCE)
+    //        ,
+    //        TOTALDENOMINATOR(MeasurePopulationType.TOTALDENOMINATOR),
+    //        TOTALNUMERATOR(MeasurePopulationType.TOTALNUMERATOR)
+    ;
         private final MeasurePopulationType measurePopulationType;
 
         RATIO_ALLOWED(MeasurePopulationType measurePopulationType) {
@@ -145,8 +150,8 @@ public class R4MeasureScoringTypePopulations {
         INITIALPOPULATION(MeasurePopulationType.INITIALPOPULATION),
         MEASUREPOPULATION(MeasurePopulationType.MEASUREPOPULATION),
         MEASUREPOPULATIONEXCLUSION(MeasurePopulationType.MEASUREPOPULATIONEXCLUSION),
-        TOTALDENOMINATOR(MeasurePopulationType.TOTALDENOMINATOR),
-        TOTALNUMERATOR(MeasurePopulationType.TOTALNUMERATOR),
+        //        TOTALDENOMINATOR(MeasurePopulationType.TOTALDENOMINATOR),
+        //        TOTALNUMERATOR(MeasurePopulationType.TOTALNUMERATOR),
         MEASUREOBSERVATION(MeasurePopulationType.MEASUREOBSERVATION);
         private final MeasurePopulationType measurePopulationType;
 
@@ -210,9 +215,12 @@ public class R4MeasureScoringTypePopulations {
     }
 
     public enum COHORT_ALLOWED {
-        INITIALPOPULATION(MeasurePopulationType.INITIALPOPULATION),
-        TOTALDENOMINATOR(MeasurePopulationType.TOTALDENOMINATOR),
-        TOTALNUMERATOR(MeasurePopulationType.TOTALNUMERATOR);
+        INITIALPOPULATION(MeasurePopulationType.INITIALPOPULATION)
+    // LUKETODO:
+    //        ,
+    //        TOTALDENOMINATOR(MeasurePopulationType.TOTALDENOMINATOR),
+    //        TOTALNUMERATOR(MeasurePopulationType.TOTALNUMERATOR)
+    ;
         private final MeasurePopulationType measurePopulationType;
 
         COHORT_ALLOWED(MeasurePopulationType measurePopulationType) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureScoringTypePopulations.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureScoringTypePopulations.java
@@ -15,12 +15,7 @@ public class R4MeasureScoringTypePopulations {
         DENOMINATOREXCEPTION(MeasurePopulationType.DENOMINATOREXCEPTION),
         NUMERATOREXCLUSION(MeasurePopulationType.NUMERATOREXCLUSION),
         NUMERATOR(MeasurePopulationType.NUMERATOR),
-        DATEOFCOMPLIANCE(MeasurePopulationType.DATEOFCOMPLIANCE)
-    // LUKETODO:
-    //        ,
-    //        TOTALDENOMINATOR(MeasurePopulationType.TOTALDENOMINATOR),
-    //        TOTALNUMERATOR(MeasurePopulationType.TOTALNUMERATOR)
-    ;
+        DATEOFCOMPLIANCE(MeasurePopulationType.DATEOFCOMPLIANCE);
 
         private final MeasurePopulationType measurePopulationType;
 
@@ -85,11 +80,8 @@ public class R4MeasureScoringTypePopulations {
         DENOMINATOREXCLUSION(MeasurePopulationType.DENOMINATOREXCLUSION),
         NUMERATOREXCLUSION(MeasurePopulationType.NUMERATOREXCLUSION),
         NUMERATOR(MeasurePopulationType.NUMERATOR),
-        DATEOFCOMPLIANCE(MeasurePopulationType.DATEOFCOMPLIANCE)
-    //        ,
-    //        TOTALDENOMINATOR(MeasurePopulationType.TOTALDENOMINATOR),
-    //        TOTALNUMERATOR(MeasurePopulationType.TOTALNUMERATOR)
-    ;
+        DATEOFCOMPLIANCE(MeasurePopulationType.DATEOFCOMPLIANCE);
+
         private final MeasurePopulationType measurePopulationType;
 
         RATIO_ALLOWED(MeasurePopulationType measurePopulationType) {
@@ -150,8 +142,6 @@ public class R4MeasureScoringTypePopulations {
         INITIALPOPULATION(MeasurePopulationType.INITIALPOPULATION),
         MEASUREPOPULATION(MeasurePopulationType.MEASUREPOPULATION),
         MEASUREPOPULATIONEXCLUSION(MeasurePopulationType.MEASUREPOPULATIONEXCLUSION),
-        //        TOTALDENOMINATOR(MeasurePopulationType.TOTALDENOMINATOR),
-        //        TOTALNUMERATOR(MeasurePopulationType.TOTALNUMERATOR),
         MEASUREOBSERVATION(MeasurePopulationType.MEASUREOBSERVATION);
         private final MeasurePopulationType measurePopulationType;
 
@@ -215,12 +205,7 @@ public class R4MeasureScoringTypePopulations {
     }
 
     public enum COHORT_ALLOWED {
-        INITIALPOPULATION(MeasurePopulationType.INITIALPOPULATION)
-    // LUKETODO:
-    //        ,
-    //        TOTALDENOMINATOR(MeasurePopulationType.TOTALDENOMINATOR),
-    //        TOTALNUMERATOR(MeasurePopulationType.TOTALNUMERATOR)
-    ;
+        INITIALPOPULATION(MeasurePopulationType.INITIALPOPULATION);
         private final MeasurePopulationType measurePopulationType;
 
         COHORT_ALLOWED(MeasurePopulationType measurePopulationType) {

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureScorerTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureScorerTest.java
@@ -100,7 +100,6 @@ class MeasureScorerTest {
         assertNull(group(measureReport, "DataCompleteness").getMeasureScore().getValue());
     }
 
-    // LUKETODO:  602 fix counts in JSONs
     @Test
     void scoreNoExtension() {
         var measureUrl = "http://content.alphora.com/fhir/uv/mips-qm-content-r4/Measure/multirate-noext";
@@ -113,13 +112,6 @@ class MeasureScorerTest {
         assertNull(group(measureReport, "PerformanceRate").getMeasureScore().getValue());
     }
 
-    // LUKETODO:  602 these counts are in sync:
-    /*
-    populationNumeratorCount = 5
-    populationDenominatorCount = 10
-    extNumeratorCount= 5
-    extDenominatorCount= 10
-     */
     @Test
     void scoreGroupIdMultiStratum() {
         var measureUrl =

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureScorerTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureScorerTest.java
@@ -18,14 +18,14 @@ import org.opencds.cqf.fhir.test.FhirResourceLoader;
 
 class MeasureScorerTest {
 
-    List<Measure> myMeasures = getMyMeasures();
-    List<MeasureReport> myMeasureReports = getMyMeasureReports();
+    List<Measure> measures = getMeasures();
+    List<MeasureReport> measureReports = getMeasureReports();
 
     @Test
     void scoreOnlyPopulationIdMultiRateMeasure() {
         var measureUrl = "http://content.alphora.com/fhir/uv/mips-qm-content-r4/Measure/multirate-groupid";
         var measureScoringDef = getMeasureScoringDef(measureUrl);
-        var measureReport = getMyMeasureReport(measureUrl);
+        var measureReport = getMeasureReport(measureUrl);
 
         try {
             R4MeasureReportScorer scorer = new R4MeasureReportScorer();
@@ -56,7 +56,7 @@ class MeasureScorerTest {
     void scorePopulationIdMultiRate() {
         var measureUrl = "http://ecqi.healthit.gov/ecqms/Measure/FHIR347";
         var measureScoringDef = getMeasureScoringDef(measureUrl);
-        var measureReport = getMyMeasureReport(measureUrl);
+        var measureReport = getMeasureReport(measureUrl);
 
         R4MeasureReportScorer scorer = new R4MeasureReportScorer();
         scorer.score(measureScoringDef, measureReport);
@@ -65,7 +65,7 @@ class MeasureScorerTest {
                 "1.0",
                 group(measureReport, "group-1").getMeasureScore().getValue().toString());
         assertEquals(
-                "1.0",
+                "0.5",
                 group(measureReport, "group-2").getMeasureScore().getValue().toString());
         assertEquals(
                 "0.5",
@@ -76,7 +76,7 @@ class MeasureScorerTest {
     void scoreErrorNoIds() {
         var measureUrl = "http://content.alphora.com/fhir/uv/mips-qm-content-r4/Measure/multirate-groupid-error";
         var measureScoringDef = getMeasureScoringDef(measureUrl);
-        var measureReport = getMyMeasureReport(measureUrl);
+        var measureReport = getMeasureReport(measureUrl);
         try {
             R4MeasureReportScorer scorer = new R4MeasureReportScorer();
             scorer.score(measureScoringDef, measureReport);
@@ -92,7 +92,7 @@ class MeasureScorerTest {
     void scoreZeroDenominator() {
         var measureUrl = "http://content.alphora.com/fhir/uv/mips-qm-content-r4/Measure/multirate-zeroden";
         var measureScoringDef = getMeasureScoringDef(measureUrl);
-        var measureReport = getMyMeasureReport(measureUrl);
+        var measureReport = getMeasureReport(measureUrl);
 
         R4MeasureReportScorer scorer = new R4MeasureReportScorer();
         scorer.score(measureScoringDef, measureReport);
@@ -100,11 +100,12 @@ class MeasureScorerTest {
         assertNull(group(measureReport, "DataCompleteness").getMeasureScore().getValue());
     }
 
+    // LUKETODO:  602 fix counts in JSONs
     @Test
     void scoreNoExtension() {
         var measureUrl = "http://content.alphora.com/fhir/uv/mips-qm-content-r4/Measure/multirate-noext";
         var measureScoringDef = getMeasureScoringDef(measureUrl);
-        var measureReport = getMyMeasureReport(measureUrl);
+        var measureReport = getMeasureReport(measureUrl);
 
         R4MeasureReportScorer scorer = new R4MeasureReportScorer();
         scorer.score(measureScoringDef, measureReport);
@@ -112,12 +113,19 @@ class MeasureScorerTest {
         assertNull(group(measureReport, "PerformanceRate").getMeasureScore().getValue());
     }
 
+    // LUKETODO:  602 these counts are in sync:
+    /*
+    populationNumeratorCount = 5
+    populationDenominatorCount = 10
+    extNumeratorCount= 5
+    extDenominatorCount= 10
+     */
     @Test
     void scoreGroupIdMultiStratum() {
         var measureUrl =
                 "http://ecqi.healthit.gov/ecqms/Measure/PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR";
         var measureScoringDef = getMeasureScoringDef(measureUrl);
-        var measureReport = getMyMeasureReport(measureUrl);
+        var measureReport = getMeasureReport(measureUrl);
 
         R4MeasureReportScorer scorer = new R4MeasureReportScorer();
         scorer.score(measureScoringDef, measureReport);
@@ -169,7 +177,7 @@ class MeasureScorerTest {
                 .get();
     }
 
-    public List<Measure> getMyMeasures() {
+    public List<Measure> getMeasures() {
         // Measures
         FhirResourceLoader measures = new FhirResourceLoader(
                 FhirContext.forR4(), this.getClass(), List.of("MeasureScoring/Measures/"), false);
@@ -181,7 +189,7 @@ class MeasureScorerTest {
         return measureList;
     }
 
-    public List<MeasureReport> getMyMeasureReports() {
+    public List<MeasureReport> getMeasureReports() {
         FhirResourceLoader measureReports = new FhirResourceLoader(
                 FhirContext.forR4(), this.getClass(), List.of("MeasureScoring/MeasureReports/"), false);
         List<MeasureReport> measureReportList = new ArrayList<>();
@@ -193,7 +201,7 @@ class MeasureScorerTest {
     }
 
     public MeasureDef getMeasureScoringDef(String measureUrl) {
-        var measureRes = myMeasures.stream()
+        var measureRes = measures.stream()
                 .filter(measure -> measureUrl.equals(measure.getUrl()))
                 .findAny()
                 .orElse(null);
@@ -201,8 +209,8 @@ class MeasureScorerTest {
         return measureDefBuilder.build(measureRes);
     }
 
-    public MeasureReport getMyMeasureReport(String measureUrl) {
-        return myMeasureReports.stream()
+    public MeasureReport getMeasureReport(String measureUrl) {
+        return measureReports.stream()
                 .filter(measureReport -> measureUrl.equals(measureReport.getMeasure()))
                 .findAny()
                 .orElse(null);

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureScoring/MeasureReports/measurereport-fhir347.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureScoring/MeasureReports/measurereport-fhir347.json
@@ -310,7 +310,7 @@
       "extension":[
         {
           "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-denominator-membership",
-          "valueString":"1"
+          "valueString":"2"
         },
         {
           "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-numerator-membership",

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureScoring/MeasureReports/measurereport-fhir347.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureScoring/MeasureReports/measurereport-fhir347.json
@@ -226,16 +226,6 @@
           },
           "count":1
         }
-      ],
-      "extension":[
-        {
-          "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-denominator-membership",
-          "valueString":"1"
-        },
-        {
-          "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-numerator-membership",
-          "valueString":"1"
-        }
       ]
     },
     {
@@ -306,16 +296,6 @@
           },
           "count":1
         }
-      ],
-      "extension":[
-        {
-          "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-denominator-membership",
-          "valueString":"2"
-        },
-        {
-          "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-numerator-membership",
-          "valueString":"1"
-        }
       ]
     },
     {
@@ -385,16 +365,6 @@
             ]
           },
           "count":1
-        }
-      ],
-      "extension":[
-        {
-          "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-denominator-membership",
-          "valueString":"2"
-        },
-        {
-          "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-numerator-membership",
-          "valueString":"1"
         }
       ]
     }

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureScoring/MeasureReports/measurereport-multirate-nopopid.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureScoring/MeasureReports/measurereport-multirate-nopopid.json
@@ -58,17 +58,7 @@
         } ]
       },
       "count": 1
-    } ],
-    "extension":[
-      {
-        "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-denominator-membership",
-        "valueString":"1"
-      },
-      {
-        "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-numerator-membership",
-        "valueString":"1"
-      }
-    ]
+    } ]
   }, {
     "population": [ {
       "id": "initial-population-2",
@@ -100,16 +90,6 @@
         } ]
       },
       "count": 1
-    } ],
-    "extension":[
-      {
-        "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-denominator-membership",
-        "valueString":"1"
-      },
-      {
-        "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-numerator-membership",
-        "valueString":"1"
-      }
-    ]
+    } ]
   } ]
 }

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureScoring/MeasureReports/measurereport-multirate-zeroden.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureScoring/MeasureReports/measurereport-multirate-zeroden.json
@@ -48,16 +48,6 @@
         } ]
       },
       "count": 0
-    } ],
-    "extension":[
-      {
-        "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-denominator-membership",
-        "valueString":"0"
-      },
-      {
-        "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-numerator-membership",
-        "valueString":"0"
-      }
-    ]
+    } ]
   } ]
 }

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureScoring/MeasureReports/measurereport-primarycariespreventionasofferedbypcpincludingdentistfhir.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureScoring/MeasureReports/measurereport-primarycariespreventionasofferedbypcpincludingdentistfhir.json
@@ -26,16 +26,6 @@
   "group":[
     {
       "id":"group-1",
-      "extension":[
-        {
-          "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-denominator-membership",
-          "valueString":"10"
-        },
-        {
-          "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-numerator-membership",
-          "valueString":"5"
-        }
-      ],
       "population":[
         {
           "id":"12FA9D2D-42F4-4D78-B121-8A5CF304DAF8",
@@ -100,16 +90,6 @@
           ],
           "stratum":[
             {
-              "extension":[
-                {
-                  "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-denominator-membership",
-                  "valueString":"10"
-                },
-                {
-                  "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-numerator-membership",
-                  "valueString":"5"
-                }
-              ],
               "value":{
                 "text":"true"
               },
@@ -179,16 +159,6 @@
           ],
           "stratum":[
             {
-              "extension":[
-                {
-                  "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-denominator-membership",
-                  "valueString":"5"
-                },
-                {
-                  "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-numerator-membership",
-                  "valueString":"3"
-                }
-              ],
               "value":{
                 "text":"false"
               },
@@ -258,16 +228,6 @@
           ],
           "stratum":[
             {
-              "extension":[
-                {
-                  "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-denominator-membership",
-                  "valueString":"3"
-                },
-                {
-                  "url":"http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-cqfm-numerator-membership",
-                  "valueString":"1"
-                }
-              ],
               "value":{
                 "text":"false"
               },


### PR DESCRIPTION
- Delete total numerator and total denominator extension URLs from MeasureConstants
- Delete total numerator and total denominator from MeasurePopulationType and all downstream enums
- Delete all code that writes to the above extensions
- Change measure scoring code to read directly from the numerator and denominator populations
- Remove conditional logic that subtracts 2 from expected population counts.
- Delete all other code that does anything with total denominator and numerator
- Remove total extensions from all JSON test files.

Closes https://github.com/cqframework/clinical-reasoning/issues/602