### PR TITLE
Fix default profile search param

### DIFF
--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/LibraryEngine.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/LibraryEngine.java
@@ -69,17 +69,25 @@ public class LibraryEngine {
             String url,
             String patientId,
             IBaseParameters parameters,
+            Map<String, Object> rawParameters,
             IBaseBundle additionalData,
             ZonedDateTime zonedDateTime,
             Set<String> expressions) {
         return this.evaluate(
-                VersionedIdentifiers.forUrl(url), patientId, parameters, additionalData, zonedDateTime, expressions);
+                VersionedIdentifiers.forUrl(url),
+                patientId,
+                parameters,
+                rawParameters,
+                additionalData,
+                zonedDateTime,
+                expressions);
     }
 
     public IBaseParameters evaluate(
             VersionedIdentifier id,
             String patientId,
             IBaseParameters parameters,
+            Map<String, Object> rawParameters,
             IBaseBundle additionalData,
             ZonedDateTime zonedDateTime,
             Set<String> expressions) {
@@ -88,6 +96,7 @@ public class LibraryEngine {
                 id,
                 patientId,
                 parameters,
+                rawParameters,
                 additionalData,
                 expressions,
                 cqlFhirParametersConverter,
@@ -202,7 +211,13 @@ public class LibraryEngine {
             case "text/cql-name":
                 validateLibrary(libraryToBeEvaluated);
                 parametersResult = this.evaluate(
-                        libraryToBeEvaluated, subjectId, parameters, bundle, null, Collections.singleton(expression));
+                        libraryToBeEvaluated,
+                        subjectId,
+                        parameters,
+                        rawParameters,
+                        bundle,
+                        null,
+                        Collections.singleton(expression));
                 results = resolveParameterValues(
                         ParametersUtil.getNamedParameters(fhirContext, parametersResult, expression));
                 break;
@@ -314,6 +329,7 @@ public class LibraryEngine {
             VersionedIdentifier id,
             String patientId,
             IBaseParameters parameters,
+            Map<String, Object> rawParameters,
             IBaseBundle additionalData,
             Set<String> expressions,
             CqlFhirParametersConverter cqlFhirParametersConverter,
@@ -329,6 +345,9 @@ public class LibraryEngine {
         }
 
         var evaluationParameters = cqlFhirParametersConverter.toCqlParameters(parameters);
+        if (rawParameters != null && !rawParameters.isEmpty()) {
+            evaluationParameters.putAll(rawParameters);
+        }
 
         return engine.evaluate(
                 new VersionedIdentifier().withId(id.getId()),

--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProvider.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProvider.java
@@ -301,11 +301,9 @@ public abstract class BaseRetrieveProvider implements RetrieveProvider {
 
     public void populateTemplateSearchParams(
             Map<String, List<IQueryParameterType>> searchParams, final String templateId) {
-
-        // TODO: If profile mode is optional, trust, or enforced AND the repository
-        // supports the _profile
-        // parameter, we should add it.
-        if (this.getRetrieveSettings().getProfileMode() != PROFILE_MODE.OFF && StringUtils.isNotBlank(templateId)) {
+        if (getRetrieveSettings().getProfileMode() != PROFILE_MODE.OFF
+                && StringUtils.isNotBlank(templateId)
+                && !templateId.startsWith("http://hl7.org/fhir/StructureDefinition/")) {
             var profileParam = getFhirVersion().isOlderThan(FhirVersionEnum.R5)
                     ? new UriParam(templateId)
                     : new ReferenceParam(templateId);

--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProvider.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProvider.java
@@ -300,10 +300,10 @@ public abstract class BaseRetrieveProvider implements RetrieveProvider {
     }
 
     public void populateTemplateSearchParams(
-            Map<String, List<IQueryParameterType>> searchParams, final String templateId) {
+            Map<String, List<IQueryParameterType>> searchParams, final String dataType, final String templateId) {
         if (getRetrieveSettings().getProfileMode() != PROFILE_MODE.OFF
                 && StringUtils.isNotBlank(templateId)
-                && !templateId.startsWith("http://hl7.org/fhir/StructureDefinition/")) {
+                && !templateId.startsWith(String.format("http://hl7.org/fhir/StructureDefinition/%s", dataType))) {
             var profileParam = getFhirVersion().isOlderThan(FhirVersionEnum.R5)
                     ? new UriParam(templateId)
                     : new ReferenceParam(templateId);

--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProvider.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProvider.java
@@ -303,7 +303,7 @@ public abstract class BaseRetrieveProvider implements RetrieveProvider {
             Map<String, List<IQueryParameterType>> searchParams, final String dataType, final String templateId) {
         if (getRetrieveSettings().getProfileMode() != PROFILE_MODE.OFF
                 && StringUtils.isNotBlank(templateId)
-                && !templateId.startsWith("http://hl7.org/fhir/StructureDefinition/%s".formatted(dataType))) {
+                && !templateId.startsWith(String.format("http://hl7.org/fhir/StructureDefinition/%s", dataType))) {
             var profileParam = getFhirVersion().isOlderThan(FhirVersionEnum.R5)
                     ? new UriParam(templateId)
                     : new ReferenceParam(templateId);

--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProvider.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProvider.java
@@ -303,7 +303,7 @@ public abstract class BaseRetrieveProvider implements RetrieveProvider {
             Map<String, List<IQueryParameterType>> searchParams, final String dataType, final String templateId) {
         if (getRetrieveSettings().getProfileMode() != PROFILE_MODE.OFF
                 && StringUtils.isNotBlank(templateId)
-                && !templateId.startsWith(String.format("http://hl7.org/fhir/StructureDefinition/%s", dataType))) {
+                && !templateId.startsWith("http://hl7.org/fhir/StructureDefinition/%s".formatted(dataType))) {
             var profileParam = getFhirVersion().isOlderThan(FhirVersionEnum.R5)
                     ? new UriParam(templateId)
                     : new ReferenceParam(templateId);

--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/retrieve/RepositoryRetrieveProvider.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/retrieve/RepositoryRetrieveProvider.java
@@ -68,7 +68,7 @@ public class RepositoryRetrieveProvider extends BaseRetrieveProvider {
                 config.filter = config.filter.and(filterByTemplateId(dataType, templateId));
                 break;
             case USE_SEARCH_PARAMETERS:
-                populateTemplateSearchParams(config.searchParams, templateId);
+                populateTemplateSearchParams(config.searchParams, dataType, templateId);
         }
     }
 

--- a/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProviderTests.java
+++ b/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProviderTests.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.fhir.cql.engine.retrieve;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
@@ -15,6 +16,10 @@ import org.mockito.Mockito;
 import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.PROFILE_MODE;
 
 class BaseRetrieveProviderTests {
+    final String PROFILE_PARAM = "_profile";
+    final String CONDITION = "Condition";
+    final String FHIR_CONDITION = "http://hl7.org/fhir/StructureDefinition/Condition";
+    final String US_CORE_CONDITION = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition";
 
     @Test
     void testProfileParameterTypeIsCorrectForVersion() {
@@ -24,12 +29,36 @@ class BaseRetrieveProviderTests {
         doReturn(FhirVersionEnum.R4).when(fixture).getFhirVersion();
 
         Map<String, List<IQueryParameterType>> searchParamsR4 = new HashMap<>();
-        fixture.populateTemplateSearchParams(searchParamsR4, null, "test");
-        assertInstanceOf(UriParam.class, searchParamsR4.get("_profile").get(0));
+        fixture.populateTemplateSearchParams(searchParamsR4, CONDITION, US_CORE_CONDITION);
+        assertInstanceOf(UriParam.class, searchParamsR4.get(PROFILE_PARAM).get(0));
 
         doReturn(FhirVersionEnum.R5).when(fixture).getFhirVersion();
         Map<String, List<IQueryParameterType>> searchParamsR5 = new HashMap<>();
-        fixture.populateTemplateSearchParams(searchParamsR5, null, "test");
-        assertInstanceOf(ReferenceParam.class, searchParamsR5.get("_profile").get(0));
+        fixture.populateTemplateSearchParams(searchParamsR5, CONDITION, US_CORE_CONDITION);
+        assertInstanceOf(ReferenceParam.class, searchParamsR5.get(PROFILE_PARAM).get(0));
+    }
+
+    @Test
+    void testProfileParameterIsNotAddedForDefaultProfile() {
+        var retrieveSettings = new RetrieveSettings().setProfileMode(PROFILE_MODE.DECLARED);
+        var fixture = Mockito.mock(BaseRetrieveProvider.class, Mockito.CALLS_REAL_METHODS);
+        doReturn(retrieveSettings).when(fixture).getRetrieveSettings();
+        doReturn(FhirVersionEnum.R4).when(fixture).getFhirVersion();
+
+        Map<String, List<IQueryParameterType>> searchParamsR4 = new HashMap<>();
+        fixture.populateTemplateSearchParams(searchParamsR4, CONDITION, FHIR_CONDITION);
+        assertTrue(searchParamsR4.isEmpty());
+    }
+
+    @Test
+    void testProfileParameterIsNotAddedWhenProfileModeOff() {
+        var retrieveSettings = new RetrieveSettings().setProfileMode(PROFILE_MODE.OFF);
+        var fixture = Mockito.mock(BaseRetrieveProvider.class, Mockito.CALLS_REAL_METHODS);
+        doReturn(retrieveSettings).when(fixture).getRetrieveSettings();
+        doReturn(FhirVersionEnum.R4).when(fixture).getFhirVersion();
+
+        Map<String, List<IQueryParameterType>> searchParamsR4 = new HashMap<>();
+        fixture.populateTemplateSearchParams(searchParamsR4, CONDITION, US_CORE_CONDITION);
+        assertTrue(searchParamsR4.isEmpty());
     }
 }

--- a/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProviderTests.java
+++ b/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/engine/retrieve/BaseRetrieveProviderTests.java
@@ -24,12 +24,12 @@ class BaseRetrieveProviderTests {
         doReturn(FhirVersionEnum.R4).when(fixture).getFhirVersion();
 
         Map<String, List<IQueryParameterType>> searchParamsR4 = new HashMap<>();
-        fixture.populateTemplateSearchParams(searchParamsR4, "test");
+        fixture.populateTemplateSearchParams(searchParamsR4, null, "test");
         assertInstanceOf(UriParam.class, searchParamsR4.get("_profile").get(0));
 
         doReturn(FhirVersionEnum.R5).when(fixture).getFhirVersion();
         Map<String, List<IQueryParameterType>> searchParamsR5 = new HashMap<>();
-        fixture.populateTemplateSearchParams(searchParamsR5, "test");
+        fixture.populateTemplateSearchParams(searchParamsR5, null, "test");
         assertInstanceOf(ReferenceParam.class, searchParamsR5.get("_profile").get(0));
     }
 }

--- a/cqf-fhir-cr-hapi/src/test/java/org/opencds/cqf/fhir/cr/hapi/r4/PlanDefinitionOperationsProviderIT.java
+++ b/cqf-fhir-cr-hapi/src/test/java/org/opencds/cqf/fhir/cr/hapi/r4/PlanDefinitionOperationsProviderIT.java
@@ -41,7 +41,7 @@ class PlanDefinitionOperationsProviderIT extends BaseCrR4TestServer {
         var requestDetails = setupRequestDetails();
         var url = "http://example.org/sdh/dtr/aslp/PlanDefinition/ASLPA1";
         var version = "1.0.0";
-        var patientID = "positive";
+        var patientID = "Patient/positive";
         var parameters = new Parameters()
                 .addParameter("Service Request Id", "SleepStudy")
                 .addParameter("Service Request Id", "SleepStudy2");
@@ -105,6 +105,7 @@ class PlanDefinitionOperationsProviderIT extends BaseCrR4TestServer {
         var questionnaireResponse =
                 (QuestionnaireResponse) questionnaireResponses.get(0).getResource();
         assertNotNull(questionnaireResponse);
+        assertEquals(patientID, questionnaireResponse.getSubject().getReference());
         var questionnaires = bundle.getEntry().stream()
                 .filter(e -> e.hasResource() && e.getResource().fhirType().equals("Questionnaire"))
                 .toList();

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/cpg/r4/R4CqlExecutionService.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/cpg/r4/R4CqlExecutionService.java
@@ -87,6 +87,7 @@ public class R4CqlExecutionService {
                     libraryIdentifier,
                     subject,
                     parameters,
+                    null,
                     data,
                     null,
                     expression == null ? null : Collections.singleton(expression));

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/cpg/r4/R4LibraryEvaluationService.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/cpg/r4/R4LibraryEvaluationService.java
@@ -62,7 +62,7 @@ public class R4LibraryEvaluationService {
         }
         try {
             return (Parameters)
-                    libraryEngine.evaluate(libraryIdentifier, subject, parameters, data, null, expressionSet);
+                    libraryEngine.evaluate(libraryIdentifier, subject, parameters, null, data, null, expressionSet);
         } catch (Exception e) {
             return parameters(part("evaluation error", (OperationOutcome)
                     baseCqlExecutionProcessor.createIssue("error", e.getMessage(), repository)));

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/library/evaluate/EvaluateProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/library/evaluate/EvaluateProcessor.java
@@ -23,6 +23,7 @@ public class EvaluateProcessor implements IEvaluateProcessor {
                             request.getLibraryAdapter().getUrl(),
                             request.getSubject(),
                             request.getParameters(),
+                            request.getRawParameters(),
                             request.getData(),
                             null,
                             request.getExpression());

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureEvaluator.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureEvaluator.java
@@ -307,7 +307,7 @@ public class MeasureEvaluator {
             context.getState().setContextValue(subjectTypePart, subjectIdPart);
             try {
                 EvaluationResult result = libraryEngine.getEvaluationResult(
-                        id, subjectId, null, null, null, null, zonedDateTime, context);
+                        id, subjectId, null, null, null, null, null, zonedDateTime, context);
                 evaluateSubject(measureDef, subjectTypePart, subjectIdPart, subjectSize, type, result);
             } catch (Exception e) {
                 // Catch Exceptions from evaluation per subject, but allow rest of subjects to be processed (if


### PR DESCRIPTION
Change to the BaseRetrieveProvider to not add a profile search parameter when using search parameters for retrieves and a template id is provided that is for a default FHIR profile.

Added rawParameters argument for raw CQL parameters to Library evaluate calls (previously was only passed when evaluating a CQL expression).