### PR TITLE
Improve MultiMeasureServiceTest to assert partial errors on invalid Encounter Interval

### DIFF
--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasure.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasure.java
@@ -55,7 +55,7 @@ class MultiMeasure {
     }
 
     @FunctionalInterface
-    interface Selector<T, S> {
+    public interface Selector<T, S> {
         T select(S from);
     }
 
@@ -294,6 +294,16 @@ class MultiMeasure {
                     measureUrl));
         }
 
+        public SelectedMeasureReport measureReport(String measureUrl, String subject) {
+            return this.measureReport(g -> resourceToMeasureReport(
+                    g.getEntry().stream()
+                            .filter(x ->
+                                    x.getResource().getResourceType().toString().equals("MeasureReport"))
+                            .toList(),
+                    measureUrl,
+                    subject));
+        }
+
         public SelectedMeasureReport getFirstMeasureReport() {
             var mr = (MeasureReport) report().getEntryFirstRep().getResource();
             return this.measureReport(g -> mr);
@@ -312,9 +322,25 @@ class MultiMeasure {
             }
             return matchedReport;
         }
+
+        public MeasureReport resourceToMeasureReport(
+                List<BundleEntryComponent> entries, String measureUrl, String subject) {
+            IParser parser = FhirContext.forR4Cached().newJsonParser();
+            MeasureReport matchedReport = null;
+            for (int i = 0; i < entries.size(); i++) {
+                MeasureReport report = (MeasureReport) parser.parseResource(
+                        parser.encodeResourceToString(entries.get(i).getResource()));
+                if (report.getMeasure().equals(measureUrl)
+                        && report.getSubject().getReference().equals(subject)) {
+                    matchedReport = report;
+                    break;
+                }
+            }
+            return matchedReport;
+        }
     }
 
-    static class SelectedMeasureReport extends MultiMeasure.Selected<MeasureReport, SelectedReport> {
+    public static class SelectedMeasureReport extends MultiMeasure.Selected<MeasureReport, SelectedReport> {
         public MeasureReport report() {
             return this.value();
         }
@@ -502,7 +528,7 @@ class MultiMeasure {
         }
     }
 
-    static class SelectedReference<P> extends MultiMeasure.Selected<Reference, P> {
+    public static class SelectedReference<P> extends MultiMeasure.Selected<Reference, P> {
 
         public SelectedReference(Reference value, P parent) {
             super(value, parent);

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasureServiceTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasureServiceTest.java
@@ -163,7 +163,10 @@ class MultiMeasureServiceTest {
                 .hasCount(10)
                 .up()
                 .up()
-                .up();
+                .hasMeasureReportStatus(MeasureReportStatus.ERROR)
+                .hasContainedOperationOutcome()
+                .hasContainedOperationOutcomeMsg("Patient/female-1988-2")
+                .hasContainedOperationOutcomeMsg("Invalid Interval");
     }
 
     @Test
@@ -287,6 +290,10 @@ class MultiMeasureServiceTest {
                 .up()
                 .up()
                 .measureReport("http://example.com/Measure/MinimalContinuousVariableResourceBasisSingleGroup")
+                .hasMeasureReportStatus(MeasureReportStatus.ERROR)
+                .hasContainedOperationOutcome()
+                .hasContainedOperationOutcomeMsg("Patient/female-1988-2")
+                .hasContainedOperationOutcomeMsg("Invalid Interval")
                 .firstGroup()
                 .population("initial-population")
                 .hasCount(10)
@@ -298,10 +305,7 @@ class MultiMeasureServiceTest {
                 .hasCount(2)
                 .up()
                 .population("measure-observation")
-                .hasCount(10)
-                .up()
-                .up()
-                .up();
+                .hasCount(10);
     }
 
     @Test
@@ -331,7 +335,15 @@ class MultiMeasureServiceTest {
                 .hasMeasureReportCountPerUrl(
                         10, "http://example.com/Measure/MinimalContinuousVariableResourceBasisSingleGroup")
                 .getFirstMeasureReport()
-                .hasReportType("Individual");
+                .hasReportType("Individual")
+                .up()
+                .measureReport(
+                        "http://example.com/Measure/MinimalContinuousVariableResourceBasisSingleGroup",
+                        "Patient/female-1988-2")
+                .hasMeasureReportStatus(MeasureReportStatus.ERROR)
+                .hasContainedOperationOutcome()
+                .hasContainedOperationOutcomeMsg("Patient/female-1988-2")
+                .hasContainedOperationOutcomeMsg("Invalid Interval");
     }
 
     @Test


### PR DESCRIPTION
- Improve MultiMeasureServiceTest to assert partial errors on invalid Encounter Interval in addition to the other successful measure reports.
- Tweak MultiMeasure to retrieve a MeasureReport by subject + measure URL as well as resolving some "class exposed outside of scope" warnings.