### PR TITLE
Add direct reference codes to manifest during $release

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/constant/MeasureConstants.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/constant/MeasureConstants.java
@@ -43,4 +43,9 @@ public class MeasureConstants {
     public static final String FHIR_ALL_TYPES_SYSTEM_URL = "http://hl7.org/fhir/fhir-types";
     public static final String POPULATION_BASIS_URL =
             "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis";
+
+    public static final String CQFM_DIRECT_REFERENCE_EXTENSION =
+            "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode";
+    public static final String CQF_DIRECT_REFERENCE_EXTENSION =
+            "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode";
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/constant/MeasureConstants.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/constant/MeasureConstants.java
@@ -43,9 +43,4 @@ public class MeasureConstants {
     public static final String FHIR_ALL_TYPES_SYSTEM_URL = "http://hl7.org/fhir/fhir-types";
     public static final String POPULATION_BASIS_URL =
             "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis";
-
-    public static final String CQFM_DIRECT_REFERENCE_EXTENSION =
-            "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode";
-    public static final String CQF_DIRECT_REFERENCE_EXTENSION =
-            "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode";
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/constant/MeasureConstants.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/constant/MeasureConstants.java
@@ -47,5 +47,5 @@ public class MeasureConstants {
     public static final String CQFM_DIRECT_REFERENCE_EXTENSION =
             "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode";
     public static final String CQF_DIRECT_REFERENCE_EXTENSION =
-            "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode";
+            "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode";
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/ReleaseVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/ReleaseVisitor.java
@@ -376,6 +376,19 @@ public class ReleaseVisitor extends BaseKnowledgeArtifactVisitor {
                     rootAdapter.setRelatedArtifact(updatedRelatedArtifacts);
                 }
             }
+
+            extractMeasureDirectReferenceCodes(rootAdapter, artifactAdapter);
+        }
+    }
+
+    private void extractMeasureDirectReferenceCodes(
+            IKnowledgeArtifactAdapter rootAdapter, IKnowledgeArtifactAdapter artifactAdapter) {
+        if (artifactAdapter instanceof org.opencds.cqf.fhir.utility.adapter.r4.MeasureAdapter) {
+            org.opencds.cqf.fhir.cr.visitor.r4.ReleaseVisitor.extractDirectReferenceCodes(
+                    rootAdapter, ((org.opencds.cqf.fhir.utility.adapter.r4.MeasureAdapter) artifactAdapter).get());
+        } else if (artifactAdapter instanceof org.opencds.cqf.fhir.utility.adapter.r5.MeasureAdapter) {
+            org.opencds.cqf.fhir.cr.visitor.r5.ReleaseVisitor.extractDirectReferenceCodes(
+                    rootAdapter, ((org.opencds.cqf.fhir.utility.adapter.r5.MeasureAdapter) artifactAdapter).get());
         }
     }
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/ReleaseVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/ReleaseVisitor.java
@@ -383,12 +383,12 @@ public class ReleaseVisitor extends BaseKnowledgeArtifactVisitor {
 
     private void extractMeasureDirectReferenceCodes(
             IKnowledgeArtifactAdapter rootAdapter, IKnowledgeArtifactAdapter artifactAdapter) {
-        if (artifactAdapter instanceof org.opencds.cqf.fhir.utility.adapter.r4.MeasureAdapter) {
+        if (artifactAdapter instanceof org.opencds.cqf.fhir.utility.adapter.r4.MeasureAdapter measureAdapter) {
             org.opencds.cqf.fhir.cr.visitor.r4.ReleaseVisitor.extractDirectReferenceCodes(
-                    rootAdapter, ((org.opencds.cqf.fhir.utility.adapter.r4.MeasureAdapter) artifactAdapter).get());
-        } else if (artifactAdapter instanceof org.opencds.cqf.fhir.utility.adapter.r5.MeasureAdapter) {
+                    rootAdapter, measureAdapter.get());
+        } else if (artifactAdapter instanceof org.opencds.cqf.fhir.utility.adapter.r5.MeasureAdapter measureAdapter) {
             org.opencds.cqf.fhir.cr.visitor.r5.ReleaseVisitor.extractDirectReferenceCodes(
-                    rootAdapter, ((org.opencds.cqf.fhir.utility.adapter.r5.MeasureAdapter) artifactAdapter).get());
+                    rootAdapter, measureAdapter.get());
         }
     }
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/r4/ReleaseVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/r4/ReleaseVisitor.java
@@ -25,7 +25,6 @@ import org.hl7.fhir.r4.model.ResourceType;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.opencds.cqf.fhir.api.Repository;
-import org.opencds.cqf.fhir.cr.measure.constant.MeasureConstants;
 import org.opencds.cqf.fhir.cr.visitor.r4.CRMIReleaseExperimentalBehavior.CRMIReleaseExperimentalBehaviorCodes;
 import org.opencds.cqf.fhir.cr.visitor.r4.CRMIReleaseVersionBehavior.CRMIReleaseVersionBehaviorCodes;
 import org.opencds.cqf.fhir.utility.Constants;
