### PR TITLE
Compositeevalresults add getters

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/CompositeEvaluationResultsPerMeasure.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/CompositeEvaluationResultsPerMeasure.java
@@ -57,6 +57,25 @@ public class CompositeEvaluationResultsPerMeasure {
         return resultsPerMeasure.getOrDefault(unqualifiedMeasureId, Map.of());
     }
 
+    /**
+     * Expose method to allow retrieval of evaluated cql results per Measure.
+     * IIdType for Measure is key, Nested Map<String, EvaluationResult> has Key for subject evaluated,
+     * and associated EvaluationResult produced from CQL expression evaluation
+     * @return {@code Map<IIdType, Map<String, EvaluationResult>>}
+     */
+    public Map<IIdType, Map<String, EvaluationResult>> getResultsPerMeasure() {
+        return this.resultsPerMeasure;
+    }
+
+    /**
+     * Expose method to allow retrieval of captured errors produced from evaluated cql per Measure.
+     * When an error is produced while evaluating, we capture the errors generated in this object, which can be rendered per Measure evaluated.
+     * @return {@code Map<IIdType, List<String>>}
+     */
+    public Map<IIdType, List<String>> getErrorsPerMeasure() {
+        return this.errorsPerMeasure;
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/CompositeEvaluationResultsPerMeasureTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/CompositeEvaluationResultsPerMeasureTest.java
@@ -1,0 +1,69 @@
+package org.opencds.cqf.fhir.cr.measure.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.IdType;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.cql.engine.execution.EvaluationResult;
+
+class CompositeEvaluationResultsPerMeasureTest {
+
+    @Test
+    void gettersContainExpectedData() {
+        // Arrange
+        IIdType m1 = new IdType("Measure/one");
+        IIdType m2 = new IdType("Measure/two");
+
+        // Create a non-empty EvaluationResult without depending on ExpressionResult constructors
+        EvaluationResult er = new EvaluationResult();
+        er.expressionResults.put("subject-123", null); // non-empty map is all the Builder checks
+
+        CompositeEvaluationResultsPerMeasure.Builder builder = CompositeEvaluationResultsPerMeasure.builder();
+        builder.addResult(m1, "subject-123", er);
+        builder.addError(m1, "oops-1");
+        builder.addError(m2, "oops-2");
+
+        CompositeEvaluationResultsPerMeasure composite = builder.build();
+
+        // Act
+        Map<IIdType, Map<String, EvaluationResult>> resultsPerMeasure = composite.getResultsPerMeasure();
+        Map<IIdType, List<String>> errorsPerMeasure = composite.getErrorsPerMeasure();
+
+        // Assert: results present for m1, none for m2
+        assertTrue(resultsPerMeasure.containsKey(m1.toUnqualifiedVersionless()));
+        assertFalse(resultsPerMeasure.containsKey(m2.toUnqualifiedVersionless()));
+        Map<String, EvaluationResult> m1Results = resultsPerMeasure.get(m1.toUnqualifiedVersionless());
+        assertNotNull(m1Results);
+        assertTrue(m1Results.containsKey("subject-123"));
+
+        // Assert: errors present for both measures
+        assertEquals(List.of("oops-1"), errorsPerMeasure.get(m1.toUnqualifiedVersionless()));
+        assertEquals(List.of("oops-2"), errorsPerMeasure.get(m2.toUnqualifiedVersionless()));
+    }
+
+    @Test
+    void gettersReturnImmutableViews() {
+        IIdType m = new IdType("Measure/immutable");
+
+        EvaluationResult er = new EvaluationResult();
+        er.expressionResults.put("s", null);
+
+        CompositeEvaluationResultsPerMeasure composite =
+                CompositeEvaluationResultsPerMeasure.builder().build(); // empty instance to test top-level immutability
+
+        // Top-level maps should be unmodifiable
+        Map<IIdType, Map<String, EvaluationResult>> resultsPerMeasure = composite.getResultsPerMeasure();
+        Map<IIdType, List<String>> errorsPerMeasure = composite.getErrorsPerMeasure();
+
+        assertThrows(UnsupportedOperationException.class, () -> resultsPerMeasure.put(m, Map.of("s", er)));
+
+        assertThrows(UnsupportedOperationException.class, () -> errorsPerMeasure.put(m, List.of("err")));
+    }
+}


### PR DESCRIPTION
CompositeEvaluationResultsPerMeasure class requires additional methods to allow extraction of built objects within it for potential use in different downstream applications that can leverage the produced data.

As it stands the Class allows building of results and convenient portability of results for methods that want to consume data per Measure, but lack access to full `Map<IIdType, Map<String, EvaluationResult>> resultsPerMeasure` or `Map<IIdType, List<String>> errorsPerMeasure`

This PR allows for access to those built objects for multiple downstream use cases outside of Measure evaluation 