### PR TITLE
Add support for applicability behavior in $apply

### DIFF
--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/Constants.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/Constants.java
@@ -73,6 +73,14 @@ public class Constants {
     public static final String CQIF_LIBRARY = "http://hl7.org/fhir/StructureDefinition/cqif-library";
     public static final String CQIF_CQL_EXPRESSION = "http://hl7.org/fhir/StructureDefinition/cqif-cqlExpression";
 
+    public static final String CQF_APPLICABILITY_BEHAVIOR =
+            "http://hl7.org/fhir/StructureDefinition/cqf-applicabilityBehavior";
+
+    public enum CqfApplicabilityBehavior {
+        ALL,
+        ANY
+    }
+
     public static final String CQF_CQL_OPTIONS = "http://hl7.org/fhir/StructureDefinition/cqf-cqlOptions";
     public static final String CQF_EXPANSION_PARAMETERS =
             "http://hl7.org/fhir/StructureDefinition/cqf-expansionParameters";


### PR DESCRIPTION
Add support for `all` and `any` applicability behavior when processing actions during the PlanDefinition/$apply operation.  

`all` - meaning the current behavior of evaluating the applicability of each child action independently. 
`any` - meaning that each child action will be evaluated in order, and the first action that returns an applicability of true will be performed, and processing of the parent action will stop.

The behavior is indicated on the action by the extension "http://hl7.org/fhir/StructureDefinition/cqf-applicabilityBehavior" with a value type of `code`.
If not specified, the current default behavior of `all` is used.