@@ -171,8 +170,8 @@ public class ReleaseVisitor {
             Library effectiveDataRequirementsLib = (Library) measure.getContained("#" + ref.getReference());
             if (effectiveDataRequirementsLib != null) {
                 effectiveDataRequirementsLib.getExtension().stream()
-                        .filter(ext -> ext.getUrl().equals(MeasureConstants.CQFM_DIRECT_REFERENCE_EXTENSION))
-                        .map(ext -> ext.setUrl(MeasureConstants.CQF_DIRECT_REFERENCE_EXTENSION))
+                        .filter(ext -> ext.getUrl().equals(Constants.CQFM_DIRECT_REFERENCE_EXTENSION))
+                        .map(ext -> ext.setUrl(Constants.CQF_DIRECT_REFERENCE_EXTENSION))
                         .forEach(rootAdapter::addExtension);
             }
         }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/r4/ReleaseVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/r4/ReleaseVisitor.java
@@ -16,14 +16,19 @@ import org.hl7.fhir.r4.model.Basic;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.Measure;
 import org.hl7.fhir.r4.model.MetadataResource;
 import org.hl7.fhir.r4.model.Period;
+import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.opencds.cqf.fhir.api.Repository;
+import org.opencds.cqf.fhir.cr.measure.constant.MeasureConstants;
 import org.opencds.cqf.fhir.cr.visitor.r4.CRMIReleaseExperimentalBehavior.CRMIReleaseExperimentalBehaviorCodes;
 import org.opencds.cqf.fhir.cr.visitor.r4.CRMIReleaseVersionBehavior.CRMIReleaseVersionBehaviorCodes;
+import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.PackageHelper;
 import org.opencds.cqf.fhir.utility.SearchHelper;
 import org.opencds.cqf.fhir.utility.adapter.IKnowledgeArtifactAdapter;
@@ -155,5 +160,21 @@ public class ReleaseVisitor {
                     returnEntries.add((BundleEntryComponent) PackageHelper.createEntry(artifactComment, true));
                 });
         return returnEntries;
+    }
+
+    public static void extractDirectReferenceCodes(IKnowledgeArtifactAdapter rootAdapter, Measure measure) {
+        Optional<Extension> effectiveDataRequirementsExt = measure.getExtension().stream()
+                .filter(ext -> ext.getUrl().equals(Constants.CQFM_EFFECTIVE_DATA_REQUIREMENTS))
+                .findFirst();
+        if (effectiveDataRequirementsExt.isPresent()) {
+            Reference ref = (Reference) effectiveDataRequirementsExt.get().getValue();
+            Library effectiveDataRequirementsLib = (Library) measure.getContained("#" + ref.getReference());
+            if (effectiveDataRequirementsLib != null) {
+                effectiveDataRequirementsLib.getExtension().stream()
+                        .filter(ext -> ext.getUrl().equals(MeasureConstants.CQFM_DIRECT_REFERENCE_EXTENSION))
+                        .map(ext -> ext.setUrl(MeasureConstants.CQF_DIRECT_REFERENCE_EXTENSION))
+                        .forEach(rootAdapter::addExtension);
+            }
+        }
     }
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/r5/ReleaseVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/r5/ReleaseVisitor.java
@@ -26,7 +26,6 @@ import org.hl7.fhir.r5.model.ResourceType;
 import org.hl7.fhir.r5.model.StringType;
 import org.hl7.fhir.r5.model.ValueSet;
 import org.opencds.cqf.fhir.api.Repository;
