### PR TITLE
applySetScoring config, fix non resourceType population basis, fix measureScoring when <0

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureEvaluator.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureEvaluator.java
@@ -135,7 +135,12 @@ public class MeasureEvaluator {
             }
         }
 
-        return (Iterable<Object>) expressionResult.value();
+        Object value = expressionResult.value();
+        if (value instanceof Iterable<?>) {
+            return (Iterable<Object>) value;
+        } else {
+            return Collections.singletonList(value);
+        }
     }
 
     protected PopulationDef evaluatePopulationMembership(
@@ -187,8 +192,7 @@ public class MeasureEvaluator {
         // Evaluate Population Expressions
         initialPopulation = evaluatePopulationMembership(subjectType, subjectId, initialPopulation, evaluationResult);
         denominator = evaluatePopulationMembership(subjectType, subjectId, denominator, evaluationResult);
-        numerator = evaluatePopulationMembership(subjectType, subjectId, numerator,
-            evaluationResult);
+        numerator = evaluatePopulationMembership(subjectType, subjectId, numerator, evaluationResult);
         if (applyScoring) {
             // remove denominator values not in IP
             denominator.getResources().retainAll(initialPopulation.getResources());
@@ -200,18 +204,15 @@ public class MeasureEvaluator {
         // Evaluate Exclusions and Exception Populations
         if (denominatorExclusion != null) {
             denominatorExclusion =
-                evaluatePopulationMembership(subjectType, subjectId, denominatorExclusion,
-                    evaluationResult);
+                    evaluatePopulationMembership(subjectType, subjectId, denominatorExclusion, evaluationResult);
         }
         if (denominatorException != null) {
             denominatorException =
-                evaluatePopulationMembership(subjectType, subjectId, denominatorException,
-                    evaluationResult);
+                    evaluatePopulationMembership(subjectType, subjectId, denominatorException, evaluationResult);
         }
         if (numeratorExclusion != null) {
             numeratorExclusion =
-                evaluatePopulationMembership(subjectType, subjectId, numeratorExclusion,
-                    evaluationResult);
+                    evaluatePopulationMembership(subjectType, subjectId, numeratorExclusion, evaluationResult);
         }
         // Apply Exclusions and Exceptions
         if (groupDef.isBooleanBasis()) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureEvaluator.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureEvaluator.java
@@ -184,93 +184,94 @@ public class MeasureEvaluator {
         // add resources
         // add subject
 
+        // Evaluate Population Expressions
         initialPopulation = evaluatePopulationMembership(subjectType, subjectId, initialPopulation, evaluationResult);
+        denominator = evaluatePopulationMembership(subjectType, subjectId, denominator, evaluationResult);
+        numerator = evaluatePopulationMembership(subjectType, subjectId, numerator,
+            evaluationResult);
+        if (applyScoring) {
+            // remove denominator values not in IP
+            denominator.getResources().retainAll(initialPopulation.getResources());
+            denominator.getSubjects().retainAll(initialPopulation.getSubjects());
+            // remove numerator values if not in Denominator
+            numerator.getSubjects().retainAll(denominator.getSubjects());
+            numerator.getResources().retainAll(denominator.getResources());
+        }
+        // Evaluate Exclusions and Exception Populations
+        if (denominatorExclusion != null) {
+            denominatorExclusion =
+                evaluatePopulationMembership(subjectType, subjectId, denominatorExclusion,
+                    evaluationResult);
+        }
+        if (denominatorException != null) {
+            denominatorException =
+                evaluatePopulationMembership(subjectType, subjectId, denominatorException,
+                    evaluationResult);
+        }
+        if (numeratorExclusion != null) {
+            numeratorExclusion =
+                evaluatePopulationMembership(subjectType, subjectId, numeratorExclusion,
+                    evaluationResult);
+        }
+        // Apply Exclusions and Exceptions
+        if (groupDef.isBooleanBasis()) {
+            // Remove Subject and Resource Exclusions
+            if (denominatorExclusion != null && applyScoring) {
+                // numerator should not include den-exclusions
+                numerator.getSubjects().removeAll(denominatorExclusion.getSubjects());
+                numerator.removeOverlaps(denominatorExclusion.getSubjectResources());
 
-        if (initialPopulation.getSubjects().contains(subjectId)) {
-            // Evaluate Population Expressions
-            denominator = evaluatePopulationMembership(subjectType, subjectId, denominator, evaluationResult);
-            numerator = evaluatePopulationMembership(subjectType, subjectId, numerator, evaluationResult);
-            if (applyScoring) {
-                // remove denominator values not in IP
-                denominator.getResources().retainAll(initialPopulation.getResources());
-                denominator.getSubjects().retainAll(initialPopulation.getSubjects());
-                // remove numerator values if not in Denominator
-                numerator.getSubjects().retainAll(denominator.getSubjects());
-                numerator.getResources().retainAll(denominator.getResources());
+                // verify exclusion results are found in denominator
+                denominatorExclusion.getResources().retainAll(denominator.getResources());
+                denominatorExclusion.getSubjects().retainAll(denominator.getSubjects());
+                denominatorExclusion.retainOverlaps(denominator.getSubjectResources());
             }
-            // Evaluate Exclusions and Exception Populations
-            if (denominatorExclusion != null) {
-                denominatorExclusion =
-                        evaluatePopulationMembership(subjectType, subjectId, denominatorExclusion, evaluationResult);
+            if (numeratorExclusion != null && applyScoring) {
+                // verify results are in Numerator
+                numeratorExclusion.getResources().retainAll(numerator.getResources());
+                numeratorExclusion.getSubjects().retainAll(numerator.getSubjects());
+                numeratorExclusion.retainOverlaps(numerator.getSubjectResources());
             }
-            if (denominatorException != null) {
-                denominatorException =
-                        evaluatePopulationMembership(subjectType, subjectId, denominatorException, evaluationResult);
-            }
-            if (numeratorExclusion != null) {
-                numeratorExclusion =
-                        evaluatePopulationMembership(subjectType, subjectId, numeratorExclusion, evaluationResult);
-            }
-            // Apply Exclusions and Exceptions
-            if (groupDef.isBooleanBasis()) {
-                // Remove Subject and Resource Exclusions
-                if (denominatorExclusion != null && applyScoring) {
-                    // numerator should not include den-exclusions
-                    numerator.getSubjects().removeAll(denominatorExclusion.getSubjects());
-                    numerator.removeOverlaps(denominatorExclusion.getSubjectResources());
+            if (denominatorException != null && applyScoring) {
+                // Remove Subjects Exceptions that are present in Numerator
+                denominatorException.getSubjects().removeAll(numerator.getSubjects());
+                denominatorException.getResources().removeAll(numerator.getResources());
+                denominatorException.removeOverlaps(numerator.getSubjectResources());
 
-                    // verify exclusion results are found in denominator
-                    denominatorExclusion.getResources().retainAll(denominator.getResources());
-                    denominatorExclusion.getSubjects().retainAll(denominator.getSubjects());
-                    denominatorExclusion.retainOverlaps(denominator.getSubjectResources());
-                }
-                if (numeratorExclusion != null && applyScoring) {
-                    // verify results are in Numerator
-                    numeratorExclusion.getResources().retainAll(numerator.getResources());
-                    numeratorExclusion.getSubjects().retainAll(numerator.getSubjects());
-                    numeratorExclusion.retainOverlaps(numerator.getSubjectResources());
-                }
-                if (denominatorException != null && applyScoring) {
-                    // Remove Subjects Exceptions that are present in Numerator
-                    denominatorException.getSubjects().removeAll(numerator.getSubjects());
-                    denominatorException.getResources().removeAll(numerator.getResources());
-                    denominatorException.removeOverlaps(numerator.getSubjectResources());
-
-                    // verify exception results are found in denominator
-                    denominatorException.getResources().retainAll(denominator.getResources());
-                    denominatorException.getSubjects().retainAll(denominator.getSubjects());
-                    denominatorException.retainOverlaps(denominator.getSubjectResources());
-                }
-            } else {
-                // Remove Only Resource Exclusions
-                // * Multiple resources can be from one subject and represented in multiple populations
-                // * This is why we only remove resources and not subjects too for `Resource Basis`.
-                if (denominatorExclusion != null && applyScoring) {
-                    // remove any denominator-exception subjects/resources found in Numerator
-                    numerator.getResources().removeAll(denominatorExclusion.getResources());
-                    numerator.removeOverlaps(denominatorExclusion.getSubjectResources());
-                    // verify exclusion results are found in denominator
-                    denominatorExclusion.getResources().retainAll(denominator.getResources());
-                    denominatorExclusion.retainOverlaps(denominator.getSubjectResources());
-                }
-                if (numeratorExclusion != null && applyScoring) {
-                    // verify exclusion results are found in numerator results, otherwise remove
-                    numeratorExclusion.getResources().retainAll(numerator.getResources());
-                    numeratorExclusion.retainOverlaps(numerator.getSubjectResources());
-                }
-                if (denominatorException != null && applyScoring) {
-                    // Remove Resource Exceptions that are present in Numerator
-                    denominatorException.getResources().removeAll(numerator.getResources());
-                    denominatorException.removeOverlaps(numerator.getSubjectResources());
-                    // verify exception results are found in denominator
-                    denominatorException.getResources().retainAll(denominator.getResources());
-                    denominatorException.retainOverlaps(denominator.getSubjectResources());
-                }
+                // verify exception results are found in denominator
+                denominatorException.getResources().retainAll(denominator.getResources());
+                denominatorException.getSubjects().retainAll(denominator.getSubjects());
+                denominatorException.retainOverlaps(denominator.getSubjectResources());
             }
-            if (reportType.equals(MeasureReportType.INDIVIDUAL) && dateOfCompliance != null) {
-                var doc = evaluateDateOfCompliance(dateOfCompliance, evaluationResult);
-                dateOfCompliance.addResource(doc);
+        } else {
+            // Remove Only Resource Exclusions
+            // * Multiple resources can be from one subject and represented in multiple populations
+            // * This is why we only remove resources and not subjects too for `Resource Basis`.
+            if (denominatorExclusion != null && applyScoring) {
+                // remove any denominator-exception subjects/resources found in Numerator
+                numerator.getResources().removeAll(denominatorExclusion.getResources());
+                numerator.removeOverlaps(denominatorExclusion.getSubjectResources());
+                // verify exclusion results are found in denominator
+                denominatorExclusion.getResources().retainAll(denominator.getResources());
+                denominatorExclusion.retainOverlaps(denominator.getSubjectResources());
             }
+            if (numeratorExclusion != null && applyScoring) {
+                // verify exclusion results are found in numerator results, otherwise remove
+                numeratorExclusion.getResources().retainAll(numerator.getResources());
+                numeratorExclusion.retainOverlaps(numerator.getSubjectResources());
+            }
+            if (denominatorException != null && applyScoring) {
+                // Remove Resource Exceptions that are present in Numerator
+                denominatorException.getResources().removeAll(numerator.getResources());
+                denominatorException.removeOverlaps(numerator.getSubjectResources());
+                // verify exception results are found in denominator
+                denominatorException.getResources().retainAll(denominator.getResources());
+                denominatorException.retainOverlaps(denominator.getSubjectResources());
+            }
+        }
+        if (reportType.equals(MeasureReportType.INDIVIDUAL) && dateOfCompliance != null) {
+            var doc = evaluateDateOfCompliance(dateOfCompliance, evaluationResult);
+            dateOfCompliance.addResource(doc);
         }
     }
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportBuilder.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.CodeableConcept;
@@ -585,8 +586,16 @@ public class R4MeasureReportBuilder implements MeasureReportBuilder<Measure, Mea
             List<String> subjectIds,
             PopulationDef populationDef,
             GroupDef groupDef) {
-        var resourceType =
-                ResourceType.fromCode(groupDef.getPopulationBasis().code()).toString();
+        String resourceType;
+        try {
+            // when this method is checked with a primitive value and not ResourceType it returns an error
+            // this try/catch is to prevent the exception thrown from setting the correct value
+            resourceType = ResourceType.fromCode(groupDef.getPopulationBasis().code()).toString();
+        }
+        catch (FHIRException e) {
+            resourceType = null;
+        }
+        // only ResourceType fhirType should return true here
         boolean isResourceType = resourceType != null;
         List<String> resourceIds = new ArrayList<>();
         assert populationDef != null;

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportBuilder.java
@@ -590,9 +590,9 @@ public class R4MeasureReportBuilder implements MeasureReportBuilder<Measure, Mea
         try {
             // when this method is checked with a primitive value and not ResourceType it returns an error
             // this try/catch is to prevent the exception thrown from setting the correct value
-            resourceType = ResourceType.fromCode(groupDef.getPopulationBasis().code()).toString();
-        }
-        catch (FHIRException e) {
+            resourceType =
+                    ResourceType.fromCode(groupDef.getPopulationBasis().code()).toString();
+        } catch (FHIRException e) {
             resourceType = null;
         }
         // only ResourceType fhirType should return true here

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportScorer.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportScorer.java
@@ -158,7 +158,7 @@ public class R4MeasureReportScorer extends BaseMeasureReportScorer<MeasureReport
                                 - getCountFromGroupPopulation(mrgc.getPopulation(), DENOMINATOR_EXCEPTION));
                 // When applySetMembership=false, this value can receive strange values
                 // This should prevent scoring in certain scenarios like <0
-                if (score != null && score >=0) {
+                if (score != null && score >= 0) {
                     if (isIncreaseImprovementNotation) {
                         mrgc.setMeasureScore(new Quantity(score));
                     } else {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportScorer.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportScorer.java
@@ -156,7 +156,9 @@ public class R4MeasureReportScorer extends BaseMeasureReportScorer<MeasureReport
                         getCountFromGroupPopulation(mrgc.getPopulation(), DENOMINATOR)
                                 - getCountFromGroupPopulation(mrgc.getPopulation(), DENOMINATOR_EXCLUSION)
                                 - getCountFromGroupPopulation(mrgc.getPopulation(), DENOMINATOR_EXCEPTION));
-                if (score != null) {
+                // When applySetMembership=false, this value can receive strange values
+                // This should prevent scoring in certain scenarios like <0
+                if (score != null && score >=0) {
                     if (isIncreaseImprovementNotation) {
                         mrgc.setMeasureScore(new Quantity(score));
                     } else {

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/ApplyScoringSetMembershipTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/ApplyScoringSetMembershipTest.java
@@ -1,0 +1,101 @@
+package org.opencds.cqf.fhir.cr.measure.r4;
+
+import static org.opencds.cqf.fhir.test.Resources.getResourcePath;
+
+import ca.uhn.fhir.context.FhirContext;
+import java.nio.file.Path;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.Period;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.api.Repository;
+import org.opencds.cqf.fhir.cr.measure.r4.Measure.Given;
+import org.opencds.cqf.fhir.cr.measure.r4.utils.TestDataGenerator;
+import org.opencds.cqf.fhir.utility.repository.ig.IgRepository;
+
+/**
+ * the purpose of this test is to validate the output and required fields for evaluating a Measure with population basis that is neither resourceType or boolean
+ */
+@SuppressWarnings("squid:S2699")
+class ApplyScoringSetMembershipTest {
+    // req'd populations
+    // exception works
+    // exclusion works
+    // has score
+    // resource based
+    // boolean based
+    // group scoring def
+    private static final String CLASS_PATH = "org/opencds/cqf/fhir/cr/measure/r4";
+    private static final Repository repository = new IgRepository(
+            FhirContext.forR4Cached(),
+            Path.of(getResourcePath(ApplyScoringSetMembershipTest.class) + "/" + CLASS_PATH + "/" + "MeasureTest"));
+    private final Given given = Measure.given(false).repository(repository);
+    private static final TestDataGenerator testDataGenerator = new TestDataGenerator(repository);
+
+    @BeforeAll
+    static void init() {
+        Period period = new Period();
+        period.setStartElement(new DateTimeType("2024-01-01T01:00:00Z"));
+        period.setEndElement(new DateTimeType("2024-01-01T03:00:00Z"));
+        testDataGenerator.makePatient(null, null, period);
+    }
+    /**
+     * scoring set membership set to false,
+     * ("numerator")/("denominator" - "denominator-exclusion") => 1/(1-0) => NA
+     * Result should omit score because it can't be calculated
+     * This also validates that exclusion criteria is not removed from denominator or numerator
+     */
+    @Test
+    void datePopulation() {
+
+        given.when()
+                .measureId("ProportionDatePopulationBasis")
+                .evaluate()
+                .then()
+                .firstGroup()
+                .population("initial-population")
+                .hasCount(1)
+                .up()
+                .population("denominator")
+                .hasCount(1)
+                .up()
+                .population("denominator-exclusion")
+                .hasCount(1)
+                .up()
+                .population("numerator")
+                .hasCount(1)
+                .up()
+                .hasMeasureScore(false)
+                .up()
+                .report();
+    }
+
+    /**
+     * scoring set membership set to false,
+     * ("numerator")/("denominator") => 1/(1) => 1.0
+     * Result should have score because it can be calculated
+     * This also validates that exclusion criteria is not removed from denominator or numerator
+     */
+    @Test
+    void datePopulationHasScore() {
+
+        given.when()
+                .measureId("ProportionDatePopulationBasisNoExcl")
+                .evaluate()
+                .then()
+                .firstGroup()
+                .population("initial-population")
+                .hasCount(1)
+                .up()
+                .population("denominator")
+                .hasCount(1)
+                .up()
+                .population("numerator")
+                .hasCount(1)
+                .up()
+                .hasMeasureScore(true)
+                .hasScore("1.0")
+                .up()
+                .report();
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/Measure.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/Measure.java
@@ -108,8 +108,12 @@ public class Measure {
         }
     }
 
+    public static Given given(@Nullable Boolean applyScoringSetMembership) {
+        return new Given(applyScoringSetMembership);
+    }
+
     public static Given given() {
-        return new Given();
+        return new Given(true);
     }
 
     public static class Given {
@@ -118,8 +122,16 @@ public class Measure {
         private final MeasurePeriodValidator measurePeriodValidator;
         private final R4MeasureServiceUtils measureServiceUtils;
 
-        public Given() {
+        public Given(@Nullable Boolean applyScoringSetMembership) {
             this.evaluationOptions = MeasureEvaluationOptions.defaultOptions();
+            if (applyScoringSetMembership != null && !applyScoringSetMembership) {
+                MeasureEvaluationOptions options = MeasureEvaluationOptions.defaultOptions();
+                options.setApplyScoringSetMembership(false);
+                this.evaluationOptions = options;
+            } else {
+                this.evaluationOptions = MeasureEvaluationOptions.defaultOptions();
+            }
+
             this.evaluationOptions
                     .getEvaluationSettings()
                     .getRetrieveSettings()
@@ -801,6 +813,11 @@ public class Measure {
 
         public SelectedGroup hasScore(String score) {
             MeasureValidationUtils.validateGroupScore(this.value(), score);
+            return this;
+        }
+
+        public SelectedGroup hasMeasureScore(boolean hasScore) {
+            assertEquals(hasScore, this.value().hasMeasureScore());
             return this;
         }
 

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/cql/SimpleCql.cql
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/cql/SimpleCql.cql
@@ -151,3 +151,18 @@ define "Matching General Practitioner":
 
 define "Age":
     AgeInYearsAt(start of "Measurement Period")
+
+define "Date":
+    Interval[@2024-02-01T00:00:00, @2024-10-31T23:59:59]
+
+define "ip date":
+    "Date"
+
+define "den date":
+    "Date"
+
+define "num date":
+    "Date"
+
+define "exc date":
+    "Date"

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/resources/measure/Measure-ProportionDatePopulationBasis.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/resources/measure/Measure-ProportionDatePopulationBasis.json
@@ -1,0 +1,93 @@
+{
+  "id": "ProportionDatePopulationBasis",
+  "resourceType": "Measure",
+  "url": "http://example.com/Measure/ProportionDatePopulationBasis",
+  "library": [
+    "http://example.com/Library/LibrarySimple"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "Period"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "proportion"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "ip date"
+          }
+        },
+        {
+          "id": "denominator",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "denominator",
+                "display": "Denominator"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "den date"
+          }
+        },
+        {
+          "id": "denominator-exclusion",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "denominator-exclusion",
+                "display": "Denominator-Exclusion"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "exc date"
+          }
+        },
+        {
+          "id": "numerator",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "numerator",
+                "display": "Numerator"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "num date"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/resources/measure/Measure-ProportionDatePopulationBasisNoExcl.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/resources/measure/Measure-ProportionDatePopulationBasisNoExcl.json
@@ -1,0 +1,77 @@
+{
+  "id": "ProportionDatePopulationBasisNoExcl",
+  "resourceType": "Measure",
+  "url": "http://example.com/Measure/ProportionDatePopulationBasisNoExcl",
+  "library": [
+    "http://example.com/Library/LibrarySimple"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "Period"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "proportion"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "ip date"
+          }
+        },
+        {
+          "id": "denominator",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "denominator",
+                "display": "Denominator"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "den date"
+          }
+        },
+        {
+          "id": "numerator",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "numerator",
+                "display": "Numerator"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "num date"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Configuration applySetScoring unit tests

population-basis that are not-resourceTypes and not boolean hit an iterable casting error. Test is used on 'Period' to mimic the error.

measureScoring on measure expressions with applySetScoring have possiblity of attempting to score < 0 or divide by 0, this merge corrects this.