### PR TITLE
Fix wrong parameter type used when filtering CQL retrieves by template

### DIFF
--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProvider.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProvider.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 
 public abstract class BaseRetrieveProvider implements RetrieveProvider {
     private static final Logger logger = LoggerFactory.getLogger(BaseRetrieveProvider.class);
-    private final FhirContext fhirContext;
+    private final FhirVersionEnum fhirVersion;
     private final CodeExtractor codeUtil;
     private final IFhirPath fhirPath;
     private final RetrieveSettings retrieveSettings;
@@ -57,7 +57,8 @@ public abstract class BaseRetrieveProvider implements RetrieveProvider {
             final FhirContext fhirContext,
             final TerminologyProvider terminologyProvider,
             final RetrieveSettings retrieveSettings) {
-        this.fhirContext = requireNonNull(fhirContext, "fhirContext can not be null.");
+        requireNonNull(fhirContext, "fhirContext can not be null.");
+        fhirVersion = fhirContext.getVersion().getVersion();
         this.retrieveSettings = requireNonNull(retrieveSettings, "retrieveSettings can not be null");
         this.terminologyProvider = requireNonNull(terminologyProvider, "terminologyProvider can not be null");
         this.codeUtil = new CodeExtractor(fhirContext);
@@ -305,7 +306,7 @@ public abstract class BaseRetrieveProvider implements RetrieveProvider {
         // supports the _profile
         // parameter, we should add it.
         if (this.getRetrieveSettings().getProfileMode() != PROFILE_MODE.OFF && StringUtils.isNotBlank(templateId)) {
-            var profileParam = fhirContext.getVersion().getVersion().isOlderThan(FhirVersionEnum.R5)
+            var profileParam = getFhirVersion().isOlderThan(FhirVersionEnum.R5)
                     ? new UriParam(templateId)
                     : new ReferenceParam(templateId);
             searchParams.put("_profile", Collections.singletonList(profileParam));
@@ -446,6 +447,10 @@ public abstract class BaseRetrieveProvider implements RetrieveProvider {
         } else {
             throw new IllegalStateException("A date path must be provided when filtering using date parameters");
         }
+    }
+
+    protected FhirVersionEnum getFhirVersion() {
+        return fhirVersion;
     }
 
     protected CodeExtractor getCodeUtil() {

--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProvider.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProvider.java
@@ -3,6 +3,7 @@ package org.opencds.cqf.fhir.cql.engine.retrieve;
 import static java.util.Objects.requireNonNull;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.fhirpath.IFhirPath;
 import ca.uhn.fhir.model.api.IQueryParameterType;
 import ca.uhn.fhir.model.primitive.IdDt;
@@ -45,6 +46,7 @@ import org.slf4j.LoggerFactory;
 
 public abstract class BaseRetrieveProvider implements RetrieveProvider {
     private static final Logger logger = LoggerFactory.getLogger(BaseRetrieveProvider.class);
+    private final FhirContext fhirContext;
     private final CodeExtractor codeUtil;
     private final IFhirPath fhirPath;
     private final RetrieveSettings retrieveSettings;
@@ -55,7 +57,7 @@ public abstract class BaseRetrieveProvider implements RetrieveProvider {
             final FhirContext fhirContext,
             final TerminologyProvider terminologyProvider,
             final RetrieveSettings retrieveSettings) {
-        requireNonNull(fhirContext, "fhirContext can not be null.");
+        this.fhirContext = requireNonNull(fhirContext, "fhirContext can not be null.");
         this.retrieveSettings = requireNonNull(retrieveSettings, "retrieveSettings can not be null");
         this.terminologyProvider = requireNonNull(terminologyProvider, "terminologyProvider can not be null");
         this.codeUtil = new CodeExtractor(fhirContext);
@@ -303,7 +305,10 @@ public abstract class BaseRetrieveProvider implements RetrieveProvider {
         // supports the _profile
         // parameter, we should add it.
         if (this.getRetrieveSettings().getProfileMode() != PROFILE_MODE.OFF && StringUtils.isNotBlank(templateId)) {
-            searchParams.put("_profile", Collections.singletonList(new UriParam(templateId)));
+            var profileParam = fhirContext.getVersion().getVersion().isOlderThan(FhirVersionEnum.R5)
+                    ? new UriParam(templateId)
+                    : new ReferenceParam(templateId);
+            searchParams.put("_profile", Collections.singletonList(profileParam));
         }
     }
 

--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProvider.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProvider.java
@@ -13,6 +13,7 @@ import ca.uhn.fhir.rest.param.ParamPrefixEnum;
 import ca.uhn.fhir.rest.param.ReferenceParam;
 import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.param.TokenParamModifier;
+import ca.uhn.fhir.rest.param.UriParam;
 import ca.uhn.fhir.util.ExtensionUtil;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -302,7 +303,7 @@ public abstract class BaseRetrieveProvider implements RetrieveProvider {
         // supports the _profile
         // parameter, we should add it.
         if (this.getRetrieveSettings().getProfileMode() != PROFILE_MODE.OFF && StringUtils.isNotBlank(templateId)) {
-            searchParams.put("_profile", Collections.singletonList(new ReferenceParam(templateId)));
+            searchParams.put("_profile", Collections.singletonList(new UriParam(templateId)));
         }
     }
 

--- a/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProviderTests.java
+++ b/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProviderTests.java
@@ -17,7 +17,7 @@ import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.PROFILE_MODE;
 class BaseRetrieveProviderTests {
 
     @Test
-    public void testProfileParameterTypeIsCorrectForVersion() {
+    void testProfileParameterTypeIsCorrectForVersion() {
         var retrieveSettings = new RetrieveSettings().setProfileMode(PROFILE_MODE.DECLARED);
         var fixture = Mockito.mock(BaseRetrieveProvider.class, Mockito.CALLS_REAL_METHODS);
         doReturn(retrieveSettings).when(fixture).getRetrieveSettings();

--- a/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProviderTests.java
+++ b/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProviderTests.java
@@ -1,0 +1,35 @@
+package org.opencds.cqf.fhir.cql.engine.retrieve;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.doReturn;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import ca.uhn.fhir.model.api.IQueryParameterType;
+import ca.uhn.fhir.rest.param.ReferenceParam;
+import ca.uhn.fhir.rest.param.UriParam;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.PROFILE_MODE;
+
+class BaseRetrieveProviderTests {
+
+    @Test
+    public void testProfileParameterTypeIsCorrectForVersion() {
+        var retrieveSettings = new RetrieveSettings().setProfileMode(PROFILE_MODE.DECLARED);
+        var fixture = Mockito.mock(BaseRetrieveProvider.class, Mockito.CALLS_REAL_METHODS);
+        doReturn(retrieveSettings).when(fixture).getRetrieveSettings();
+        doReturn(FhirVersionEnum.R4).when(fixture).getFhirVersion();
+
+        Map<String, List<IQueryParameterType>> searchParamsR4 = new HashMap<>();
+        fixture.populateTemplateSearchParams(searchParamsR4, "test");
+        assertInstanceOf(UriParam.class, searchParamsR4.get("_profile").get(0));
+
+        doReturn(FhirVersionEnum.R5).when(fixture).getFhirVersion();
+        Map<String, List<IQueryParameterType>> searchParamsR5 = new HashMap<>();
+        fixture.populateTemplateSearchParams(searchParamsR5, "test");
+        assertInstanceOf(ReferenceParam.class, searchParamsR5.get("_profile").get(0));
+    }
+}


### PR DESCRIPTION
When a CQL retrieve is filtered by a template and the engine is set to use search parameters for filtering the `_profile` searchParam was always being given a ReferenceParam.  This parameter type was changed in R5 to be a ReferenceParam but is still a UriParam in R4 and previous versions.  This fix checks the version of the FhirContext being used and sets the parameter type accordingly.