### PR TITLE
Add qualifier for correct object mapper in CrCdsHooksConfig

### DIFF
--- a/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/config/CrCdsHooksConfig.java
+++ b/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/config/CrCdsHooksConfig.java
@@ -25,9 +25,12 @@ import org.opencds.cqf.fhir.cr.hapi.cdshooks.discovery.ICrDiscoveryServiceFactor
 import org.opencds.cqf.fhir.cr.hapi.common.IRepositoryFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
+import static ca.uhn.hapi.fhir.cdshooks.config.CdsHooksConfig.CDS_HOOKS_OBJECT_MAPPER_FACTORY;
 
 @Configuration
 @Import(CrCdsConfig.class)
@@ -118,7 +121,7 @@ public class CrCdsHooksConfig {
             CdsServiceRegistryImpl cdsServiceRegistry,
             ICrDiscoveryServiceFactory discoveryServiceFactory,
             ICdsCrServiceFactory crServiceFactory,
-            ObjectMapper om,
+            @Qualifier(CDS_HOOKS_OBJECT_MAPPER_FACTORY) ObjectMapper om,
             Optional<IResourceChangeListenerRegistry> resourceChangeListenerRegistry) {
         if (resourceChangeListenerRegistry.isEmpty()) {
             return null;

--- a/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/config/CrCdsHooksConfig.java
+++ b/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/config/CrCdsHooksConfig.java
@@ -1,5 +1,7 @@
 package org.opencds.cqf.fhir.cr.hapi.config;
 
+import static ca.uhn.hapi.fhir.cdshooks.config.CdsHooksConfig.CDS_HOOKS_OBJECT_MAPPER_FACTORY;
+
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.jpa.cache.IResourceChangeListenerRegistry;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
@@ -29,8 +31,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-
-import static ca.uhn.hapi.fhir.cdshooks.config.CdsHooksConfig.CDS_HOOKS_OBJECT_MAPPER_FACTORY;
 
 @Configuration
 @Import(CrCdsConfig.class)


### PR DESCRIPTION
Qualify the name of the CDS Hooks ObjectMapper bean for use in CrCdsHooksConfig in case the downstream project uses multiple ObjectMapper beans.