### PR TITLE
CRMI Approve Operation (R4)

### DIFF
--- a/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/config/r4/CrR4Config.java
+++ b/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/config/r4/CrR4Config.java
@@ -135,7 +135,7 @@ public class CrR4Config {
     }
 
     @Bean
-    IApproveServiceFactory r4ApproveProvider(IRepositoryFactory repositoryFactory) {
+    IApproveServiceFactory approveServiceFactory(IRepositoryFactory repositoryFactory) {
         return rd -> new R4ApproveService(repositoryFactory.create(rd));
     }
 

--- a/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/config/r4/CrR4Config.java
+++ b/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/config/r4/CrR4Config.java
@@ -172,7 +172,8 @@ public class CrR4Config {
                                 CareGapsOperationProvider.class,
                                 CqlExecutionOperationProvider.class,
                                 CollectDataOperationProvider.class,
-                                DataRequirementsOperationProvider.class)));
+                                DataRequirementsOperationProvider.class,
+                                ApproveProvider.class)));
 
         return new ProviderLoader(restfulServer, applicationContext, selector);
     }

--- a/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/config/r4/CrR4Config.java
+++ b/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/config/r4/CrR4Config.java
@@ -8,11 +8,13 @@ import java.util.Arrays;
 import java.util.Map;
 import org.opencds.cqf.fhir.cql.EvaluationSettings;
 import org.opencds.cqf.fhir.cr.cpg.r4.R4CqlExecutionService;
+import org.opencds.cqf.fhir.cr.crmi.R4ApproveService;
 import org.opencds.cqf.fhir.cr.hapi.common.StringTimePeriodHandler;
 import org.opencds.cqf.fhir.cr.hapi.config.CrBaseConfig;
 import org.opencds.cqf.fhir.cr.hapi.config.ProviderLoader;
 import org.opencds.cqf.fhir.cr.hapi.config.ProviderSelector;
 import org.opencds.cqf.fhir.cr.hapi.config.RepositoryConfig;
+import org.opencds.cqf.fhir.cr.hapi.r4.IApproveServiceFactory;
 import org.opencds.cqf.fhir.cr.hapi.r4.ICareGapsServiceFactory;
 import org.opencds.cqf.fhir.cr.hapi.r4.ICollectDataServiceFactory;
 import org.opencds.cqf.fhir.cr.hapi.r4.ICqlExecutionServiceFactory;
@@ -22,6 +24,7 @@ import org.opencds.cqf.fhir.cr.hapi.r4.R4MeasureEvaluatorMultipleFactory;
 import org.opencds.cqf.fhir.cr.hapi.r4.R4MeasureEvaluatorSingleFactory;
 import org.opencds.cqf.fhir.cr.hapi.r4.R4MeasureServiceUtilsFactory;
 import org.opencds.cqf.fhir.cr.hapi.r4.cpg.CqlExecutionOperationProvider;
+import org.opencds.cqf.fhir.cr.hapi.r4.crmi.ApproveProvider;
 import org.opencds.cqf.fhir.cr.hapi.r4.measure.CareGapsOperationProvider;
 import org.opencds.cqf.fhir.cr.hapi.r4.measure.CollectDataOperationProvider;
 import org.opencds.cqf.fhir.cr.hapi.r4.measure.DataRequirementsOperationProvider;
