### PR TITLE
Enable unit test logging

### DIFF
--- a/cqf-fhir-benchmark/src/test/resources/slf4jtest.properties
+++ b/cqf-fhir-benchmark/src/test/resources/slf4jtest.properties
@@ -1,0 +1,1 @@
+print.level=INFO

--- a/cqf-fhir-cql/src/test/resources/slf4jtest.properties
+++ b/cqf-fhir-cql/src/test/resources/slf4jtest.properties
@@ -1,0 +1,1 @@
+print.level=INFO

--- a/cqf-fhir-cr-cli/src/test/resources/slf4jtest.properties
+++ b/cqf-fhir-cr-cli/src/test/resources/slf4jtest.properties
@@ -1,0 +1,1 @@
+print.level=INFO

--- a/cqf-fhir-cr-hapi/src/test/resources/slf4jtest.properties
+++ b/cqf-fhir-cr-hapi/src/test/resources/slf4jtest.properties
@@ -1,0 +1,1 @@
+print.level=INFO

--- a/cqf-fhir-cr/src/test/resources/slf4jtest.properties
+++ b/cqf-fhir-cr/src/test/resources/slf4jtest.properties
@@ -1,0 +1,1 @@
+print.level=INFO

--- a/cqf-fhir-test/src/test/resources/slf4jtest.properties
+++ b/cqf-fhir-test/src/test/resources/slf4jtest.properties
@@ -1,0 +1,1 @@
+print.level=INFO

--- a/cqf-fhir-utility/src/test/resources/slf4jtest.properties
+++ b/cqf-fhir-utility/src/test/resources/slf4jtest.properties
@@ -1,0 +1,1 @@
+print.level=INFO


### PR DESCRIPTION
Enable unit test logging by adding valfirst properties files in all test resources folders.