-import org.opencds.cqf.fhir.cr.measure.constant.MeasureConstants;
 import org.opencds.cqf.fhir.cr.visitor.r5.CRMIReleaseExperimentalBehavior.CRMIReleaseExperimentalBehaviorCodes;
 import org.opencds.cqf.fhir.cr.visitor.r5.CRMIReleaseVersionBehavior.CRMIReleaseVersionBehaviorCodes;
 import org.opencds.cqf.fhir.utility.Constants;
@@ -158,7 +157,7 @@ public class ReleaseVisitor {
             Library effectiveDataRequirementsLib = (Library) measure.getContained("#" + ref.getReference());
             if (effectiveDataRequirementsLib != null) {
                 effectiveDataRequirementsLib.getExtension().stream()
-                        .filter(ext -> ext.getUrl().equals(MeasureConstants.CQF_DIRECT_REFERENCE_EXTENSION))
+                        .filter(ext -> ext.getUrl().equals(Constants.CQF_DIRECT_REFERENCE_EXTENSION))
                         .forEach(rootAdapter::addExtension);
             }
         }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/ReleaseVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/ReleaseVisitorTests.java
@@ -48,7 +48,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsDeepStubs;
 import org.opencds.cqf.fhir.api.Repository;
-import org.opencds.cqf.fhir.cr.measure.constant.MeasureConstants;
 import org.opencds.cqf.fhir.cr.visitor.ReleaseVisitor;
 import org.opencds.cqf.fhir.cr.visitor.VisitorHelper;
 import org.opencds.cqf.fhir.utility.Canonicals;
@@ -281,7 +280,7 @@ class ReleaseVisitorTests {
         Library releasedLibrary =
                 repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         var directReferenceExtensions = releasedLibrary.getExtension().stream()
-                .filter(ext -> ext.getUrl().equals(MeasureConstants.CQF_DIRECT_REFERENCE_EXTENSION))
+                .filter(ext -> ext.getUrl().equals(Constants.CQF_DIRECT_REFERENCE_EXTENSION))
                 .toList();
 
         assertEquals(18, directReferenceExtensions.size());

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/ReleaseVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/ReleaseVisitorTests.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsDeepStubs;
 import org.opencds.cqf.fhir.api.Repository;
+import org.opencds.cqf.fhir.cr.measure.constant.MeasureConstants;
 import org.opencds.cqf.fhir.cr.visitor.ReleaseVisitor;
 import org.opencds.cqf.fhir.cr.visitor.VisitorHelper;
 import org.opencds.cqf.fhir.utility.Canonicals;
@@ -250,6 +251,40 @@ class ReleaseVisitorTests {
         // this should be 73, but we're not handling contained reference correctly
         assertEquals(72, dependenciesOnReleasedArtifact.size());
         assertEquals(2, componentsOnReleasedArtifact.size());
+    }
+
+    @Test
+    void measureDirectReferenceCodesIncludedInReleaseTest() {
+        Bundle bundle = (Bundle) jsonParser.parseResource(
+                ReleaseVisitorTests.class.getResourceAsStream("Bundle-ecqm-qicore-2024-simplified.json"));
+        repo.transaction(bundle);
+        Library library = repo.read(Library.class, new IdType("Library/ecqm-update-2024-05-02"))
+                .copy();
+        ILibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
+        Parameters params = new Parameters();
+        params.addParameter("version", "1.0.0");
+        params.addParameter("versionBehavior", new CodeType("default"));
+        var crmiEDRId = "exp-params-crmi-test";
+        var crmiEDRExtension = new Extension();
+        crmiEDRExtension.setUrl(Constants.CRMI_EFFECTIVE_DATA_REQUIREMENTS);
+        crmiEDRExtension.setValue(new CanonicalType("#" + crmiEDRId));
+        ReleaseVisitor releaseVisitor = new ReleaseVisitor(repo);
+        // Approval date is required to release an artifact
+        library.setApprovalDateElement(new DateType("2024-04-23"));
+
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, params);
+        assertNotNull(returnResource);
+        Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
+                .filter(entry -> entry.getResponse().getLocation().contains("Library"))
+                .findFirst();
+        assertTrue(maybeLib.isPresent());
+        Library releasedLibrary =
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+        var directReferenceExtensions = releasedLibrary.getExtension().stream()
+                .filter(ext -> ext.getUrl().equals(MeasureConstants.CQF_DIRECT_REFERENCE_EXTENSION))
+                .toList();
+
+        assertEquals(18, directReferenceExtensions.size());
     }
 
     @Test

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r5/ReleaseVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r5/ReleaseVisitorTests.java
@@ -48,7 +48,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsDeepStubs;
 import org.opencds.cqf.fhir.api.Repository;