@@ -129,6 +132,16 @@ public class CrR4Config {
     CareGapsOperationProvider r4CareGapsOperationProvider(
             ICareGapsServiceFactory r4CareGapsProcessorFactory, StringTimePeriodHandler stringTimePeriodHandler) {
         return new CareGapsOperationProvider(r4CareGapsProcessorFactory, stringTimePeriodHandler);
+    }
+
+    @Bean
+    IApproveServiceFactory r4ApproveProvider(IRepositoryFactory repositoryFactory) {
+        return rd -> new R4ApproveService(repositoryFactory.create(rd));
+    }
+
+    @Bean
+    ApproveProvider r4ApproveProvider(IApproveServiceFactory r4ApproveServiceFactory) {
+        return new ApproveProvider(r4ApproveServiceFactory);
     }
 
     @Bean

--- a/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/r4/IApproveServiceFactory.java
+++ b/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/r4/IApproveServiceFactory.java
@@ -1,0 +1,9 @@
+package org.opencds.cqf.fhir.cr.hapi.r4;
+
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import org.opencds.cqf.fhir.cr.crmi.R4ApproveService;
+
+@FunctionalInterface
+public interface IApproveServiceFactory {
+    R4ApproveService create(RequestDetails requestDetails);
+}

--- a/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/r4/crmi/ApproveProvider.java
+++ b/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/r4/crmi/ApproveProvider.java
@@ -1,0 +1,85 @@
+package org.opencds.cqf.fhir.cr.hapi.r4.crmi;
+
+import ca.uhn.fhir.model.api.annotation.Description;
+import ca.uhn.fhir.rest.annotation.IdParam;
+import ca.uhn.fhir.rest.annotation.Operation;
+import ca.uhn.fhir.rest.annotation.OperationParam;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import java.util.Date;
+import org.hl7.fhir.instance.model.api.IPrimitiveType;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CanonicalType;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.MetadataResource;
+import org.hl7.fhir.r4.model.Reference;
+import org.opencds.cqf.fhir.cr.hapi.r4.IApproveServiceFactory;
+
+public class ApproveProvider {
+
+    private final IApproveServiceFactory r4ApproveServiceFactory;
+
+    public ApproveProvider(IApproveServiceFactory r4ApproveServiceFactory) {
+        this.r4ApproveServiceFactory = r4ApproveServiceFactory;
+    }
+
+    /**
+     * The "approve" operation supports applying an approval to an existing artifact, all its
+     * children, regardless of status. The operation sets the date and approvalDate elements
+     * of the approved artifact and child artifacts, and is otherwise only allowed to create
+     * ArtifactAssessment (Basic or cqf-artifactComment extensions in R4) resources in the
+     * repository.
+     * The "approve" operation supports the ability of a repository to record commentary on a
+     * specific state of an artifact in an ArtifactAssessment (Basic or cqf-artifactComment
+     * extension in R4) resource by applying an approval. The artifact assessments which are added
+     * by the operation must reference a version of the artifact.
+     *
+     * @param id                                The logical id of the artifact to approved. The
+     *                                          server must know the artifact (e.g. it is defined
+     *                                          explicitly in the server's artifacts)
+     * @param approvalDate                      The date on which the artifact was approved. If one
+     *                                          is not provided the system date will be used.
+     * @param artifactAssessmentType            If a comment is submitted as part of the approval,
+     *                                          this parameter denotes the type of artifact comment.
+     * @param artifactAssessmentSummary         The body of the comment.
+     * @param artifactAssessmentTarget          The canonical {@link CanonicalType} url for the
+     *                                          artifact being approved. The format is:
+     *                                          [system]|[version] - e.g. http://loinc.org|2.56
+     * @param artifactAssessmentRelatedArtifact Optional supporting canonical {@link CanonicalType}
+     *                                          URL / Reference for the comment.
+     * @param artifactAssessmentAuthor          A {@link Reference} Reference to a resource
+     *                                          containing information about the entity applying
+     *                                          the approval.
+     * @param requestDetails                    The {@link RequestDetails RequestDetails}
+     * @return  The {@link Bundle} Bundle result containing all updated artifacts and the
+     *          ArtifactAssessment (Basic in R4) resource containing the Approval metadata
+     */
+    @Operation(
+            name = "$approve",
+            idempotent = true,
+            global = true,
+            type = MetadataResource.class,
+            canonicalUrl = "http://hl7.org/fhir/uv/crmi/OperationDefinition/crmi-approve")
+    @Description(
+            shortDefinition = "$approve",
+            value = "Apply an approval to an existing artifact, regardless of status.")
+    public Bundle approveOperation(
+            @IdParam IdType id,
+            @OperationParam(name = "approvalDate", typeName = "Date") IPrimitiveType<Date> approvalDate,
+            @OperationParam(name = "artifactAssessmentType") String artifactAssessmentType,
+            @OperationParam(name = "artifactAssessmentSummary") String artifactAssessmentSummary,
+            @OperationParam(name = "artifactAssessmentTarget") CanonicalType artifactAssessmentTarget,
+            @OperationParam(name = "artifactAssessmentRelatedArtifact") CanonicalType artifactAssessmentRelatedArtifact,
+            @OperationParam(name = "artifactAssessmentAuthor") Reference artifactAssessmentAuthor,
+            RequestDetails requestDetails) {
+        return r4ApproveServiceFactory
+                .create(requestDetails)
+                .approve(
+                        id,
+                        approvalDate,
+                        artifactAssessmentType,
+                        artifactAssessmentSummary,
+                        artifactAssessmentTarget,
+                        artifactAssessmentRelatedArtifact,
+                        artifactAssessmentAuthor);
+    }
+}

--- a/cqf-fhir-cr-hapi/src/test/java/org/opencds/cqf/fhir/cr/hapi/r4/ApproveProviderIT.java
+++ b/cqf-fhir-cr-hapi/src/test/java/org/opencds/cqf/fhir/cr/hapi/r4/ApproveProviderIT.java
@@ -1,0 +1,161 @@
+package org.opencds.cqf.fhir.cr.hapi.r4;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+import ca.uhn.fhir.model.valueset.BundleTypeEnum;
+import ca.uhn.fhir.util.BundleUtil;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import org.hl7.fhir.r4.model.Basic;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CanonicalType;
+import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.DateType;
+import org.hl7.fhir.r4.model.MarkdownType;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.RelatedArtifact;
+import org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.opencds.cqf.fhir.utility.r4.ArtifactAssessment;
+import org.opencds.cqf.fhir.utility.r4.ArtifactAssessment.ArtifactAssessmentContentExtension;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+public class ApproveProviderIT extends BaseCrR4TestServer {
+
+    private final FhirContext fhirContext = FhirContext.forR4Cached();
+
+    public Bundle callApprove(
+            String id,
+            Date approvalDate,
+            String artifactAssessmentType,
+            String artifactAssessmentSummary,
+            CanonicalType artifactAssessmentTarget,
+            CanonicalType artifactAssessmentRelatedArtifact,
+            Reference artifactAssessmentAuthor) {
+        var parametersEval = new Parameters();
+        parametersEval.addParameter(
+                "approvalDate", approvalDate == null ? null : new DateType(approvalDate, TemporalPrecisionEnum.DAY));
+        parametersEval.addParameter(
+                "artifactAssessmentType",
+                artifactAssessmentType == null ? null : new StringType(artifactAssessmentType));
+        parametersEval.addParameter(
+                "artifactAssessmentSummary",
+                artifactAssessmentSummary == null ? null : new StringType(artifactAssessmentSummary));
+        parametersEval.addParameter("artifactAssessmentTarget", artifactAssessmentTarget);
+        parametersEval.addParameter("artifactAssessmentRelatedArtifact", artifactAssessmentRelatedArtifact);
+        parametersEval.addParameter("artifactAssessmentAuthor", artifactAssessmentAuthor);
+
+        return ourClient
+                .operation()
+                .onInstance(id)
+                .named("$approve")
+                .withParameters(parametersEval)
+                .returnResourceType(Bundle.class)
+                .execute();
+    }
+
+    @Test
+    void test_approve() {
+        loadResourceFromPath("ersd-active-library-example.json");
+        loadResourceFromPath("practitioner-example-for-refs.json");
+
+        var id = "Library/SpecificationLibrary";
+        var approvalDate = new Date();
+        var assessmentType = "comment";
+        var artifactAssessmentSummary = "comment text";
+        var artifactAssessmentTarget =
+                new CanonicalType("http://hl7.org/fhir/us/ecr/Library/SpecificationLibrary|1.0.0");
+        var artifactAssessmentRelatedArtifact = new CanonicalType("reference-valid-no-spaces");
+        var artifactAssessmentAuthor = new Reference("Practitioner/sample-practitioner");
+        var result = callApprove(
+                id,
+                approvalDate,
+                assessmentType,
+                artifactAssessmentSummary,
+                artifactAssessmentTarget,
+                artifactAssessmentRelatedArtifact,
+                artifactAssessmentAuthor);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(BundleTypeEnum.TRANSACTION_RESPONSE, BundleUtil.getBundleTypeEnum(fhirContext, result));
+
+        var artifactAssessment = result.getEntry().stream()
+                .filter(e -> e.hasResponse()
+                        && e.getResponse().hasLocation()
+                        && e.getResponse().getLocation().contains("Basic"))
+                .findFirst();
+        Assertions.assertTrue(artifactAssessment.isPresent());
+        var persisted = ourClient
+                .read()
+                .resource(Basic.class)
+                .withUrl(artifactAssessment.get().getResponse().getLocation())
+                .execute();
+        Assertions.assertNotNull(persisted);
+
+        Assertions.assertNotNull(persisted.getExtensionByUrl(ArtifactAssessment.ARTIFACT));
+        var artifactExtValue =
+                persisted.getExtensionByUrl(ArtifactAssessment.ARTIFACT).getValue();
+        Assertions.assertInstanceOf(Reference.class, artifactExtValue);
+        Assertions.assertEquals(id, ((Reference) artifactExtValue).getReference());
+
+        Assertions.assertNotNull(persisted.getExtensionByUrl(ArtifactAssessment.CONTENT));
+        var contentExt = persisted.getExtensionByUrl(ArtifactAssessment.CONTENT);
+        Assertions.assertTrue(contentExt.hasExtension(ArtifactAssessmentContentExtension.INFOTYPE));
+        var infoTypeExtValue = contentExt
+                .getExtensionByUrl(ArtifactAssessmentContentExtension.INFOTYPE)
+                .getValue();
+        Assertions.assertInstanceOf(CodeType.class, infoTypeExtValue);
+        Assertions.assertEquals(assessmentType, ((CodeType) infoTypeExtValue).getCode());
+        Assertions.assertTrue(contentExt.hasExtension(ArtifactAssessmentContentExtension.SUMMARY));
+        var summaryExtValue = contentExt
+                .getExtensionByUrl(ArtifactAssessmentContentExtension.SUMMARY)
+                .getValue();
+        Assertions.assertInstanceOf(MarkdownType.class, summaryExtValue);
+        Assertions.assertEquals(artifactAssessmentSummary, ((MarkdownType) summaryExtValue).getValueAsString());
+        Assertions.assertTrue(contentExt.hasExtension(ArtifactAssessmentContentExtension.RELATEDARTIFACT));
+        var relatedArtifactExtList = contentExt.getExtensionsByUrl(ArtifactAssessmentContentExtension.RELATEDARTIFACT);
+        Assertions.assertEquals(2, relatedArtifactExtList.size());
+        var citation = relatedArtifactExtList.stream()
+                .filter(e -> e.getValue() instanceof RelatedArtifact
+                        && ((RelatedArtifact) e.getValue()).hasType()
+                        && ((RelatedArtifact) e.getValue()).getType().equals(RelatedArtifactType.CITATION))
+                .findFirst();
+        Assertions.assertTrue(citation.isPresent());
+        var relatedArtifact = (RelatedArtifact) citation.get().getValue();
+        Assertions.assertInstanceOf(CanonicalType.class, relatedArtifact.getResourceElement());
+        Assertions.assertEquals(
+                "reference-valid-no-spaces",
+                relatedArtifact.getResourceElement().getValue());
+        var derivedFrom = relatedArtifactExtList.stream()
+                .filter(e -> e.getValue() instanceof RelatedArtifact
+                        && ((RelatedArtifact) e.getValue()).hasType()
+                        && ((RelatedArtifact) e.getValue()).getType().equals(RelatedArtifactType.DERIVEDFROM))
+                .findFirst();
+        Assertions.assertTrue(derivedFrom.isPresent());
+        relatedArtifact = (RelatedArtifact) derivedFrom.get().getValue();
+        Assertions.assertInstanceOf(CanonicalType.class, relatedArtifact.getResourceElement());
+        Assertions.assertEquals(
+                "http://hl7.org/fhir/us/ecr/Library/SpecificationLibrary|1.0.0",
+                relatedArtifact.getResourceElement().getValue());
+
+        Assertions.assertTrue(contentExt.hasExtension(ArtifactAssessmentContentExtension.AUTHOR));
+        var authorExtValue = contentExt
+                .getExtensionByUrl(ArtifactAssessmentContentExtension.AUTHOR)
+                .getValue();
+        Assertions.assertInstanceOf(Reference.class, authorExtValue);
+        Assertions.assertEquals("Practitioner/sample-practitioner", ((Reference) authorExtValue).getReference());
+
+        Assertions.assertNotNull(persisted.getExtensionByUrl(ArtifactAssessment.DATE));
+        var dateExtValue = persisted.getExtensionByUrl(ArtifactAssessment.DATE).getValue();
+        Assertions.assertInstanceOf(DateTimeType.class, dateExtValue);
+        Assertions.assertEquals(
+                approvalDate.toInstant().truncatedTo(ChronoUnit.DAYS),
+                ((DateTimeType) dateExtValue).getValue().toInstant().truncatedTo(ChronoUnit.DAYS));
+    }
+}

--- a/cqf-fhir-cr-hapi/src/test/resources/ersd-active-library-example.json
+++ b/cqf-fhir-cr-hapi/src/test/resources/ersd-active-library-example.json
@@ -1,0 +1,81 @@
+{
+	"resourceType": "Library",
+	"id": "SpecificationLibrary",
+	"meta": {
+		"profile": [
+			"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-specification-library"
+		]
+	},
+	"text": {
+		"status": "generated",
+		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: Library</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Library \"SpecificationLibrary\" Version \"1.0.0\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-specification-library.html\">US Public Health Specification Library</a></p></div><p><b>url</b>: <code>http://hl7.org/fhir/us/ecr/Library/SpecificationLibrary</code></p><p><b>version</b>: 1.0.0</p><p><b>name</b>: SpecificationLibrary</p><p><b>title</b>: Specification Library</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>type</b>: Asset Collection <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-library-type.html\">LibraryType</a>#asset-collection)</span></p><p><b>publisher</b>: eCR</p><p><b>description</b>: Defines the asset-collection library containing the US Public Health specification assets.</p></div>"
+	},
+	"url": "http://hl7.org/fhir/us/ecr/Library/SpecificationLibrary",
+	"version": "1.0.0",
+	"name": "SpecificationLibrary",
+	"title": "Specification Library",
+	"status": "active",
+	"experimental": true,
+	"type": {
+		"coding": [
+			{
+				"system": "http://terminology.hl7.org/CodeSystem/library-type",
+				"code": "asset-collection"
+			}
+		]
+	},
+	"publisher": "eCR",
+	"description": "Defines the asset-collection library containing the US Public Health specification assets.",
+	"useContext": [
+		{
+			"code": {
+				"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+				"code": "reporting"
+			},
+			"valueCodeableConcept": {
+				"coding": [
+					{
+						"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+						"code": "triggering"
+					}
+				]
+			}
+		},
+		{
+			"code": {
+				"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+				"code": "specification-type"
+			},
+			"valueCodeableConcept": {
+				"coding": [
+					{
+						"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+						"code": "program"
+					}
+				]
+			}
+		}
+	],
+	"relatedArtifact": [
+		{
+			"type": "composed-of",
+			"resource": "http://hl7.org/fhir/us/ecr/PlanDefinition/plandefinition-ersd-instance-example",
+			"extension":[
+				{
+					"url":"http://hl7.org/fhir/StructureDefinition/artifact-isOwned",
+					"valueBoolean": true
+				}
+			]
+		},
+		{
+			"type": "composed-of",
+			"resource": "http://hl7.org/fhir/us/ecr/Library/library-rctc-example",
+			"extension":[
+				{
+					"url":"http://hl7.org/fhir/StructureDefinition/artifact-isOwned",
+					"valueBoolean": true
+				}
+			]
+		}
+	]
+}

--- a/cqf-fhir-cr-hapi/src/test/resources/practitioner-example-for-refs.json
+++ b/cqf-fhir-cr-hapi/src/test/resources/practitioner-example-for-refs.json
@@ -1,0 +1,4 @@
+{
+        "resourceType":"Practitioner",
+        "id":"sample-practitioner"
+      }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/crmi/R4ApproveService.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/crmi/R4ApproveService.java
@@ -82,7 +82,7 @@ public class R4ApproveService {
                         "ArtifactAssessmentTarget version does not match version of resource being approved.");
             }
         } else {
-            String target = null;
+            String target = "";
             String url = resource.getUrl();
             String version = resource.getVersion();
             if (url != null) {
@@ -94,7 +94,7 @@ public class R4ApproveService {
                 }
                 target += version;
             }
-            if (target != null) {
+            if (!target.isEmpty()) {
                 artifactAssessmentTarget = new CanonicalType(target);
             }
         }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/crmi/R4ApproveService.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/crmi/R4ApproveService.java
@@ -1,0 +1,124 @@
+package org.opencds.cqf.fhir.cr.crmi;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import ca.uhn.fhir.repository.IRepository;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
+import java.util.Date;
+import org.hl7.fhir.instance.model.api.IPrimitiveType;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CanonicalType;
+import org.hl7.fhir.r4.model.DateType;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.MetadataResource;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Reference;
+import org.opencds.cqf.fhir.cr.visitor.ApproveVisitor;
+import org.opencds.cqf.fhir.utility.Canonicals;
+import org.opencds.cqf.fhir.utility.SearchHelper;
+import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
+
+public class R4ApproveService {
+
+    private final IAdapterFactory adapterFactory = IAdapterFactory.forFhirVersion(FhirVersionEnum.R4);
+
+    private final IRepository repository;
+
+    public R4ApproveService(IRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * The "approve" operation supports applying an approval to an existing artifact, all its
+     * children, regardless of status. The operation sets the date and approvalDate elements
+     * of the approved artifact and child artifacts, and is otherwise only allowed to create
+     * ArtifactAssessment (Basic or cqf-artifactComment extensions in R4) resources in the
+     * repository.
+     * The "approve" operation supports the ability of a repository to record commentary on a
+     * specific state of an artifact in an ArtifactAssessment (Basic or cqf-artifactComment
+     * extension in R4) resource by applying an approval. The artifact assessments which are added
+     * by the operation must reference a version of the artifact.
+     *
+     * @param id                                The logical id of the artifact to approved. The
+     *                                          server must know the artifact (e.g. it is defined
+     *                                          explicitly in the server's artifacts)
+     * @param approvalDate                      The date on which the artifact was approved. If one
+     *                                          is not provided the system date will be used.
+     * @param artifactAssessmentType            If a comment is submitted as part of the approval,
+     *                                          this parameter denotes the type of artifact comment.
+     * @param artifactAssessmentSummary         The body of the comment.
+     * @param artifactAssessmentTarget          The canonical {@link CanonicalType} url for the
+     *                                          artifact being approved. The format is:
+     *                                          [system]|[version] - e.g. http://loinc.org|2.56
+     * @param artifactAssessmentRelatedArtifact Optional supporting canonical {@link CanonicalType}
+     *                                          URL / Reference for the comment.
+     * @param artifactAssessmentAuthor          A {@link Reference} Reference to a resource
+     *                                          containing information about the entity applying
+     *                                          the approval.
+     * @return  The {@link Bundle} Bundle result containing all updated artifacts and the
+     *          ArtifactAssessment (Basic in R4) resource containing the Approval metadata
+     */
+    public Bundle approve(
+            IdType id,
+            IPrimitiveType<Date> approvalDate,
+            String artifactAssessmentType,
+            String artifactAssessmentSummary,
+            CanonicalType artifactAssessmentTarget,
+            CanonicalType artifactAssessmentRelatedArtifact,
+            Reference artifactAssessmentAuthor) {
+        var resource = (MetadataResource) SearchHelper.readRepository(repository, id);
+        if (resource == null) {
+            throw new ResourceNotFoundException(id);
+        }
+        if (artifactAssessmentTarget != null) {
+            if (Canonicals.getUrl(artifactAssessmentTarget) != null
+                    && !Canonicals.getUrl(artifactAssessmentTarget).equals(resource.getUrl())) {
+                throw new UnprocessableEntityException(
+                        "ArtifactAssessmentTarget URL does not match URL of resource being approved.");
+            }
+            if (Canonicals.getVersion(artifactAssessmentTarget) != null
+                    && !Canonicals.getVersion(artifactAssessmentTarget).equals(resource.getVersion())) {
+                throw new UnprocessableEntityException(
+                        "ArtifactAssessmentTarget version does not match version of resource being approved.");
+            }
+        } else {
+            String target = null;
+            String url = resource.getUrl();
+            String version = resource.getVersion();
+            if (url != null) {
+                target += url;
+            }
+            if (version != null) {
+                if (url != null) {
+                    target += "|";
+                }
+                target += version;
+            }
+            if (target != null) {
+                artifactAssessmentTarget = new CanonicalType(target);
+            }
+        }
+        var params = new Parameters();
+        if (approvalDate != null && approvalDate.hasValue()) {
+            params.addParameter("approvalDate", new DateType(approvalDate.getValue()));
+        }
+        if (artifactAssessmentType != null) {
+            params.addParameter("artifactAssessmentType", artifactAssessmentType);
+        }
+        if (artifactAssessmentTarget != null) {
+            params.addParameter("artifactAssessmentTarget", artifactAssessmentTarget);
+        }
+        if (artifactAssessmentSummary != null) {
+            params.addParameter("artifactAssessmentSummary", artifactAssessmentSummary);
+        }
+        if (artifactAssessmentRelatedArtifact != null) {
+            params.addParameter("artifactAssessmentRelatedArtifact", artifactAssessmentRelatedArtifact);
+        }
+        if (artifactAssessmentAuthor != null) {
+            params.addParameter("artifactAssessmentAuthor", artifactAssessmentAuthor);
+        }
+        var adapter = adapterFactory.createKnowledgeArtifactAdapter(resource);
+        var visitor = new ApproveVisitor(repository);
+        return ((Bundle) adapter.accept(visitor, params));
+    }
+}


### PR DESCRIPTION
- Added $approve operation provider and service
- Added the operation to the R4 CR config
- Added documentation
- TODO - Add tests, add operation name and operation definition URL to ProviderConstants in HAPI (or some other constants class), and run integration testing with eCR components

Motivation for this enhancement is tracked [here](https://github.com/DBCG/aphl-vsm/issues/526)