### PR TITLE
Make package paging public

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/PackageVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/PackageVisitor.java
@@ -232,7 +232,7 @@ public class PackageVisitor extends BaseKnowledgeArtifactVisitor {
         });
     }
 
-    protected void setCorrectBundleType(Optional<Integer> count, Optional<Integer> offset, IBaseBundle bundle) {
+    public static void setCorrectBundleType(Optional<Integer> count, Optional<Integer> offset, IBaseBundle bundle) {
         // if the bundle is paged then it must be of type = collection and modified to follow bundle.type constraints
         // if not, set type = transaction
         // special case of count = 0 -> set type = searchset so we can display bundle.total

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/PackageVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/PackageVisitor.java
@@ -261,7 +261,7 @@ public class PackageVisitor extends BaseKnowledgeArtifactVisitor {
      * @param offset the number of resources to skip beginning from the start of the bundle (starts from 1)
      * @param bundle the bundle to page
      */
-    protected void pageBundleBasedOnCountAndOffset(
+    public static void pageBundleBasedOnCountAndOffset(
             Optional<Integer> count, Optional<Integer> offset, IBaseBundle bundle) {
         if (offset.isPresent()) {
             var entries = BundleHelper.getEntry(bundle);


### PR DESCRIPTION
[APHL-1352] - In eCR we need to do some post-processing to the packaged bundle before returning it to the customer but don't want to duplicate the paging code. It would be great if we could just re-use from the visitor.

[APHL-1352]: https://alphora.atlassian.net/browse/APHL-1352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