### PR TITLE
Add interfaces on top of R4CareGapsProcessor and R4CareGapsService

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsProcessor.java
@@ -69,12 +69,12 @@ public class R4CareGapsProcessor implements R4CareGapsProcessorInterface {
 
     @Override
     public Parameters getCareGapsReport(
-        @Nullable ZonedDateTime periodStart,
-        @Nullable ZonedDateTime periodEnd,
-        String subject,
-        List<String> status,
-        List<Either3<IdType, String, CanonicalType>> measure,
-        boolean notDocument) {
+            @Nullable ZonedDateTime periodStart,
+            @Nullable ZonedDateTime periodEnd,
+            String subject,
+            List<String> status,
+            List<Either3<IdType, String, CanonicalType>> measure,
+            boolean notDocument) {
 
         // set Parameters
         R4CareGapsParameters r4CareGapsParams =
@@ -107,12 +107,12 @@ public class R4CareGapsProcessor implements R4CareGapsProcessorInterface {
 
     @Override
     public R4CareGapsParameters setCareGapParameters(
-        @Nullable ZonedDateTime periodStart,
-        @Nullable ZonedDateTime periodEnd,
-        String subject,
-        List<String> status,
-        List<Either3<IdType, String, CanonicalType>> measure,
-        boolean notDocument) {
+            @Nullable ZonedDateTime periodStart,
+            @Nullable ZonedDateTime periodEnd,
+            String subject,
+            List<String> status,
+            List<Either3<IdType, String, CanonicalType>> measure,
+            boolean notDocument) {
         R4CareGapsParameters r4CareGapsParams = new R4CareGapsParameters();
         r4CareGapsParams.setMeasure(measure);
         r4CareGapsParams.setPeriodStart(periodStart);
@@ -176,8 +176,7 @@ public class R4CareGapsProcessor implements R4CareGapsProcessorInterface {
     }
 
     @Override
-    public void checkValidStatusCode(List<Either3<IdType, String, CanonicalType>> measure,
-        List<String> statuses) {
+    public void checkValidStatusCode(List<Either3<IdType, String, CanonicalType>> measure, List<String> statuses) {
         r4MeasureServiceUtils.listThrowIllegalArgumentIfEmpty(statuses, "status");
 
         for (String status : statuses) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsProcessor.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Care Gaps Processor houses construction of result body with input of different Result Bodies, such as Document Bundle vs non-document bundle
  */
-public class R4CareGapsProcessor {
+public class R4CareGapsProcessor implements R4CareGapsProcessorInterface {
 
     private static final Logger ourLog = LoggerFactory.getLogger(R4CareGapsProcessor.class);
     private final Repository repository;
@@ -67,13 +67,14 @@ public class R4CareGapsProcessor {
         subjectProvider = new R4RepositorySubjectProvider(measureEvaluationOptions.getSubjectProviderOptions());
     }
 
+    @Override
     public Parameters getCareGapsReport(
-            @Nullable ZonedDateTime periodStart,
-            @Nullable ZonedDateTime periodEnd,
-            String subject,
-            List<String> status,
-            List<Either3<IdType, String, CanonicalType>> measure,
-            boolean notDocument) {
+        @Nullable ZonedDateTime periodStart,
+        @Nullable ZonedDateTime periodEnd,
+        String subject,
+        List<String> status,
+        List<Either3<IdType, String, CanonicalType>> measure,
+        boolean notDocument) {
 
         // set Parameters
         R4CareGapsParameters r4CareGapsParams =
@@ -104,13 +105,14 @@ public class R4CareGapsProcessor {
         return result.setParameter(components);
     }
 
-    protected R4CareGapsParameters setCareGapParameters(
-            @Nullable ZonedDateTime periodStart,
-            @Nullable ZonedDateTime periodEnd,
-            String subject,
-            List<String> status,
-            List<Either3<IdType, String, CanonicalType>> measure,
-            boolean notDocument) {
+    @Override
+    public R4CareGapsParameters setCareGapParameters(
+        @Nullable ZonedDateTime periodStart,
+        @Nullable ZonedDateTime periodEnd,
+        String subject,
+        List<String> status,
+        List<Either3<IdType, String, CanonicalType>> measure,
+        boolean notDocument) {
         R4CareGapsParameters r4CareGapsParams = new R4CareGapsParameters();
         r4CareGapsParams.setMeasure(measure);
         r4CareGapsParams.setPeriodStart(periodStart);
@@ -121,7 +123,8 @@ public class R4CareGapsProcessor {
         return r4CareGapsParams;
     }
 
-    protected List<Measure> resolveMeasure(List<Either3<IdType, String, CanonicalType>> measure) {
+    @Override
+    public List<Measure> resolveMeasure(List<Either3<IdType, String, CanonicalType>> measure) {
         return measure.stream()
                 .map(x -> x.fold(
                         id -> repository.read(Measure.class, id),
@@ -130,7 +133,8 @@ public class R4CareGapsProcessor {
                 .collect(Collectors.toList());
     }
 
-    protected List<String> getSubjects(String subject) {
+    @Override
+    public List<String> getSubjects(String subject) {
         var subjects = subjectProvider.getSubjects(repository, subject).collect(Collectors.toList());
         if (!subjects.isEmpty()) {
             ourLog.info(String.format("care-gaps report requested for: %s subjects.", subjects.size()));
@@ -140,7 +144,8 @@ public class R4CareGapsProcessor {
         return subjects;
     }
 
-    protected void addConfiguredResource(String id, String key) {
+    @Override
+    public void addConfiguredResource(String id, String key) {
         // read resource from repository
         Resource resource = repository.read(Organization.class, new IdType(RESOURCE_TYPE_ORGANIZATION, id));
 
@@ -155,7 +160,8 @@ public class R4CareGapsProcessor {
         configuredResources.put(key, resource);
     }
 
-    protected void checkMeasureImprovementNotation(Measure measure) {
+    @Override
+    public void checkMeasureImprovementNotation(Measure measure) {
         if (!measure.hasImprovementNotation()) {
             ourLog.warn(
                     "Measure '{}' does not specify an improvement notation, defaulting to: '{}'.",
@@ -164,11 +170,14 @@ public class R4CareGapsProcessor {
         }
     }
 
-    protected Parameters initializeResult() {
+    @Override
+    public Parameters initializeResult() {
         return newResource(Parameters.class, "care-gaps-report-" + UUID.randomUUID());
     }
 
-    protected void checkValidStatusCode(List<Either3<IdType, String, CanonicalType>> measure, List<String> statuses) {
+    @Override
+    public void checkValidStatusCode(List<Either3<IdType, String, CanonicalType>> measure,
+        List<String> statuses) {
         r4MeasureServiceUtils.listThrowIllegalArgumentIfEmpty(statuses, "status");
 
         for (String status : statuses) {
@@ -183,7 +192,8 @@ public class R4CareGapsProcessor {
         }
     }
 
-    protected void measureCompatibilityCheck(List<Measure> measures) {
+    @Override
+    public void measureCompatibilityCheck(List<Measure> measures) {
         for (Measure measure : measures) {
             checkMeasureScoringType(measure);
             checkMeasureImprovementNotation(measure);
@@ -192,7 +202,8 @@ public class R4CareGapsProcessor {
         }
     }
 
-    protected void checkMeasureBasis(Measure measure) {
+    @Override
+    public void checkMeasureBasis(Measure measure) {
         var msg = String.format("CareGaps can't process Measure: %s, it is not Boolean basis.", measure.getIdPart());
         R4MeasureDefBuilder measureDefBuilder = new R4MeasureDefBuilder();
         var measureDef = measureDefBuilder.build(measure);
@@ -209,7 +220,8 @@ public class R4CareGapsProcessor {
      * This is helpful when creating DetectedIssues per GroupComponent so endUsers can attribute evidence of a Care-Gap to the specific MeasureReport result
      * @param measure Measure resource
      */
-    protected void checkMeasureGroupComponents(Measure measure) {
+    @Override
+    public void checkMeasureGroupComponents(Measure measure) {
         // if a Multi-rate Measure, enforce groupId to be populated
         if (measure.getGroup().size() > 1) {
             for (MeasureGroupComponent group : measure.getGroup()) {
@@ -223,7 +235,8 @@ public class R4CareGapsProcessor {
         }
     }
 
-    protected void checkMeasureScoringType(Measure measure) {
+    @Override
+    public void checkMeasureScoringType(Measure measure) {
         List<MeasureScoring> scoringTypes = r4MeasureServiceUtils.getMeasureScoringDef(measure);
         for (MeasureScoring measureScoringType : scoringTypes) {
             if (!MeasureScoring.PROPORTION.equals(measureScoringType)
@@ -235,7 +248,8 @@ public class R4CareGapsProcessor {
         }
     }
 
-    protected void checkConfigurationReferences() {
+    @Override
+    public void checkConfigurationReferences() {
         careGapsProperties.validateRequiredProperties();
 
         addConfiguredResource(careGapsProperties.getCareGapsReporter(), CareGapsConstants.CARE_GAPS_REPORTER_KEY);

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsProcessorInterface.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsProcessorInterface.java
@@ -1,0 +1,55 @@
+package org.opencds.cqf.fhir.cr.measure.r4;
+
+import jakarta.annotation.Nullable;
+import java.time.ZonedDateTime;
+import java.util.List;
+import org.hl7.fhir.r4.model.CanonicalType;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Measure;
+import org.hl7.fhir.r4.model.Parameters;
+import org.opencds.cqf.fhir.utility.monad.Either3;
+
+/**
+ * Describe operations provided to process caregaps for downstream implementors
+ */
+public interface R4CareGapsProcessorInterface {
+
+    Parameters getCareGapsReport(
+        @Nullable ZonedDateTime periodStart,
+        @Nullable ZonedDateTime periodEnd,
+        String subject,
+        List<String> status,
+        List<Either3<IdType, String, CanonicalType>> measure,
+        boolean notDocument);
+
+    R4CareGapsParameters setCareGapParameters(
+        @Nullable ZonedDateTime periodStart,
+        @Nullable ZonedDateTime periodEnd,
+        String subject,
+        List<String> status,
+        List<Either3<IdType, String, CanonicalType>> measure,
+        boolean notDocument);
+
+    List<Measure> resolveMeasure(List<Either3<IdType, String, CanonicalType>> measure);
+
+    List<String> getSubjects(String subject);
+
+    void addConfiguredResource(String id, String key);
+
+    void checkMeasureImprovementNotation(Measure measure);
+
+    Parameters initializeResult();
+
+    void checkValidStatusCode(List<Either3<IdType, String, CanonicalType>> measure,
+        List<String> statuses);
+
+    void measureCompatibilityCheck(List<Measure> measures);
+
+    void checkMeasureBasis(Measure measure);
+
+    void checkMeasureGroupComponents(Measure measure);
+
+    void checkMeasureScoringType(Measure measure);
+
+    void checkConfigurationReferences();
+}

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsProcessorInterface.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsProcessorInterface.java
@@ -15,20 +15,20 @@ import org.opencds.cqf.fhir.utility.monad.Either3;
 public interface R4CareGapsProcessorInterface {
 
     Parameters getCareGapsReport(
-        @Nullable ZonedDateTime periodStart,
-        @Nullable ZonedDateTime periodEnd,
-        String subject,
-        List<String> status,
-        List<Either3<IdType, String, CanonicalType>> measure,
-        boolean notDocument);
+            @Nullable ZonedDateTime periodStart,
+            @Nullable ZonedDateTime periodEnd,
+            String subject,
+            List<String> status,
+            List<Either3<IdType, String, CanonicalType>> measure,
+            boolean notDocument);
 
     R4CareGapsParameters setCareGapParameters(
-        @Nullable ZonedDateTime periodStart,
-        @Nullable ZonedDateTime periodEnd,
-        String subject,
-        List<String> status,
-        List<Either3<IdType, String, CanonicalType>> measure,
-        boolean notDocument);
+            @Nullable ZonedDateTime periodStart,
+            @Nullable ZonedDateTime periodEnd,
+            String subject,
+            List<String> status,
+            List<Either3<IdType, String, CanonicalType>> measure,
+            boolean notDocument);
 
     List<Measure> resolveMeasure(List<Either3<IdType, String, CanonicalType>> measure);
 
@@ -40,8 +40,7 @@ public interface R4CareGapsProcessorInterface {
 
     Parameters initializeResult();
 
-    void checkValidStatusCode(List<Either3<IdType, String, CanonicalType>> measure,
-        List<String> statuses);
+    void checkValidStatusCode(List<Either3<IdType, String, CanonicalType>> measure, List<String> statuses);
 
     void measureCompatibilityCheck(List<Measure> measures);
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsService.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsService.java
@@ -22,7 +22,7 @@ import org.opencds.cqf.fhir.utility.monad.Eithers;
 /**
  * Care Gap service that processes and produces care-gaps report as a result
  */
-public class R4CareGapsService {
+public class R4CareGapsService implements R4CareGapsServiceInterface {
     private final R4CareGapsProcessor r4CareGapsProcessor;
 
     public R4CareGapsService(
@@ -53,15 +53,16 @@ public class R4CareGapsService {
      * @return Parameters that includes zero to many document bundles that include Care Gap Measure
      *         Reports will be returned.
      */
+    @Override
     public Parameters getCareGapsReport(
-            @Nullable ZonedDateTime periodStart,
-            @Nullable ZonedDateTime periodEnd,
-            @Nullable String subject,
-            List<String> status,
-            List<IdType> measureId,
-            List<String> measureIdentifier,
-            List<CanonicalType> measureUrl,
-            boolean notDocument) {
+        @Nullable ZonedDateTime periodStart,
+        @Nullable ZonedDateTime periodEnd,
+        @Nullable String subject,
+        List<String> status,
+        List<IdType> measureId,
+        List<String> measureIdentifier,
+        List<CanonicalType> measureUrl,
+        boolean notDocument) {
 
         return r4CareGapsProcessor.getCareGapsReport(
                 periodStart,
@@ -72,8 +73,9 @@ public class R4CareGapsService {
                 notDocument);
     }
 
-    protected List<Either3<IdType, String, CanonicalType>> liftMeasureParameters(
-            List<IdType> measureId, List<String> measureIdentifier, List<CanonicalType> measureUrl) {
+    @Override
+    public List<Either3<IdType, String, CanonicalType>> liftMeasureParameters(
+        List<IdType> measureId, List<String> measureIdentifier, List<CanonicalType> measureUrl) {
 
         List<Either3<IdType, String, CanonicalType>> eitherList = new ArrayList<>();
         Optional.ofNullable(measureId).ifPresent(list -> measureId.stream()

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsService.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsService.java
@@ -55,14 +55,14 @@ public class R4CareGapsService implements R4CareGapsServiceInterface {
      */
     @Override
     public Parameters getCareGapsReport(
-        @Nullable ZonedDateTime periodStart,
-        @Nullable ZonedDateTime periodEnd,
-        @Nullable String subject,
-        List<String> status,
-        List<IdType> measureId,
-        List<String> measureIdentifier,
-        List<CanonicalType> measureUrl,
-        boolean notDocument) {
+            @Nullable ZonedDateTime periodStart,
+            @Nullable ZonedDateTime periodEnd,
+            @Nullable String subject,
+            List<String> status,
+            List<IdType> measureId,
+            List<String> measureIdentifier,
+            List<CanonicalType> measureUrl,
+            boolean notDocument) {
 
         return r4CareGapsProcessor.getCareGapsReport(
                 periodStart,
@@ -75,7 +75,7 @@ public class R4CareGapsService implements R4CareGapsServiceInterface {
 
     @Override
     public List<Either3<IdType, String, CanonicalType>> liftMeasureParameters(
-        List<IdType> measureId, List<String> measureIdentifier, List<CanonicalType> measureUrl) {
+            List<IdType> measureId, List<String> measureIdentifier, List<CanonicalType> measureUrl) {
 
         List<Either3<IdType, String, CanonicalType>> eitherList = new ArrayList<>();
         Optional.ofNullable(measureId).ifPresent(list -> measureId.stream()

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsServiceInterface.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsServiceInterface.java
@@ -1,12 +1,12 @@
 package org.opencds.cqf.fhir.cr.measure.r4;
 
 import jakarta.annotation.Nullable;
+import java.time.ZonedDateTime;
+import java.util.List;
 import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Parameters;
 import org.opencds.cqf.fhir.utility.monad.Either3;
-import java.time.ZonedDateTime;
-import java.util.List;
 
 /**
  * Describe operations provided by caregaps services for downstream implementors
@@ -14,15 +14,15 @@ import java.util.List;
 public interface R4CareGapsServiceInterface {
 
     Parameters getCareGapsReport(
-        @Nullable ZonedDateTime periodStart,
-        @Nullable ZonedDateTime periodEnd,
-        @Nullable String subject,
-        List<String> status,
-        List<IdType> measureId,
-        List<String> measureIdentifier,
-        List<CanonicalType> measureUrl,
-        boolean notDocument);
+            @Nullable ZonedDateTime periodStart,
+            @Nullable ZonedDateTime periodEnd,
+            @Nullable String subject,
+            List<String> status,
+            List<IdType> measureId,
+            List<String> measureIdentifier,
+            List<CanonicalType> measureUrl,
+            boolean notDocument);
 
     List<Either3<IdType, String, CanonicalType>> liftMeasureParameters(
-        List<IdType> measureId, List<String> measureIdentifier, List<CanonicalType> measureUrl);
+            List<IdType> measureId, List<String> measureIdentifier, List<CanonicalType> measureUrl);
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsServiceInterface.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsServiceInterface.java
@@ -1,0 +1,28 @@
+package org.opencds.cqf.fhir.cr.measure.r4;
+
+import jakarta.annotation.Nullable;
+import org.hl7.fhir.r4.model.CanonicalType;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Parameters;
+import org.opencds.cqf.fhir.utility.monad.Either3;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+/**
+ * Describe operations provided by caregaps services for downstream implementors
+ */
+public interface R4CareGapsServiceInterface {
+
+    Parameters getCareGapsReport(
+        @Nullable ZonedDateTime periodStart,
+        @Nullable ZonedDateTime periodEnd,
+        @Nullable String subject,
+        List<String> status,
+        List<IdType> measureId,
+        List<String> measureIdentifier,
+        List<CanonicalType> measureUrl,
+        boolean notDocument);
+
+    List<Either3<IdType, String, CanonicalType>> liftMeasureParameters(
+        List<IdType> measureId, List<String> measureIdentifier, List<CanonicalType> measureUrl);
+}


### PR DESCRIPTION
- See https://github.com/cqframework/clinical-reasoning/pull/510 for similar work done for measure evaluation services
- Add interfaces on top of R4CareGapsProcessor and R4CareGapsService so downstream systems can use composition instead of inheritance.