### PR TITLE
The R5 version of PlanDefinition $apply now returns Parameters resource

### DIFF
--- a/cqf-fhir-benchmark/src/test/java/org/opencds/cqf/fhir/benchmark/plandefinition/TestPlanDefinition.java
+++ b/cqf-fhir-benchmark/src/test/java/org/opencds/cqf/fhir/benchmark/plandefinition/TestPlanDefinition.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +46,8 @@ import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.TERMINOLOGY_FIL
 import org.opencds.cqf.fhir.cql.engine.terminology.TerminologySettings.VALUESET_EXPANSION_MODE;
 import org.opencds.cqf.fhir.cr.plandefinition.PlanDefinitionProcessor;
 import org.opencds.cqf.fhir.utility.Ids;
+import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
+import org.opencds.cqf.fhir.utility.adapter.IParametersAdapter;
 import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 import org.opencds.cqf.fhir.utility.monad.Eithers;
 import org.opencds.cqf.fhir.utility.repository.InMemoryFhirRepository;
@@ -241,7 +242,7 @@ public class TestPlanDefinition {
 
         public When prefetchData(String name, String dataAssetName) {
             var data = jsonParser.parseResource(open(dataAssetName));
-            prefetchData = Arrays.asList((IBaseBackboneElement) newPart(repository.fhirContext(), name, data));
+            prefetchData = List.of((IBaseBackboneElement) newPart(repository.fhirContext(), name, data));
             return this;
         }
 
@@ -259,9 +260,9 @@ public class TestPlanDefinition {
             if (additionalDataId != null) {
                 loadAdditionalData(readRepository(repository, additionalDataId));
             }
-            return processor.applyR5(
+            var param = (IParametersAdapter) IAdapterFactory.createAdapterForResource(processor.applyR5(
                     Eithers.forMiddle3(Ids.newId(repository.fhirContext(), PLAN_DEFINITION, planDefinitionId)),
-                    subjectId,
+                    List.of(subjectId),
                     encounterId,
                     practitionerId,
                     organizationId,
@@ -276,7 +277,8 @@ public class TestPlanDefinition {
                     prefetchData,
                     dataRepository,
                     contentRepository,
-                    terminologyRepository);
+                    terminologyRepository));
+            return (IBaseBundle) param.getParameter().get(0).getResource();
         }
 
         public GeneratedBundle thenApplyR5() {

--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/parameters/CqlFhirParametersConverter.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/parameters/CqlFhirParametersConverter.java
@@ -233,7 +233,6 @@ public class CqlFhirParametersConverter {
         IParametersAdapter parametersAdapter = this.adapterFactory.createParameters(parameters);
 
         Map<String, List<IParametersParameterComponentAdapter>> children = parametersAdapter.getParameter().stream()
-                .map(x -> this.adapterFactory.createParametersParameter(x))
                 .filter(x -> x.getName() != null)
                 .collect(Collectors.groupingBy(IParametersParameterComponentAdapter::getName));
 

--- a/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/cdshooks/ICdsCrService.java
+++ b/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/cdshooks/ICdsCrService.java
@@ -43,14 +43,14 @@ public interface ICdsCrService {
                             org.hl7.fhir.r4.model.PlanDefinition.class,
                             operationName,
                             params,
-                            org.hl7.fhir.r4.model.Bundle.class,
+                            org.hl7.fhir.r4.model.Parameters.class,
                             Collections.singletonMap(Constants.HEADER_CONTENT_TYPE, Constants.CT_FHIR_JSON));
             case R5 -> getRepository()
                     .invoke(
                             org.hl7.fhir.r5.model.PlanDefinition.class,
                             operationName,
                             params,
-                            org.hl7.fhir.r5.model.Bundle.class,
+                            org.hl7.fhir.r5.model.Parameters.class,
                             Collections.singletonMap(Constants.HEADER_CONTENT_TYPE, Constants.CT_FHIR_JSON));
             default -> null;
         };

--- a/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/r4/plandefinition/PlanDefinitionApplyProvider.java
+++ b/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/r4/plandefinition/PlanDefinitionApplyProvider.java
@@ -1,5 +1,6 @@
 package org.opencds.cqf.fhir.cr.hapi.r4.plandefinition;
 
+import static ca.uhn.fhir.rest.annotation.OperationParam.MAX_UNLIMITED;
 import static org.opencds.cqf.fhir.cr.hapi.common.CanonicalHelper.getCanonicalType;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
@@ -211,7 +212,7 @@ public class PlanDefinitionApplyProvider {
             @OperationParam(name = "canonical") String canonical,
             @OperationParam(name = "url") String url,
             @OperationParam(name = "version") String version,
-            @OperationParam(name = "subject") String subject,
+            @OperationParam(name = "subject", min = 1, max = MAX_UNLIMITED) List<String> subject,
             @OperationParam(name = "encounter") String encounter,
             @OperationParam(name = "practitioner") String practitioner,
             @OperationParam(name = "organization") String organization,
@@ -258,7 +259,7 @@ public class PlanDefinitionApplyProvider {
             @OperationParam(name = "canonical") String canonical,
             @OperationParam(name = "url") String url,
             @OperationParam(name = "version") String version,
-            @OperationParam(name = "subject") String subject,
+            @OperationParam(name = "subject", min = 1, max = MAX_UNLIMITED) List<String> subject,
             @OperationParam(name = "encounter") String encounter,
             @OperationParam(name = "practitioner") String practitioner,
             @OperationParam(name = "organization") String organization,

--- a/cqf-fhir-cr-hapi/src/test/java/org/opencds/cqf/fhir/cr/hapi/cdshooks/CdsCrServiceR4Test.java
+++ b/cqf-fhir-cr-hapi/src/test/java/org/opencds/cqf/fhir/cr/hapi/cdshooks/CdsCrServiceR4Test.java
@@ -16,6 +16,7 @@ import ca.uhn.hapi.fhir.cdshooks.module.CdsHooksObjectMapperFactory;
 import java.io.IOException;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,7 +64,7 @@ class CdsCrServiceR4Test extends BaseCdsCrServiceTest {
                 new CdsCrService(requestDetails, repository, cdsConfigService).encodeParams(cdsServiceRequestJson));
 
         assertEquals(2, params.getParameter().size());
-        assertTrue(((ParametersParameterComponent) params.getParameter("parameters")).hasResource());
+        assertTrue((params.getParameter("parameters")).hasResource());
     }
 
     @Test
@@ -73,11 +74,14 @@ class CdsCrServiceR4Test extends BaseCdsCrServiceTest {
         final Repository repository = new InMemoryFhirRepository(fhirContext, bundle);
         final Bundle responseBundle = ClasspathUtil.loadResource(
                 fhirContext, Bundle.class, "org/opencds/cqf/fhir/cr/hapi/cdshooks/Bundle-ASLPCrd-Response.json");
+        final Parameters response = new Parameters()
+                .addParameter(
+                        new ParametersParameterComponent().setName("return").setResource(responseBundle));
         final RequestDetails requestDetails = new SystemRequestDetails();
         final IdType planDefinitionId = new IdType(PLAN_DEFINITION_RESOURCE_NAME, "ASLPCrd");
         requestDetails.setId(planDefinitionId);
         final CdsServiceResponseJson cdsServiceResponseJson =
-                new CdsCrService(requestDetails, repository, cdsConfigService).encodeResponse(responseBundle);
+                new CdsCrService(requestDetails, repository, cdsConfigService).encodeResponse(response);
 
         assertEquals(1, cdsServiceResponseJson.getCards().size());
         assertFalse(cdsServiceResponseJson.getCards().get(0).getSummary().isEmpty());

--- a/cqf-fhir-cr-hapi/src/test/java/org/opencds/cqf/fhir/cr/hapi/r4/PlanDefinitionOperationsProviderIT.java
+++ b/cqf-fhir-cr-hapi/src/test/java/org/opencds/cqf/fhir/cr/hapi/r4/PlanDefinitionOperationsProviderIT.java
@@ -72,13 +72,13 @@ class PlanDefinitionOperationsProviderIT extends BaseCrR4TestServer {
         assertNotNull(result);
         assertEquals(1, result.getContained().size());
 
-        var resultR5 = (Bundle) planDefinitionApplyProvider.applyR5(
+        var resultR5 = (Parameters) planDefinitionApplyProvider.applyR5(
                 null,
                 null,
                 null,
                 url,
                 version,
-                patientID,
+                List.of(patientID),
                 null,
                 null,
                 null,
@@ -97,14 +97,15 @@ class PlanDefinitionOperationsProviderIT extends BaseCrR4TestServer {
                 requestDetails);
 
         assertNotNull(resultR5);
-        var questionnaireResponses = resultR5.getEntry().stream()
+        var bundle = (Bundle) resultR5.getParameter().get(0).getResource();
+        var questionnaireResponses = bundle.getEntry().stream()
                 .filter(e -> e.hasResource() && e.getResource().fhirType().equals("QuestionnaireResponse"))
                 .toList();
         assertEquals(1, questionnaireResponses.size());
         var questionnaireResponse =
                 (QuestionnaireResponse) questionnaireResponses.get(0).getResource();
         assertNotNull(questionnaireResponse);
-        var questionnaires = resultR5.getEntry().stream()
+        var questionnaires = bundle.getEntry().stream()
                 .filter(e -> e.hasResource() && e.getResource().fhirType().equals("Questionnaire"))
                 .toList();
         assertEquals(1, questionnaires.size());

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/MeasureOperationParameterConverter.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/MeasureOperationParameterConverter.java
@@ -3,7 +3,6 @@ package org.opencds.cqf.fhir.cr.measure;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import org.hl7.fhir.instance.model.api.IBaseDatatype;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.ICompositeType;
@@ -56,9 +55,7 @@ public class MeasureOperationParameterConverter {
 
     protected void addChild(IBaseParameters parameters, String name, IBaseDatatype value) {
         IParametersAdapter parametersAdapter = this.adapterFactory.createParameters(parameters);
-        List<IParametersParameterComponentAdapter> parts = parametersAdapter.getParameter().stream()
-                .map(x -> this.adapterFactory.createParametersParameter(x))
-                .collect(Collectors.toList());
+        List<IParametersParameterComponentAdapter> parts = parametersAdapter.getParameter();
 
         IParametersParameterComponentAdapter part =
                 parts.stream().filter(x -> x.getName().equals(name)).findFirst().orElse(null);

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/PlanDefinitionProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/PlanDefinitionProcessor.java
@@ -7,6 +7,7 @@ import static org.opencds.cqf.fhir.utility.repository.Repositories.createRestRep
 import static org.opencds.cqf.fhir.utility.repository.Repositories.proxy;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
+import jakarta.annotation.Nonnull;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
@@ -30,6 +31,8 @@ import org.opencds.cqf.fhir.cr.plandefinition.apply.ApplyProcessor;
 import org.opencds.cqf.fhir.cr.plandefinition.apply.ApplyRequest;
 import org.opencds.cqf.fhir.cr.plandefinition.apply.IApplyProcessor;
 import org.opencds.cqf.fhir.utility.Ids;
+import org.opencds.cqf.fhir.utility.Resources;
+import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
 import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 import org.opencds.cqf.fhir.utility.monad.Either3;
 
@@ -132,8 +135,8 @@ public class PlanDefinitionProcessor {
     }
 
     protected <C extends IPrimitiveType<String>, R extends IBaseResource> ApplyRequest buildApplyRequest(
-            Either3<C, IIdType, R> planDefinition,
-            String subject,
+            @Nonnull Either3<C, IIdType, R> planDefinition,
+            @Nonnull String subject,
             String encounter,
             String practitioner,
             String organization,
@@ -293,7 +296,7 @@ public class PlanDefinitionProcessor {
         if (fhirVersion == FhirVersionEnum.R5) {
             return applyR5(
                     planDefinition,
-                    subject,
+                    List.of(subject),
                     encounter,
                     practitioner,
                     organization,
@@ -331,9 +334,9 @@ public class PlanDefinitionProcessor {
         return applyProcessor.apply(request);
     }
 
-    public <C extends IPrimitiveType<String>, R extends IBaseResource> IBaseBundle applyR5(
+    public <C extends IPrimitiveType<String>, R extends IBaseResource> IBaseParameters applyR5(
             Either3<C, IIdType, R> planDefinition,
-            String subject,
+            List<String> subject,
             String encounter,
             String practitioner,
             String organization,
@@ -369,9 +372,9 @@ public class PlanDefinitionProcessor {
                 createRestRepository(repository.fhirContext(), terminologyEndpoint));
     }
 
-    public <C extends IPrimitiveType<String>, R extends IBaseResource> IBaseBundle applyR5(
+    public <C extends IPrimitiveType<String>, R extends IBaseResource> IBaseParameters applyR5(
             Either3<C, IIdType, R> planDefinition,
-            String subject,
+            List<String> subject,
             String encounter,
             String practitioner,
             String organization,
@@ -406,9 +409,9 @@ public class PlanDefinitionProcessor {
                 new LibraryEngine(repository, this.evaluationSettings));
     }
 
-    public <C extends IPrimitiveType<String>, R extends IBaseResource> IBaseBundle applyR5(
+    public <C extends IPrimitiveType<String>, R extends IBaseResource> IBaseParameters applyR5(
             Either3<C, IIdType, R> planDefinition,
-            String subject,
+            List<String> subject,
             String encounter,
             String practitioner,
             String organization,
@@ -422,22 +425,29 @@ public class PlanDefinitionProcessor {
             IBaseBundle data,
             List<? extends IBaseBackboneElement> prefetchData,
             LibraryEngine libraryEngine) {
-        return applyR5(buildApplyRequest(
-                planDefinition,
-                subject,
-                encounter,
-                practitioner,
-                organization,
-                userType,
-                userLanguage,
-                userTaskContext,
-                setting,
-                settingContext,
-                parameters,
-                useServerData,
-                data,
-                prefetchData,
-                libraryEngine));
+        var param = IAdapterFactory.forFhirVersion(fhirVersion)
+                .createParameters((IBaseParameters) Resources.newBaseForVersion("Parameters", fhirVersion));
+        subject.forEach(s -> {
+            param.addParameter(
+                    "return",
+                    applyR5(buildApplyRequest(
+                            planDefinition,
+                            s,
+                            encounter,
+                            practitioner,
+                            organization,
+                            userType,
+                            userLanguage,
+                            userTaskContext,
+                            setting,
+                            settingContext,
+                            parameters,
+                            useServerData,
+                            data,
+                            prefetchData,
+                            libraryEngine)));
+        });
+        return (IBaseParameters) param.get();
     }
 
     public IBaseBundle applyR5(ApplyRequest request) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/BaseKnowledgeArtifactVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/BaseKnowledgeArtifactVisitor.java
@@ -205,11 +205,7 @@ public abstract class BaseKnowledgeArtifactVisitor implements IKnowledgeArtifact
         if (client != null
                 && endpoint != null
                 && Canonicals.getResourceType(ra.getReference()).equals("ValueSet")) {
-            return client.getResource(
-                            endpoint,
-                            ra.getReference(),
-                            fhirContext().getVersion().getVersion())
-                    .orElse(null);
+            return client.getResource(endpoint, ra.getReference()).orElse(null);
         }
         return null;
     }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/ExpandHelper.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/ExpandHelper.java
@@ -3,7 +3,6 @@ package org.opencds.cqf.fhir.cr.visitor;
 import static org.opencds.cqf.fhir.utility.ValueSets.addCodeToExpansion;
 import static org.opencds.cqf.fhir.utility.ValueSets.addParameterToExpansion;
 import static org.opencds.cqf.fhir.utility.ValueSets.getCodesInExpansion;
-import static org.opencds.cqf.fhir.utility.adapter.IAdapterFactory.createAdapterForResource;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
@@ -12,6 +11,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
@@ -20,8 +20,10 @@ import org.opencds.cqf.fhir.utility.Canonicals;
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.Parameters;
 import org.opencds.cqf.fhir.utility.ValueSets;
+import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
 import org.opencds.cqf.fhir.utility.adapter.IEndpointAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IParametersAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IParametersParameterComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetAdapter;
 import org.opencds.cqf.fhir.utility.client.TerminologyServerClient;
 import org.slf4j.Logger;
@@ -30,11 +32,13 @@ import org.slf4j.LoggerFactory;
 public class ExpandHelper {
     private static final Logger myLogger = LoggerFactory.getLogger(ExpandHelper.class);
     private final Repository repository;
+    private final IAdapterFactory adapterFactory;
     private final TerminologyServerClient terminologyServerClient;
     public static final List<String> unsupportedParametersToRemove = List.of(Constants.CANONICAL_VERSION);
 
     public ExpandHelper(Repository repository, TerminologyServerClient server) {
         this.repository = repository;
+        adapterFactory = IAdapterFactory.forFhirContext(this.repository.fhirContext());
         terminologyServerClient = server;
     }
 
@@ -45,9 +49,11 @@ public class ExpandHelper {
     private static void filterOutUnsupportedParameters(IParametersAdapter parameters) {
         var paramsToSet = parameters.getParameter();
         unsupportedParametersToRemove.forEach(parameterUrl -> {
-            while (parameters.getParameter(parameterUrl) != null) {
-                paramsToSet.remove(parameters.getParameter(parameterUrl));
-                parameters.setParameter(paramsToSet);
+            while (parameters.hasParameter(parameterUrl)) {
+                parameters.setParameter(paramsToSet.stream()
+                        .filter(p -> !p.getName().equals(parameterUrl))
+                        .map(IParametersParameterComponentAdapter::get)
+                        .toList());
             }
         });
     }
@@ -104,7 +110,7 @@ public class ExpandHelper {
 
     private void terminologyServerExpand(
             IValueSetAdapter valueSet, IParametersAdapter expansionParameters, IEndpointAdapter terminologyEndpoint) {
-        var expandedValueSet = (IValueSetAdapter) createAdapterForResource(
+        var expandedValueSet = (IValueSetAdapter) adapterFactory.createResource(
                 terminologyServerClient.expand(valueSet, terminologyEndpoint, expansionParameters));
         // expansions are only valid for a particular version
         if (!valueSet.hasVersion()) {
@@ -218,7 +224,7 @@ public class ExpandHelper {
                     if (terminologyEndpoint.isPresent()) {
                         return terminologyServerClient
                                 .getResource(terminologyEndpoint.get(), reference)
-                                .map(r -> (IValueSetAdapter) createAdapterForResource(r))
+                                .map(r -> (IValueSetAdapter) adapterFactory.createResource(r))
                                 .orElse(null);
                     } else {
                         return VisitorHelper.tryGetLatestVersion(reference, repository)
@@ -236,28 +242,34 @@ public class ExpandHelper {
             Date expansionTimestamp,
             IValueSetAdapter includedVS) {
         // update url and version exp params for child expansions
-        var childExpParams = (IParametersAdapter) createAdapterForResource(expansionParameters.copy());
-        var urlParam = childExpParams.getParameter(TerminologyServerClient.urlParamName);
-        if (urlParam != null) {
-            var ind = childExpParams.getParameter().indexOf(urlParam);
-            childExpParams.getParameter().remove(ind);
+        var childExpParams = (IParametersAdapter) adapterFactory.createResource(expansionParameters.copy());
+        if (childExpParams.hasParameter(TerminologyServerClient.urlParamName)) {
+            var newParams = childExpParams.getParameter().stream()
+                    .filter(p -> !p.getName().equals(TerminologyServerClient.urlParamName))
+                    .collect(Collectors.toList());
             if (includedVS.hasUrl()) {
-                childExpParams.addParameter(
-                        fhirContext().getVersion().getVersion() == FhirVersionEnum.DSTU3
+                newParams.add(adapterFactory.createParametersParameter((IBaseBackboneElement)
+                        (fhirContext().getVersion().getVersion() == FhirVersionEnum.DSTU3
                                 ? Parameters.newUriPart(
                                         fhirContext(), TerminologyServerClient.urlParamName, includedVS.getUrl())
                                 : Parameters.newUrlPart(
-                                        fhirContext(), TerminologyServerClient.urlParamName, includedVS.getUrl()));
+                                        fhirContext(), TerminologyServerClient.urlParamName, includedVS.getUrl()))));
             }
+            childExpParams.setParameter(newParams.stream()
+                    .map(IParametersParameterComponentAdapter::get)
+                    .toList());
         }
-        var versionParam = childExpParams.getParameter(TerminologyServerClient.versionParamName);
-        if (versionParam != null) {
-            var ind = childExpParams.getParameter().indexOf(versionParam);
-            childExpParams.getParameter().remove(ind);
+        if (childExpParams.hasParameter(TerminologyServerClient.versionParamName)) {
+            var newParams = childExpParams.getParameter().stream()
+                    .filter(p -> !p.getName().equals(TerminologyServerClient.versionParamName))
+                    .collect(Collectors.toList());
             if (includedVS.hasVersion()) {
-                childExpParams.addParameter(Parameters.newStringPart(
-                        fhirContext(), TerminologyServerClient.versionParamName, includedVS.getVersion()));
+                newParams.add(adapterFactory.createParametersParameter((IBaseBackboneElement) Parameters.newStringPart(
+                        fhirContext(), TerminologyServerClient.versionParamName, includedVS.getVersion())));
             }
+            childExpParams.setParameter(newParams.stream()
+                    .map(IParametersParameterComponentAdapter::get)
+                    .toList());
         }
         expandValueSet(includedVS, childExpParams, terminologyEndpoint, valueSets, expandedList, expansionTimestamp);
     }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/ReleaseVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/ReleaseVisitor.java
@@ -264,7 +264,7 @@ public class ReleaseVisitor extends BaseKnowledgeArtifactVisitor {
             // we trust in this case that the Endpoint URL matches up with the Authoritative Source in the ValueSet
             // if this assumption is faulty the only consequence is that the VSet doesn't get resolved
             latest = terminologyServerClient
-                    .getLatestNonDraftResource(endpoint, preReleaseReference, this.fhirVersion())
+                    .getLatestNonDraftResource(endpoint, preReleaseReference)
                     .map(r -> (IKnowledgeArtifactAdapter) createAdapterForResource(r));
         } else {
             // get the latest ACTIVE version, if not fallback to the latest non-DRAFT version
@@ -405,7 +405,7 @@ public class ReleaseVisitor extends BaseKnowledgeArtifactVisitor {
         // if this assumption is faulty the only consequence is that the VSet doesn't get resolved
         if (resourceType != null && resourceType.equals(VALUESET) && latestFromTxServer) {
             maybeAdapter = terminologyServerClient
-                    .getLatestNonDraftResource(endpoint, reference, this.fhirVersion())
+                    .getLatestNonDraftResource(endpoint, reference)
                     .map(r -> (IKnowledgeArtifactAdapter) createAdapterForResource(r));
         } else {
             // get the latest ACTIVE version, if not fallback to the latest non-DRAFT version

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/VisitorHelper.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/VisitorHelper.java
@@ -32,7 +32,6 @@ public class VisitorHelper {
         return Optional.ofNullable(operationParameters)
                 .map(factory::createParameters)
                 .map(p -> p.getParameter(name))
-                .map(factory::createParametersParameter)
                 .map(parametersParameters -> (T) parametersParameters.getValue());
     }
 
@@ -43,7 +42,6 @@ public class VisitorHelper {
         return Optional.ofNullable(operationParameters)
                 .map(factory::createParameters)
                 .map(p -> p.getParameter(name))
-                .map(factory::createParametersParameter)
                 .map(parametersParameters -> (T) parametersParameters.getResource());
     }
 
@@ -74,7 +72,6 @@ public class VisitorHelper {
         return Optional.ofNullable(operationParameters)
                 .map(factory::createParameters)
                 .map(p -> p.getParameter(name))
-                .map(factory::createParametersParameter)
                 .map(parametersParameters -> ((IPrimitiveType<Boolean>) parametersParameters.getValue()).getValue());
     }
 
@@ -84,7 +81,6 @@ public class VisitorHelper {
         return Optional.ofNullable(operationParameters)
                 .map(factory::createParameters)
                 .map(p -> p.getParameter(name))
-                .map(factory::createParametersParameter)
                 .map(parametersParameters -> ((IPrimitiveType<Date>) parametersParameters.getValue()).getValue());
     }
 
@@ -94,7 +90,6 @@ public class VisitorHelper {
         return Optional.ofNullable(operationParameters)
                 .map(factory::createParameters)
                 .map(p -> p.getParameter(name))
-                .map(factory::createParametersParameter)
                 .map(parametersParameters -> ((IPrimitiveType<Integer>) parametersParameters.getValue()).getValue());
     }
 
@@ -104,7 +99,6 @@ public class VisitorHelper {
         return Optional.ofNullable(operationParameters)
                 .map(factory::createParameters)
                 .map(p -> p.getParameter(name))
-                .map(factory::createParametersParameter)
                 .map(parametersParameters -> ((IPrimitiveType<String>) parametersParameters.getValue()).getValue());
     }
 

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/PlanDefinitionProcessorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/PlanDefinitionProcessorTests.java
@@ -3,8 +3,8 @@ package org.opencds.cqf.fhir.cr.plandefinition;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.opencds.cqf.fhir.cr.plandefinition.PlanDefinition.CLASS_PATH;
-import static org.opencds.cqf.fhir.cr.plandefinition.PlanDefinition.given;
+import static org.opencds.cqf.fhir.cr.plandefinition.TestPlanDefinition.CLASS_PATH;
+import static org.opencds.cqf.fhir.cr.plandefinition.TestPlanDefinition.given;
 import static org.opencds.cqf.fhir.test.Resources.getResourcePath;
 
 import ca.uhn.fhir.context.FhirContext;

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/TestPlanDefinition.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/TestPlanDefinition.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,17 +45,19 @@ import org.opencds.cqf.fhir.cr.TestOperationProvider;
 import org.opencds.cqf.fhir.cr.helpers.DataRequirementsLibrary;
 import org.opencds.cqf.fhir.cr.helpers.GeneratedPackage;
 import org.opencds.cqf.fhir.utility.Ids;
+import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
+import org.opencds.cqf.fhir.utility.adapter.IParametersAdapter;
 import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 import org.opencds.cqf.fhir.utility.monad.Eithers;
 import org.opencds.cqf.fhir.utility.repository.InMemoryFhirRepository;
 import org.opencds.cqf.fhir.utility.repository.ig.IgRepository;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-public class PlanDefinition {
+public class TestPlanDefinition {
     public static final String CLASS_PATH = "org/opencds/cqf/fhir/cr/shared";
 
     private static InputStream open(String asset) {
-        var path = Paths.get(getResourcePath(PlanDefinition.class) + "/" + CLASS_PATH + "/" + asset);
+        var path = Paths.get(getResourcePath(TestPlanDefinition.class) + "/" + CLASS_PATH + "/" + asset);
         var file = path.toFile();
         try {
             return new FileInputStream(file);
@@ -222,7 +223,7 @@ public class PlanDefinition {
 
         public When prefetchData(String name, String dataAssetName) {
             var data = jsonParser.parseResource(open(dataAssetName));
-            prefetchData = Arrays.asList((IBaseBackboneElement) newPart(repository.fhirContext(), name, data));
+            prefetchData = List.of((IBaseBackboneElement) newPart(repository.fhirContext(), name, data));
             return this;
         }
 
@@ -240,9 +241,9 @@ public class PlanDefinition {
             if (additionalDataId != null) {
                 loadAdditionalData(readRepository(repository, additionalDataId));
             }
-            return processor.applyR5(
+            var param = (IParametersAdapter) IAdapterFactory.createAdapterForResource(processor.applyR5(
                     Eithers.forMiddle3(Ids.newId(repository.fhirContext(), "PlanDefinition", planDefinitionId)),
-                    subjectId,
+                    List.of(subjectId),
                     encounterId,
                     practitionerId,
                     organizationId,
@@ -257,7 +258,8 @@ public class PlanDefinition {
                     prefetchData,
                     dataRepository,
                     contentRepository,
-                    terminologyRepository);
+                    terminologyRepository));
+            return (IBaseBundle) param.getParameter().get(0).getResource();
         }
 
         public GeneratedBundle thenApplyR5() {

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/ExpandHelperTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/ExpandHelperTest.java
@@ -21,7 +21,6 @@ import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.Endpoint;
 import org.hl7.fhir.r4.model.Parameters;
-import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.r4.model.UriType;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.junit.jupiter.api.Test;
@@ -148,9 +147,8 @@ class ExpandHelperTest {
         // leaf is expanded with Leaf url not Grouper url
 
         @SuppressWarnings("unchecked")
-        var url = ((IPrimitiveType<String>) ((ParametersParameterComponent)
-                                childExpParams.getParameter(TerminologyServerClient.urlParamName))
-                        .getValue())
+        var url = ((IPrimitiveType<String>)
+                        (childExpParams.getParameter(TerminologyServerClient.urlParamName)).getValue())
                 .getValue();
         assertEquals(leafUrl, url);
         // the Version parameter is removed because leaf has no version

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/ExpandHelperTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/ExpandHelperTest.java
@@ -1,8 +1,8 @@
 package org.opencds.cqf.fhir.cr.visitor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -63,7 +63,7 @@ class ExpandHelperTest {
         assertEquals(
                 expansionDate.getTime(), grouper.getExpansion().getTimestamp().getTime());
         verify(rep, times(1)).search(any(), any(), any(), any());
-        verify(client, never()).getResource(any(), any(), any());
+        verify(client, never()).getResource(any(), any());
         verify(client, never()).expand(any(IValueSetAdapter.class), any(), any());
     }
 
@@ -91,7 +91,7 @@ class ExpandHelperTest {
 
         var expandHelper = new ExpandHelper(rep, client);
         expandHelper.expandValueSet(
-                (IValueSetAdapter) this.factory.createKnowledgeArtifactAdapter(grouper),
+                (IValueSetAdapter) factory.createKnowledgeArtifactAdapter(grouper),
                 factory.createParameters(new Parameters()),
                 // important part of the test
                 Optional.of(factory.createEndpoint(endpoint)),
@@ -100,7 +100,7 @@ class ExpandHelperTest {
                 new Date());
         assertEquals(3, grouper.getExpansion().getContains().size());
         verify(rep, never()).search(any(), any(), any());
-        verify(client, times(1)).getResource(any(), any(), any());
+        verify(client, times(1)).getResource(any(), any());
         verify(client, times(1)).expand(any(IValueSetAdapter.class), any(), any());
     }
 
@@ -371,7 +371,7 @@ class ExpandHelperTest {
 
     TerminologyServerClient mockTerminologyServerWithValueSetR4(ValueSet valueSet) {
         var mockClient = mock(TerminologyServerClient.class);
-        when(mockClient.getResource(any(), anyString(), any())).thenReturn(java.util.Optional.of(valueSet));
+        when(mockClient.getResource(any(), anyString())).thenReturn(java.util.Optional.of(valueSet));
         when(mockClient.expand(any(IValueSetAdapter.class), any(), any())).thenReturn(valueSet);
         return mockClient;
     }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/dstu3/PackageVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/dstu3/PackageVisitorTests.java
@@ -493,7 +493,7 @@ class PackageVisitorTests {
 
         var clientMock = mock(TerminologyServerClient.class, new ReturnsDeepStubs());
         // expect the Tx Server to provide the missing ValueSet
-        when(clientMock.getResource(any(IEndpointAdapter.class), any(), any())).thenReturn(Optional.of(missingVset));
+        when(clientMock.getResource(any(IEndpointAdapter.class), any())).thenReturn(Optional.of(missingVset));
         doAnswer(new Answer<ValueSet>() {
                     @Override
                     public ValueSet answer(InvocationOnMock invocation) throws Throwable {

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/dstu3/ReleaseVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/dstu3/ReleaseVisitorTests.java
@@ -511,7 +511,7 @@ class ReleaseVisitorTests {
         var endpoint = createEndpoint(authoritativeSource);
 
         var clientMock = mock(TerminologyServerClient.class, new ReturnsDeepStubs());
-        when(clientMock.getLatestNonDraftResource(any(), any(), any())).thenReturn(Optional.of(latestVSet));
+        when(clientMock.getLatestNonDraftResource(any(), any())).thenReturn(Optional.of(latestVSet));
         var releaseVisitor = new ReleaseVisitor(repo, clientMock);
         var libraryAdapter = new AdapterFactory().createLibrary(library);
         var params = parameters(

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/ReleaseVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/ReleaseVisitorTests.java
@@ -486,7 +486,7 @@ class ReleaseVisitorTests {
         var endpoint = createEndpoint(authoritativeSource);
 
         var clientMock = mock(TerminologyServerClient.class, new ReturnsDeepStubs());
-        when(clientMock.getLatestNonDraftResource(any(), any(), any())).thenReturn(Optional.of(latestVSet));
+        when(clientMock.getLatestNonDraftResource(any(), any())).thenReturn(Optional.of(latestVSet));
         var releaseVisitor = new ReleaseVisitor(repo, clientMock);
         var libraryAdapter = new AdapterFactory().createLibrary(library);
         var params = parameters(

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r5/PackageVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r5/PackageVisitorTests.java
@@ -494,7 +494,7 @@ class PackageVisitorTests {
 
         var clientMock = mock(TerminologyServerClient.class, new ReturnsDeepStubs());
         // expect the Tx Server to provide the missing ValueSet
-        when(clientMock.getResource(any(IEndpointAdapter.class), any(), any())).thenReturn(Optional.of(missingVset));
+        when(clientMock.getResource(any(IEndpointAdapter.class), any())).thenReturn(Optional.of(missingVset));
         doAnswer(new Answer<ValueSet>() {
                     @Override
                     public ValueSet answer(InvocationOnMock invocation) throws Throwable {

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r5/ReleaseVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r5/ReleaseVisitorTests.java
@@ -482,7 +482,7 @@ class ReleaseVisitorTests {
         var endpoint = createEndpoint(authoritativeSource);
 
         var clientMock = mock(TerminologyServerClient.class, new ReturnsDeepStubs());
-        when(clientMock.getLatestNonDraftResource(any(), any(), any())).thenReturn(Optional.of(latestVSet));
+        when(clientMock.getLatestNonDraftResource(any(), any())).thenReturn(Optional.of(latestVSet));
         var releaseVisitor = new ReleaseVisitor(repo, clientMock);
         var libraryAdapter = new AdapterFactory().createLibrary(library);
         var params = parameters(

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IParametersAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IParametersAdapter.java
@@ -10,9 +10,11 @@ public interface IParametersAdapter extends IResourceAdapter {
 
     public boolean hasParameter();
 
-    public <T extends IBaseBackboneElement> List<T> getParameter();
+    public List<IParametersParameterComponentAdapter> getParameter();
 
-    public IBaseBackboneElement getParameter(String name);
+    public boolean hasParameter(String name);
+
+    public IParametersParameterComponentAdapter getParameter(String name);
 
     public <T extends IBaseDatatype> List<T> getParameterValues(String name);
 

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ParametersAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ParametersAdapter.java
@@ -11,6 +11,7 @@ import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.opencds.cqf.fhir.utility.adapter.IParametersAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IParametersParameterComponentAdapter;
 
 class ParametersAdapter extends ResourceAdapter implements IParametersAdapter {
 
@@ -24,7 +25,7 @@ class ParametersAdapter extends ResourceAdapter implements IParametersAdapter {
         this.parameters = (Parameters) parameters;
     }
 
-    private Parameters parameters;
+    private final Parameters parameters;
 
     protected Parameters getParameters() {
         return this.parameters;
@@ -35,10 +36,11 @@ class ParametersAdapter extends ResourceAdapter implements IParametersAdapter {
         return parameters.hasParameter();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public List<ParametersParameterComponent> getParameter() {
-        return this.getParameters().getParameter();
+    public List<IParametersParameterComponentAdapter> getParameter() {
+        return this.getParameters().getParameter().stream()
+                .map(adapterFactory::createParametersParameter)
+                .toList();
     }
 
     @Override
@@ -92,14 +94,20 @@ class ParametersAdapter extends ResourceAdapter implements IParametersAdapter {
     public List<Type> getParameterValues(String name) {
         return this.getParameters().getParameter().stream()
                 .filter(p -> p.getName().equals(name))
-                .map(p -> p.getValue())
+                .map(ParametersParameterComponent::getValue)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public ParametersParameterComponent getParameter(String name) {
-        return this.getParameters().getParameter().stream()
+    public boolean hasParameter(String name) {
+        return getParameters().getParameter().stream().anyMatch(p -> p.getName().equals(name));
+    }
+
+    @Override
+    public IParametersParameterComponentAdapter getParameter(String name) {
+        return getParameters().getParameter().stream()
                 .filter(p -> p.getName().equals(name))
+                .map(adapterFactory::createParametersParameter)
                 .findFirst()
                 .orElse(null);
     }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/ParametersAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/ParametersAdapter.java
@@ -10,6 +10,7 @@ import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.Type;
 import org.opencds.cqf.fhir.utility.adapter.IParametersAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IParametersParameterComponentAdapter;
 
 class ParametersAdapter extends ResourceAdapter implements IParametersAdapter {
 
@@ -34,10 +35,11 @@ class ParametersAdapter extends ResourceAdapter implements IParametersAdapter {
         return parameters.hasParameter();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public List<ParametersParameterComponent> getParameter() {
-        return this.getParameters().getParameter();
+    public List<IParametersParameterComponentAdapter> getParameter() {
+        return this.getParameters().getParameter().stream()
+                .map(adapterFactory::createParametersParameter)
+                .toList();
     }
 
     @SuppressWarnings("unchecked")
@@ -47,8 +49,14 @@ class ParametersAdapter extends ResourceAdapter implements IParametersAdapter {
     }
 
     @Override
-    public ParametersParameterComponent getParameter(String name) {
-        return this.getParameters().getParameter(name);
+    public boolean hasParameter(String name) {
+        return parameters.hasParameter(name);
+    }
+
+    @Override
+    public IParametersParameterComponentAdapter getParameter(String name) {
+        var param = getParameters().getParameter(name);
+        return param == null ? null : adapterFactory.createParametersParameter(param);
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/ParametersAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/ParametersAdapter.java
@@ -10,6 +10,7 @@ import org.hl7.fhir.r5.model.Parameters;
 import org.hl7.fhir.r5.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.r5.model.Resource;
 import org.opencds.cqf.fhir.utility.adapter.IParametersAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IParametersParameterComponentAdapter;
 
 class ParametersAdapter extends ResourceAdapter implements IParametersAdapter {
 
@@ -23,7 +24,7 @@ class ParametersAdapter extends ResourceAdapter implements IParametersAdapter {
         this.parameters = (Parameters) parameters;
     }
 
-    private Parameters parameters;
+    private final Parameters parameters;
 
     protected Parameters getParameters() {
         return this.parameters;
@@ -34,10 +35,11 @@ class ParametersAdapter extends ResourceAdapter implements IParametersAdapter {
         return parameters.hasParameter();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public List<ParametersParameterComponent> getParameter() {
-        return this.getParameters().getParameter().stream().collect(Collectors.toList());
+    public List<IParametersParameterComponentAdapter> getParameter() {
+        return getParameters().getParameter().stream()
+                .map(adapterFactory::createParametersParameter)
+                .toList();
     }
 
     @SuppressWarnings("unchecked")
@@ -47,8 +49,14 @@ class ParametersAdapter extends ResourceAdapter implements IParametersAdapter {
     }
 
     @Override
-    public ParametersParameterComponent getParameter(String name) {
-        return this.getParameters().getParameter(name);
+    public boolean hasParameter(String name) {
+        return parameters.hasParameter(name);
+    }
+
+    @Override
+    public IParametersParameterComponentAdapter getParameter(String name) {
+        var param = getParameters().getParameter(name);
+        return param == null ? null : adapterFactory.createParametersParameter(param);
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/client/ExpandRunner.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/client/ExpandRunner.java
@@ -1,0 +1,118 @@
+package org.opencds.cqf.fhir.utility.client;
+
+import static java.util.Objects.requireNonNull;
+
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
+import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.hl7.fhir.instance.model.api.IBaseParameters;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.opencds.cqf.fhir.utility.Resources;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExpandRunner implements Runnable {
+
+    private static final Logger logger = LoggerFactory.getLogger(ExpandRunner.class);
+
+    private int expansionAttempt = 0;
+    private IBaseResource expandedValueSet;
+    private final IGenericClient fhirClient;
+    private final String valueSetUrl;
+    private final IBaseParameters parameters;
+
+    private final TerminologyServerClientSettings terminologyServerClientSettings;
+    private final ScheduledExecutorService scheduler;
+
+    public ExpandRunner(
+            IGenericClient client,
+            TerminologyServerClientSettings terminologyServerClientSettings,
+            String valueSetUrl,
+            IBaseParameters parameters) {
+        this(client, terminologyServerClientSettings, valueSetUrl, parameters, null);
+    }
+
+    public ExpandRunner(
+            IGenericClient fhirClient,
+            TerminologyServerClientSettings terminologyServerClientSettings,
+            String valueSetUrl,
+            IBaseParameters parameters,
+            ScheduledExecutorService scheduler) {
+        this.fhirClient = requireNonNull(fhirClient);
+        this.terminologyServerClientSettings = requireNonNull(terminologyServerClientSettings);
+        this.valueSetUrl = requireNonNull(valueSetUrl);
+        this.parameters = parameters;
+        this.scheduler = scheduler != null ? scheduler : Executors.newScheduledThreadPool(1);
+    }
+
+    public IBaseResource expandValueSet() {
+        var result = scheduler.schedule(this, 0, TimeUnit.SECONDS);
+        try {
+            result.get();
+            if (scheduler.awaitTermination(terminologyServerClientSettings.getTimeoutSeconds(), TimeUnit.SECONDS)) {
+                if (result.isDone() && expandedValueSet != null) {
+                    return expandedValueSet;
+                } else {
+                    throw new UnprocessableEntityException(String.format(
+                            "Terminology Server expansion failed for ValueSet (%s) - Server could not process expansion requests.",
+                            valueSetUrl));
+                }
+            } else {
+                throw new UnprocessableEntityException(String.format(
+                        "Terminology Server expansion took longer than the allotted timeout: %s",
+                        terminologyServerClientSettings.getTimeoutSeconds()));
+            }
+        } catch (Exception e) {
+            scheduler.shutdown();
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new TerminologyServerExpansionException(e.getMessage());
+        }
+    }
+
+    @Override
+    public void run() {
+        try {
+            expansionAttempt++;
+            if (expansionAttempt <= terminologyServerClientSettings.getMaxRetryCount()) {
+                logger.info("Expansion attempt: {} for ValueSet: {}", expansionAttempt, valueSetUrl);
+                expandedValueSet = fhirClient
+                        .operation()
+                        .onType("ValueSet")
+                        .named("$expand")
+                        .withParameters(parameters)
+                        .returnResourceType(getValueSetClass())
+                        .execute();
+                scheduler.shutdown();
+            }
+        } catch (Exception ex) {
+            logger.info("Expansion attempt {} failed: {}", expansionAttempt, ex.getMessage());
+            if (expansionAttempt < terminologyServerClientSettings.getMaxRetryCount()) {
+                scheduler.schedule(
+                        this,
+                        terminologyServerClientSettings.getRetryIntervalMillis() * expansionAttempt,
+                        TimeUnit.MILLISECONDS);
+            } else {
+                scheduler.shutdown();
+            }
+        }
+    }
+
+    private Class<IBaseResource> getValueSetClass() {
+        return Resources.getClassForTypeAndVersion(
+                "ValueSet", fhirClient.getFhirContext().getVersion().getVersion());
+    }
+
+    public static class TerminologyServerExpansionException extends BaseServerResponseException {
+
+        private static final int STATUS_CODE = 429;
+
+        public TerminologyServerExpansionException(String message) {
+            super(STATUS_CODE, message);
+        }
+    }
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/client/TerminologyServerClient.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/client/TerminologyServerClient.java
@@ -1,12 +1,12 @@
 package org.opencds.cqf.fhir.utility.client;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
-import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseEnumFactory;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
@@ -15,6 +15,7 @@ import org.hl7.fhir.instance.model.api.IDomainResource;
 import org.opencds.cqf.fhir.utility.Canonicals;
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.Parameters;
+import org.opencds.cqf.fhir.utility.Resources;
 import org.opencds.cqf.fhir.utility.adapter.IEndpointAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IKnowledgeArtifactAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IParametersAdapter;
@@ -30,12 +31,21 @@ import org.slf4j.LoggerFactory;
 public class TerminologyServerClient {
     private static final Logger myLogger = LoggerFactory.getLogger(TerminologyServerClient.class);
 
-    private final FhirContext ctx;
+    private final FhirContext fhirContext;
+    private final TerminologyServerClientSettings terminologyServerClientSettings;
     public static final String versionParamName = "valueSetVersion";
     public static final String urlParamName = "url";
 
-    public TerminologyServerClient(FhirContext ctx) {
-        this.ctx = ctx;
+    public TerminologyServerClient(FhirContext fhirContext) {
+        this(fhirContext, null);
+    }
+
+    public TerminologyServerClient(
+            FhirContext fhirContext, TerminologyServerClientSettings terminologyServerClientSettings) {
+        this.fhirContext = requireNonNull(fhirContext);
+        this.terminologyServerClientSettings = terminologyServerClientSettings != null
+                ? terminologyServerClientSettings
+                : new TerminologyServerClientSettings();
     }
 
     public IBaseResource expand(IValueSetAdapter valueSet, IEndpointAdapter endpoint, IParametersAdapter parameters) {
@@ -73,23 +83,21 @@ public class TerminologyServerClient {
             }
             parameters.addParameter(
                     fhirVersion == FhirVersionEnum.DSTU3
-                            ? Parameters.newUriPart(ctx, urlParamName, url)
-                            : Parameters.newUrlPart(ctx, urlParamName, url));
+                            ? Parameters.newUriPart(fhirContext, urlParamName, url)
+                            : Parameters.newUrlPart(fhirContext, urlParamName, url));
         }
         if (parameters.getParameter(versionParamName) == null && valueSetVersion != null) {
-            parameters.addParameter(Parameters.newStringPart(ctx, versionParamName, valueSetVersion));
+            parameters.addParameter(Parameters.newStringPart(fhirContext, versionParamName, valueSetVersion));
         }
-        // Invoke on the type using the url parameter
-        return fhirClient
-                .operation()
-                .onType("ValueSet")
-                .named("$expand")
-                .withParameters((IBaseParameters) parameters.get())
-                .returnResourceType(getValueSetClass(fhirVersion))
-                .execute();
+        return expand(fhirClient, url, (IBaseParameters) parameters.get());
     }
 
-    private IGenericClient initializeClientWithAuth(IEndpointAdapter endpoint) {
+    public IBaseResource expand(IGenericClient fhirClient, String url, IBaseParameters parameters) {
+        var expandRunner = new ExpandRunner(fhirClient, terminologyServerClientSettings, url, parameters);
+        return expandRunner.expandValueSet();
+    }
+
+    public IGenericClient initializeClientWithAuth(IEndpointAdapter endpoint) {
         var username = endpoint.getExtensionsByUrl(Constants.VSAC_USERNAME).stream()
                 .findFirst()
                 .map(ext -> ext.getValue().toString())
@@ -98,52 +106,43 @@ public class TerminologyServerClient {
                 .findFirst()
                 .map(ext -> ext.getValue().toString())
                 .orElseThrow(() -> new UnprocessableEntityException("Cannot expand ValueSet without VSAC API Key."));
-        IGenericClient fhirClient = ctx.newRestfulGenericClient(getAddressBase(endpoint.getAddress()));
+        var fhirClient = fhirContext.newRestfulGenericClient(getAddressBase(endpoint.getAddress()));
         Clients.registerAdditionalRequestHeadersAuth(fhirClient, username, apiKey);
         return fhirClient;
     }
 
-    public java.util.Optional<IDomainResource> getResource(
-            IEndpointAdapter endpoint, String url, FhirVersionEnum versionEnum) {
+    public java.util.Optional<IDomainResource> getResource(IEndpointAdapter endpoint, String url) {
         return IKnowledgeArtifactAdapter.findLatestVersion(initializeClientWithAuth(endpoint)
                 .search()
-                .forResource(getValueSetClass(versionEnum))
+                .forResource(getValueSetClass())
                 .where(Searches.byCanonical(url))
                 .execute());
     }
 
-    public java.util.Optional<IDomainResource> getLatestNonDraftResource(
-            IEndpointAdapter endpoint, String url, FhirVersionEnum versionEnum) {
+    public java.util.Optional<IDomainResource> getLatestNonDraftResource(IEndpointAdapter endpoint, String url) {
         var urlParams = Searches.byCanonical(url);
         var statusParam = Searches.exceptStatus("draft");
         urlParams.putAll(statusParam);
         return IKnowledgeArtifactAdapter.findLatestVersion(initializeClientWithAuth(endpoint)
                 .search()
-                .forResource(getValueSetClass(versionEnum))
+                .forResource(getValueSetClass())
                 .where(urlParams)
                 .execute());
     }
 
-    private Class<? extends IBaseResource> getValueSetClass(FhirVersionEnum fhirVersion) {
-        switch (fhirVersion) {
-            case DSTU3:
-                return org.hl7.fhir.dstu3.model.ValueSet.class;
-            case R4:
-                return org.hl7.fhir.r4.model.ValueSet.class;
-            case R5:
-                return org.hl7.fhir.r5.model.ValueSet.class;
-            default:
-                throw new UnprocessableEntityException("Unknown ValueSet version");
-        }
+    private Class<? extends IBaseResource> getValueSetClass() {
+        return Resources.getClassForTypeAndVersion(
+                "ValueSet", fhirContext.getVersion().getVersion());
     }
 
     private String getAddressBase(String address) {
-        return getAddressBase(address, this.ctx);
+        return getAddressBase(address, this.fhirContext);
     }
+
     // Strips resource and id from the endpoint address URL, these are not needed as the client constructs the URL.
     // Converts http URLs to https
     public static String getAddressBase(String address, FhirContext ctx) {
-        Objects.requireNonNull(address, "address must not be null");
+        requireNonNull(address, "address must not be null");
         if (address.startsWith("http://")) {
             address = address.replaceFirst("http://", "https://");
         }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/client/TerminologyServerClientSettings.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/client/TerminologyServerClientSettings.java
@@ -1,0 +1,52 @@
+package org.opencds.cqf.fhir.utility.client;
+
+public class TerminologyServerClientSettings {
+
+    private int maxRetryCount = 3;
+    private long retryIntervalMillis = 1000;
+    private int timeoutSeconds = 30;
+
+    /*
+     * Default constructor for TerminologySettings
+     */
+    public TerminologyServerClientSettings() {
+        // intentionally empty
+    }
+
+    /**
+     * Copy constructor for ExpandSettings
+     * @param terminologyServerClientSettings
+     */
+    public TerminologyServerClientSettings(TerminologyServerClientSettings terminologyServerClientSettings) {
+        this.maxRetryCount = terminologyServerClientSettings.maxRetryCount;
+        this.retryIntervalMillis = terminologyServerClientSettings.retryIntervalMillis;
+        this.timeoutSeconds = terminologyServerClientSettings.timeoutSeconds;
+    }
+
+    public int getMaxRetryCount() {
+        return maxRetryCount;
+    }
+
+    public TerminologyServerClientSettings setMaxRetryCount(int maxRetryCount) {
+        this.maxRetryCount = maxRetryCount;
+        return this;
+    }
+
+    public long getRetryIntervalMillis() {
+        return retryIntervalMillis;
+    }
+
+    public TerminologyServerClientSettings setRetryIntervalMillis(long retryIntervalMillis) {
+        this.retryIntervalMillis = retryIntervalMillis;
+        return this;
+    }
+
+    public int getTimeoutSeconds() {
+        return timeoutSeconds;
+    }
+
+    public TerminologyServerClientSettings setTimeoutSeconds(int timeoutSeconds) {
+        this.timeoutSeconds = timeoutSeconds;
+        return this;
+    }
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/repository/operations/OperationParametersParser.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/repository/operations/OperationParametersParser.java
@@ -34,9 +34,7 @@ public class OperationParametersParser {
         requireNonNull(parameters, "parameters must not be null");
         requireNonNull(name, "name must not be null");
         IParametersAdapter parametersAdapter = this.adapterFactory.createParameters(parameters);
-        List<IParametersParameterComponentAdapter> parts = parametersAdapter.getParameter().stream()
-                .map(x -> this.adapterFactory.createParametersParameter(x))
-                .collect(Collectors.toList());
+        var parts = parametersAdapter.getParameter();
 
         IParametersParameterComponentAdapter part =
                 parts.stream().filter(x -> x.getName().equals(name)).findFirst().orElse(null);
@@ -53,9 +51,7 @@ public class OperationParametersParser {
         requireNonNull(parameters, "parameters must not be null");
         requireNonNull(name, "name must not be null");
         IParametersAdapter parametersAdapter = this.adapterFactory.createParameters(parameters);
-        List<IParametersParameterComponentAdapter> parts = parametersAdapter.getParameter().stream()
-                .map(x -> this.adapterFactory.createParametersParameter(x))
-                .collect(Collectors.toList());
+        var parts = parametersAdapter.getParameter();
 
         IParametersParameterComponentAdapter part =
                 parts.stream().filter(x -> x.getName().equals(name)).findFirst().orElse(null);
@@ -74,17 +70,11 @@ public class OperationParametersParser {
         }
         requireNonNull(name, "name must not be null");
         IParametersAdapter parametersAdapter = this.adapterFactory.createParameters(parameters);
-        List<IParametersParameterComponentAdapter> parts = parametersAdapter.getParameter().stream()
-                .map(x -> this.adapterFactory.createParametersParameter(x))
-                .collect(Collectors.toList());
-
-        IBaseResource value = parts.stream()
+        return parametersAdapter.getParameter().stream()
                 .filter(x -> x.getName().equals(name))
-                .map(x -> x.getResource())
+                .map(IParametersParameterComponentAdapter::getResource)
                 .findFirst()
                 .orElse(null);
-
-        return value;
     }
 
     public Map<String, IBaseResource> getResourceChildren(IBaseParameters parameters) {
@@ -93,14 +83,10 @@ public class OperationParametersParser {
         }
         requireNonNull(parameters, "parameters must not be null");
         IParametersAdapter parametersAdapter = this.adapterFactory.createParameters(parameters);
-        List<IParametersParameterComponentAdapter> parts = parametersAdapter.getParameter().stream()
-                .map(x -> this.adapterFactory.createParametersParameter(x))
-                .collect(Collectors.toList());
-
-        Map<String, IBaseResource> resources =
-                parts.stream().collect(Collectors.toMap(x -> x.getName(), x -> x.getResource()));
-
-        return resources;
+        return parametersAdapter.getParameter().stream()
+                .collect(Collectors.toMap(
+                        IParametersParameterComponentAdapter::getName,
+                        IParametersParameterComponentAdapter::getResource));
     }
 
     public IBaseDatatype getValueChild(IBaseParameters parameters, String name) {
@@ -110,17 +96,11 @@ public class OperationParametersParser {
         requireNonNull(parameters, "parameters must not be null");
         requireNonNull(name, "name must not be null");
         IParametersAdapter parametersAdapter = this.adapterFactory.createParameters(parameters);
-        List<IParametersParameterComponentAdapter> parts = parametersAdapter.getParameter().stream()
-                .map(x -> this.adapterFactory.createParametersParameter(x))
-                .collect(Collectors.toList());
-
-        IBaseDatatype value = parts.stream()
+        return parametersAdapter.getParameter().stream()
                 .filter(x -> x.getName().equals(name))
-                .map(x -> x.getValue())
+                .map(IParametersParameterComponentAdapter::getValue)
                 .findFirst()
                 .orElse(null);
-
-        return value;
     }
 
     public Map<String, IBaseDatatype> getValueChildren(IBaseParameters parameters) {
@@ -129,23 +109,16 @@ public class OperationParametersParser {
         }
         requireNonNull(parameters, "parameters must not be null");
         IParametersAdapter parametersAdapter = this.adapterFactory.createParameters(parameters);
-        List<IParametersParameterComponentAdapter> parts = parametersAdapter.getParameter().stream()
-                .map(x -> this.adapterFactory.createParametersParameter(x))
-                .collect(Collectors.toList());
-
-        Map<String, IBaseDatatype> values =
-                parts.stream().collect(Collectors.toMap(x -> x.getName(), x -> x.getValue()));
-
-        return values;
+        return parametersAdapter.getParameter().stream()
+                .collect(Collectors.toMap(
+                        IParametersParameterComponentAdapter::getName, IParametersParameterComponentAdapter::getValue));
     }
 
     @SuppressWarnings("unchecked")
     public Map<String, Object> getParameterParts(IBaseParameters parameters) {
         requireNonNull(parameters, "parameters must not be null");
         var parametersAdapter = adapterFactory.createParameters(parameters);
-        var parts = parametersAdapter.getParameter().stream()
-                .map(x -> adapterFactory.createParametersParameter(x))
-                .collect(Collectors.toList());
+        var parts = parametersAdapter.getParameter();
 
         Map<String, Object> parameterParts = new HashMap<>();
         for (var part : parts) {

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/client/ExpandRunnerTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/client/ExpandRunnerTest.java
@@ -1,0 +1,26 @@
+package org.opencds.cqf.fhir.utility.client;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import org.hl7.fhir.r4.model.Parameters;
+import org.junit.jupiter.api.Test;
+import org.mockito.internal.stubbing.defaultanswers.ReturnsDeepStubs;
+import org.opencds.cqf.fhir.utility.client.ExpandRunner.TerminologyServerExpansionException;
+
+class ExpandRunnerTest {
+
+    @Test
+    void testTimeout() {
+        var url = "test";
+        var params = new Parameters();
+        var settings = new TerminologyServerClientSettings().setTimeoutSeconds(2);
+        var fhirClient = mock(IGenericClient.class, new ReturnsDeepStubs());
+        var fixture = new ExpandRunner(fhirClient, settings, url, params);
+        assertThrows(
+                TerminologyServerExpansionException.class,
+                fixture::expandValueSet,
+                "Terminology Server expansion took longer than the allotted timeout: 2");
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/client/TerminologyServerClientSettingsTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/client/TerminologyServerClientSettingsTest.java
@@ -1,0 +1,26 @@
+package org.opencds.cqf.fhir.utility.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class TerminologyServerClientSettingsTest {
+
+    @Test
+    void testSettings() {
+        var retryCount = 5;
+        var interval = 500;
+        var timeout = 10;
+        var settings = new TerminologyServerClientSettings()
+                .setMaxRetryCount(retryCount)
+                .setRetryIntervalMillis(interval)
+                .setTimeoutSeconds(timeout);
+        assertEquals(retryCount, settings.getMaxRetryCount());
+        assertEquals(interval, settings.getRetryIntervalMillis());
+        assertEquals(timeout, settings.getTimeoutSeconds());
+        var copy = new TerminologyServerClientSettings(settings);
+        assertEquals(settings.getMaxRetryCount(), copy.getMaxRetryCount());
+        assertEquals(settings.getRetryIntervalMillis(), copy.getRetryIntervalMillis());
+        assertEquals(settings.getTimeoutSeconds(), copy.getTimeoutSeconds());
+    }
+}


### PR DESCRIPTION
Because the output in the $apply OperationDefinition is 0..*, the result should always be a Parameters resource containing a "return" parameter for each subject passed into the operation, with the Bundle result in the `resource` property on the parameter.