### PR TITLE
Change return type of $evaluate operation to a Parameters resource

### DIFF
--- a/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/r4/measure/MeasureOperationsProvider.java
+++ b/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/r4/measure/MeasureOperationsProvider.java
@@ -130,10 +130,10 @@ public class MeasureOperationsProvider {
      *                               referenced by the Measure.
      * @param parameters      additional parameters for evaluation
      * @param reporter        The reporter for this evaluation, if applicable.
-     * @return a Bundle containing multiple MeasureReports, one for each Measure evaluated.
+     * @return a Parameters resource containing a Bundle for each Measure evaluated.
      */
     @Operation(name = ProviderConstants.CR_OPERATION_EVALUATE, idempotent = true, type = Measure.class)
-    public Bundle evaluate(
+    public Parameters evaluate(
             @OperationParam(name = "measureId") List<IdType> measureId,
             @OperationParam(name = "measureUrl") List<String> measureUrl,
             @OperationParam(name = "measureIdentifier") List<String> measureIdentifier,

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsBundleBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsBundleBuilder.java
@@ -19,6 +19,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import jakarta.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -120,8 +121,11 @@ public class R4CareGapsBundleBuilder {
                     reporter);
 
             var entries = result.getParameter().stream()
-                    .map(p -> ((Bundle) p.getResource()))
-                    .flatMap(b -> b.getEntry().stream())
+                    .map(ParametersParameterComponent::getResource)
+                    .filter(Bundle.class::isInstance)
+                    .map(Bundle.class::cast)
+                    .map(Bundle::getEntry)
+                    .flatMap(Collection::stream)
                     .toList();
 
             // Patient, subject comes in as format "ResourceType/[id]", no resourceType required to be specified.

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureEvaluatorMultiple.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureEvaluatorMultiple.java
@@ -14,7 +14,7 @@ import org.hl7.fhir.r4.model.Parameters;
  */
 public interface R4MeasureEvaluatorMultiple {
 
-    Bundle evaluate(
+    Parameters evaluate(
             List<IdType> measureId,
             List<String> measureUrl,
             List<String> measureIdentifier,

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MultiMeasureService.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MultiMeasureService.java
@@ -109,10 +109,6 @@ public class R4MultiMeasureService implements R4MeasureEvaluatorMultiple {
 
         // create parameters
         var result = new Parameters();
-        //        // create bundle
-        //        Bundle bundle = new BundleBuilder<>(Bundle.class)
-        //                .withType(BundleType.SEARCHSET.toString())
-        //                .build();
 
         var context = Engines.forRepository(
                 r4ProcessorToUse.getRepository(),

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MultiMeasureService.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MultiMeasureService.java
@@ -34,7 +34,7 @@ import org.opencds.cqf.fhir.utility.repository.Repositories;
  * Alternate MeasureService call to Process MeasureEvaluation for the selected population of subjects against n-number
  * of measure resources. The output of this operation would be a bundle of MeasureReports instead of MeasureReport.
  */
-@SuppressWarnings("squid:S107")
+@SuppressWarnings({"squid:S107", "UnstableApiUsage"})
 public class R4MultiMeasureService implements R4MeasureEvaluatorMultiple {
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(R4MultiMeasureService.class);
@@ -64,7 +64,7 @@ public class R4MultiMeasureService implements R4MeasureEvaluatorMultiple {
     }
 
     @Override
-    public Bundle evaluate(
+    public Parameters evaluate(
             List<IdType> measureId,
             List<String> measureUrl,
             List<String> measureIdentifier,
@@ -107,10 +107,12 @@ public class R4MultiMeasureService implements R4MeasureEvaluatorMultiple {
         // get subjects
         var subjects = getSubjects(subjectProvider, subject);
 
-        // create bundle
-        Bundle bundle = new BundleBuilder<>(Bundle.class)
-                .withType(BundleType.SEARCHSET.toString())
-                .build();
+        // create parameters
+        var result = new Parameters();
+        //        // create bundle
+        //        Bundle bundle = new BundleBuilder<>(Bundle.class)
+        //                .withType(BundleType.SEARCHSET.toString())
+        //                .build();
 
         var context = Engines.forRepository(
                 r4ProcessorToUse.getRepository(),
@@ -128,7 +130,7 @@ public class R4MultiMeasureService implements R4MeasureEvaluatorMultiple {
                     r4MeasureServiceUtilsToUse,
                     compositeEvaluationResultsPerMeasure,
                     context,
-                    bundle,
+                    result,
                     measures,
                     periodStart,
                     periodEnd,
@@ -144,7 +146,7 @@ public class R4MultiMeasureService implements R4MeasureEvaluatorMultiple {
                     r4MeasureServiceUtilsToUse,
                     compositeEvaluationResultsPerMeasure,
                     context,
-                    bundle,
+                    result,
                     measures,
                     periodStart,
                     periodEnd,
@@ -155,7 +157,7 @@ public class R4MultiMeasureService implements R4MeasureEvaluatorMultiple {
                     reporter);
         }
 
-        return bundle;
+        return result;
     }
 
     protected void populationMeasureReport(
@@ -163,7 +165,7 @@ public class R4MultiMeasureService implements R4MeasureEvaluatorMultiple {
             R4MeasureServiceUtils r4MeasureServiceUtils,
             CompositeEvaluationResultsPerMeasure compositeEvaluationResultsPerMeasure,
             CqlEngine context,
-            Bundle bundle,
+            Parameters result,
             List<Measure> measures,
             @Nullable ZonedDateTime periodStart,
             @Nullable ZonedDateTime periodEnd,
@@ -202,8 +204,14 @@ public class R4MultiMeasureService implements R4MeasureEvaluatorMultiple {
             // add id to measureReport
             initializeReport(measureReport);
 
+            // create bundle
+            Bundle bundle = new BundleBuilder<>(Bundle.class)
+                    .withType(BundleType.SEARCHSET.toString())
+                    .build();
             // add report to bundle
             bundle.addEntry(getBundleEntry(serverBase, measureReport));
+            // add bundle to result
+            result.addParameter().setName("return").setResource(bundle);
 
             // progress feedback
             var measureUrl = measureReport.getMeasure();
@@ -221,7 +229,7 @@ public class R4MultiMeasureService implements R4MeasureEvaluatorMultiple {
             R4MeasureServiceUtils r4MeasureServiceUtils,
             CompositeEvaluationResultsPerMeasure compositeEvaluationResultsPerMeasure,
             CqlEngine context,
-            Bundle bundle,
+            Parameters result,
             List<Measure> measures,
             @Nullable ZonedDateTime periodStart,
             @Nullable ZonedDateTime periodEnd,
@@ -263,8 +271,14 @@ public class R4MultiMeasureService implements R4MeasureEvaluatorMultiple {
                 // add id to measureReport
                 initializeReport(measureReport);
 
+                // create bundle
+                Bundle bundle = new BundleBuilder<>(Bundle.class)
+                        .withType(BundleType.SEARCHSET.toString())
+                        .build();
                 // add report to bundle
                 bundle.addEntry(getBundleEntry(serverBase, measureReport));
+                // add bundle to result
+                result.addParameter().setName("return").setResource(bundle);
 
                 // progress feedback
                 var measureUrl = measureReport.getMeasure();

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasure.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasure.java
@@ -174,7 +174,7 @@ class MultiMeasure {
         private Bundle additionalData;
         private Parameters parameters;
 
-        private Supplier<Bundle> operation;
+        private Supplier<Parameters> operation;
         private String productLine;
         private String reporter;
 
@@ -264,24 +264,25 @@ class MultiMeasure {
         }
     }
 
-    public static class SelectedReport extends MultiMeasure.Selected<Bundle, Void> {
+    public static class SelectedReport extends MultiMeasure.Selected<Parameters, Void> {
 
-        public SelectedReport(Bundle report) {
+        public SelectedReport(Parameters report) {
             super(report, null);
         }
 
-        public Bundle report() {
+        public Parameters report() {
             return this.value();
         }
 
         public MultiMeasure.SelectedReport hasMeasureReportCount(int count) {
-            assertEquals(count, report().getEntry().size());
+            assertEquals(count, report().getParameter().size());
             return this;
         }
 
         public MultiMeasure.SelectedReport hasMeasureReportCountPerUrl(int count, String measureUrl) {
-            var reports = report().getEntry().stream()
-                    .map(t -> (MeasureReport) t.getResource())
+            var reports = report().getParameter().stream()
+                    .map(p -> ((Bundle) p.getResource()))
+                    .map(t -> (MeasureReport) t.getEntryFirstRep().getResource())
                     .filter(x -> x.getMeasure().equals(measureUrl))
                     .toList();
             var msg =
@@ -291,14 +292,15 @@ class MultiMeasure {
             return this;
         }
 
-        public SelectedMeasureReport measureReport(MultiMeasure.Selector<MeasureReport, Bundle> bundleSelector) {
+        public SelectedMeasureReport measureReport(MultiMeasure.Selector<MeasureReport, Parameters> bundleSelector) {
             var p = bundleSelector.select(value());
             return new SelectedMeasureReport(p, this);
         }
 
         public SelectedMeasureReport measureReport(String measureUrl) {
             return this.measureReport(g -> resourceToMeasureReport(
-                    g.getEntry().stream()
+                    g.getParameter().stream()
+                            .flatMap(p -> ((Bundle) p.getResource()).getEntry().stream())
                             .filter(x ->
                                     x.getResource().getResourceType().toString().equals("MeasureReport"))
                             .toList(),
@@ -307,7 +309,8 @@ class MultiMeasure {
 
         public SelectedMeasureReport measureReport(String measureUrl, String subject) {
             return this.measureReport(g -> resourceToMeasureReport(
-                    g.getEntry().stream()
+                    g.getParameter().stream()
+                            .flatMap(p -> ((Bundle) p.getResource()).getEntry().stream())
                             .filter(x ->
                                     x.getResource().getResourceType().toString().equals("MeasureReport"))
                             .toList(),
@@ -316,12 +319,16 @@ class MultiMeasure {
         }
 
         public SelectedMeasureReport getFirstMeasureReport() {
-            var mr = (MeasureReport) report().getEntryFirstRep().getResource();
+            var mr = (MeasureReport) ((Bundle) report().getParameterFirstRep().getResource())
+                    .getEntryFirstRep()
+                    .getResource();
             return this.measureReport(g -> mr);
         }
 
         public SelectedMeasureReport getSecondMeasureReport() {
-            var entries = report().getEntry();
+            var entries = report().getParameter().stream()
+                    .flatMap(p -> ((Bundle) p.getResource()).getEntry().stream())
+                    .toList();
             if (entries.size() < 2) {
                 fail("There are not enough entries in the report to get the second one.");
             }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasure.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasure.java
@@ -35,6 +35,7 @@ import org.hl7.fhir.r4.model.MeasureReport.StratifierGroupComponent;
 import org.hl7.fhir.r4.model.MeasureReport.StratifierGroupPopulationComponent;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
@@ -281,7 +282,9 @@ class MultiMeasure {
 
         public MultiMeasure.SelectedReport hasMeasureReportCountPerUrl(int count, String measureUrl) {
             var reports = report().getParameter().stream()
-                    .map(p -> ((Bundle) p.getResource()))
+                    .map(ParametersParameterComponent::getResource)
+                    .filter(Bundle.class::isInstance)
+                    .map(Bundle.class::cast)
                     .map(t -> (MeasureReport) t.getEntryFirstRep().getResource())
                     .filter(x -> x.getMeasure().equals(measureUrl))
                     .toList();


### PR DESCRIPTION
Change the return type of the Measure/$evaluate operation to match the DEQM STU5 publication and always return a Parameters resource with a Bundle for each Measure/Subject being evaluated.

#682 