-import org.opencds.cqf.fhir.cr.measure.constant.MeasureConstants;
 import org.opencds.cqf.fhir.cr.visitor.ReleaseVisitor;
 import org.opencds.cqf.fhir.cr.visitor.VisitorHelper;
 import org.opencds.cqf.fhir.utility.Canonicals;
@@ -282,7 +281,7 @@ class ReleaseVisitorTests {
         Library releasedLibrary =
                 repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
         var directReferenceExtensions = releasedLibrary.getExtension().stream()
-                .filter(ext -> ext.getUrl().equals(MeasureConstants.CQF_DIRECT_REFERENCE_EXTENSION))
+                .filter(ext -> ext.getUrl().equals(Constants.CQF_DIRECT_REFERENCE_EXTENSION))
                 .toList();
 
         assertEquals(18, directReferenceExtensions.size());

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/visitor/r5/Bundle-ecqm-qicore-2024-simplified.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/visitor/r5/Bundle-ecqm-qicore-2024-simplified.json
@@ -209,7 +209,7 @@
             "id": "effective-data-requirements",
             "extension": [
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://terminology.hl7.org/CodeSystem/observation-category",
                   "code": "laboratory",
@@ -217,7 +217,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://snomed.info/sct",
                   "code": "428361000124107",
@@ -225,7 +225,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://snomed.info/sct",
                   "code": "428371000124100",
@@ -233,7 +233,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://terminology.hl7.org/CodeSystem/observation-category",
                   "code": "survey",
@@ -241,7 +241,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://snomed.info/sct",
                   "code": "373066001",
@@ -249,7 +249,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://loinc.org",
                   "code": "45755-6",
@@ -257,7 +257,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://loinc.org",
                   "code": "71007-9",
@@ -2145,7 +2145,7 @@
             "id": "effective-data-requirements",
             "extension": [
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://snomed.info/sct",
                   "code": "428361000124107",
@@ -2153,7 +2153,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://snomed.info/sct",
                   "code": "428371000124100",
@@ -2161,7 +2161,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://terminology.hl7.org/CodeSystem/observation-category",
                   "code": "survey",
@@ -2169,7 +2169,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://snomed.info/sct",
                   "code": "373066001",
@@ -2177,7 +2177,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://loinc.org",
                   "code": "45755-6",
@@ -2185,7 +2185,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://snomed.info/sct",
                   "code": "24028007",
@@ -2193,7 +2193,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://snomed.info/sct",
                   "code": "7771000",
@@ -2201,7 +2201,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://loinc.org",
                   "code": "98181-1",
@@ -2209,7 +2209,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://loinc.org",
                   "code": "71802-3",
@@ -2217,7 +2217,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://snomed.info/sct",
                   "code": "160734000",
@@ -2225,7 +2225,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://loinc.org",
                   "code": "71007-9",

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/visitor/r5/Bundle-ecqm-qicore-2024-simplified.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/visitor/r5/Bundle-ecqm-qicore-2024-simplified.json
@@ -209,7 +209,7 @@
             "id": "effective-data-requirements",
             "extension": [
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://terminology.hl7.org/CodeSystem/observation-category",
                   "code": "laboratory",
@@ -217,7 +217,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://snomed.info/sct",
                   "code": "428361000124107",
@@ -225,7 +225,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://snomed.info/sct",
                   "code": "428371000124100",
@@ -233,7 +233,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://terminology.hl7.org/CodeSystem/observation-category",
                   "code": "survey",
@@ -241,7 +241,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://snomed.info/sct",
                   "code": "373066001",
@@ -249,7 +249,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://loinc.org",
                   "code": "45755-6",
@@ -257,7 +257,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://loinc.org",
                   "code": "71007-9",
@@ -2145,7 +2145,7 @@
             "id": "effective-data-requirements",
             "extension": [
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://snomed.info/sct",
                   "code": "428361000124107",
@@ -2153,7 +2153,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://snomed.info/sct",
                   "code": "428371000124100",
@@ -2161,7 +2161,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://terminology.hl7.org/CodeSystem/observation-category",
                   "code": "survey",
@@ -2169,7 +2169,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://snomed.info/sct",
                   "code": "373066001",
@@ -2177,7 +2177,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://loinc.org",
                   "code": "45755-6",
@@ -2185,7 +2185,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://snomed.info/sct",
                   "code": "24028007",
@@ -2193,7 +2193,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://snomed.info/sct",
                   "code": "7771000",
@@ -2201,7 +2201,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://loinc.org",
                   "code": "98181-1",
@@ -2209,7 +2209,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://loinc.org",
                   "code": "71802-3",
@@ -2217,7 +2217,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://snomed.info/sct",
                   "code": "160734000",
@@ -2225,7 +2225,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://loinc.org",
                   "code": "71007-9",

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/Constants.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/Constants.java
@@ -80,6 +80,8 @@ public class Constants {
     public static final String CQF_LIBRARY = "http://hl7.org/fhir/StructureDefinition/cqf-library";
     public static final String CQF_CALCULATED_VALUE = "http://hl7.org/fhir/StructureDefinition/cqf-calculatedValue";
     public static final String CQF_FHIR_QUERY_PATTERN = "http://hl7.org/fhir/StructureDefinition/cqf-fhirQueryPattern";
+    public static final String CQF_DIRECT_REFERENCE_EXTENSION =
+            "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode";
 
     public static final String CQFM_EFFECTIVE_DATA_REQUIREMENTS =
             "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-effectiveDataRequirements";
@@ -90,7 +92,8 @@ public class Constants {
     public static final String CQFM_INPUT_PARAMETERS =
             "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-inputParameters";
     public static final String CQFM_COMPONENT = "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-component";
-
+    public static final String CQFM_DIRECT_REFERENCE_EXTENSION =
+            "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode";
     public static final String CRMI_EFFECTIVE_DATA_REQUIREMENTS =
             "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-effectiveDataRequirements";
 


### PR DESCRIPTION
Update $release operation to gather any direct-reference codes referenced by component measures and add them to the manifest, using the directReferenceCode extension slice on the root of the release manifest.

Functionality handles STU4/STU5+, works with cqfm-directReferenceCode (STU4) and cqf-directReferenceCode (STU5) in the Measure source, output is always cqf-directReferenceCode extensions in the Manifest because cqfm-directReferenceCode isn't allowed in a CRMIManifest.