### PR TITLE
Fix expression evaluation issues

### DIFF
--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/retrieve/RepositoryRetrieveProvider.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/retrieve/RepositoryRetrieveProvider.java
@@ -17,6 +17,7 @@ import org.opencds.cqf.cql.engine.runtime.Code;
 import org.opencds.cqf.cql.engine.runtime.Interval;
 import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
 import org.opencds.cqf.fhir.utility.iterable.BundleMappingIterable;
+import org.opencds.cqf.fhir.utility.repository.InMemoryFhirRepository;
 import org.opencds.cqf.fhir.utility.repository.ig.IgRepository;
 
 public class RepositoryRetrieveProvider extends BaseRetrieveProvider {
@@ -137,5 +138,12 @@ public class RepositoryRetrieveProvider extends BaseRetrieveProvider {
     private class SearchConfig {
         public Map<String, List<IQueryParameterType>> searchParams = new HashMap<>();
         public Predicate<IBaseResource> filter = x -> true;
+    }
+
+    @Override
+    protected boolean inModifierSupported(String valueSet, String resourceName, String searchParamName) {
+        // The IN modifier is not currently supported by the ResourceMatcher used by the InMemoryRepository
+        return !(repository instanceof InMemoryFhirRepository)
+                && super.inModifierSupported(valueSet, resourceName, searchParamName);
     }
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/common/ExpressionProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/common/ExpressionProcessor.java
@@ -11,6 +11,7 @@ import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
+import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.CqfExpression;
 import org.slf4j.Logger;
@@ -84,7 +85,15 @@ public class ExpressionProcessor {
                                 request.getResourceVariable());
         return result == null
                 ? new ArrayList<>()
-                : result.stream().filter(Objects::nonNull).collect(Collectors.toList());
+                : result.stream()
+                        // Missing values are returned as a BooleanType with a null value which can cause
+                        // problems when the consumer of the result is expecting a specific result type,
+                        // so we are filtering out primitive types with no value.
+                        .map(r -> r instanceof IPrimitiveType<?> primitiveType && primitiveType.getValue() == null
+                                ? null
+                                : r)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
     }
 
     /**

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/QuestionnaireProcessorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/QuestionnaireProcessorTests.java
@@ -337,6 +337,6 @@ class QuestionnaireProcessorTests {
                 .itemHasAnswerValue(
                         "test-requested|diagnosis-description",
                         "Type 2 diabetes mellitus with other diabetic arthropathy")
-                .itemHasAnswer("history|other-findings");
+                .itemHasNoAnswer("history|other-findings");
     }
 }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/TestQuestionnaire.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/TestQuestionnaire.java
@@ -392,7 +392,12 @@ public class TestQuestionnaire {
         }
 
         public GeneratedQuestionnaireResponse itemHasAnswer(String linkId) {
-            assertTrue(!request.resolvePathList(items.get(linkId), "answer").isEmpty());
+            assertFalse(request.resolvePathList(items.get(linkId), "answer").isEmpty());
+            return this;
+        }
+
+        public GeneratedQuestionnaireResponse itemHasNoAnswer(String linkId) {
+            assertTrue(request.resolvePathList(items.get(linkId), "answer").isEmpty());
             return this;
         }
 


### PR DESCRIPTION
Resolved an issue when the result of an expression evaluation is null and the consumer is expecting the result to be a specific type.

Resolved an issue when an expression resulted in a query using the 'IN' modifier while using an In Memory Repository.