### PR TITLE
Add adapters for Questionnaire and QuestionnaireResponse items

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/common/ExpressionProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/common/ExpressionProcessor.java
@@ -14,6 +14,7 @@ import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.CqfExpression;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -148,7 +149,7 @@ public class ExpressionProcessor {
      * @param item the item
      * @return a CqfExpression
      */
-    public CqfExpression getItemInitialExpression(IOperationRequest request, IBaseBackboneElement item) {
+    public CqfExpression getItemInitialExpression(IOperationRequest request, IQuestionnaireItemComponentAdapter item) {
         if (!item.hasExtension()) {
             return null;
         }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/common/ExtensionBuilders.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/common/ExtensionBuilders.java
@@ -18,8 +18,8 @@ public class ExtensionBuilders {
         return new SimpleEntry<>(Constants.SDC_QUESTIONNAIRE_PREPOPULATE_SUBJECT, patientCode + "/" + patientId);
     }
 
-    public static SimpleEntry<String, String> crmiMessagesExtension(String operationOutcomeId) {
-        return new SimpleEntry<>(Constants.EXT_CRMI_MESSAGES, operationOutcomeId);
+    public static SimpleEntry<String, String> cqfMessagesExtension(String operationOutcomeId) {
+        return new SimpleEntry<>(Constants.CQF_MESSAGES, operationOutcomeId);
     }
 
     public static SimpleEntry<String, String> dtrQuestionnaireResponseExtension(String questionnaireId) {
@@ -38,17 +38,12 @@ public class ExtensionBuilders {
     public static <T extends IBaseExtension<?, ?>> T buildReferenceExt(
             FhirVersionEnum fhirVersion, SimpleEntry<String, String> entry, Boolean isContained) {
         var value = buildReference(fhirVersion, entry.getValue(), isContained);
-        switch (fhirVersion) {
-            case DSTU3:
-                return (T) new org.hl7.fhir.dstu3.model.Extension(entry.getKey(), value);
-            case R4:
-                return (T) new org.hl7.fhir.r4.model.Extension(entry.getKey(), value);
-            case R5:
-                return (T) new org.hl7.fhir.r5.model.Extension(entry.getKey(), value);
-
-            default:
-                return null;
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> (T) new org.hl7.fhir.dstu3.model.Extension(entry.getKey(), value);
+            case R4 -> (T) new org.hl7.fhir.r4.model.Extension(entry.getKey(), value);
+            case R5 -> (T) new org.hl7.fhir.r5.model.Extension(entry.getKey(), value);
+            default -> null;
+        };
     }
 
     public static IBaseReference buildReference(FhirVersionEnum fhirVersion, String id) {
@@ -57,48 +52,33 @@ public class ExtensionBuilders {
 
     public static IBaseReference buildReference(FhirVersionEnum fhirVersion, String id, Boolean isContained) {
         var reference = Boolean.TRUE.equals(isContained) ? "#".concat(id) : id;
-        switch (fhirVersion) {
-            case DSTU3:
-                return new org.hl7.fhir.dstu3.model.Reference(reference);
-            case R4:
-                return new org.hl7.fhir.r4.model.Reference(reference);
-            case R5:
-                return new org.hl7.fhir.r5.model.Reference(reference);
-
-            default:
-                return null;
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> new org.hl7.fhir.dstu3.model.Reference(reference);
+            case R4 -> new org.hl7.fhir.r4.model.Reference(reference);
+            case R5 -> new org.hl7.fhir.r5.model.Reference(reference);
+            default -> null;
+        };
     }
 
     public static IBaseBooleanDatatype buildBooleanType(FhirVersionEnum fhirVersion, Boolean value) {
-        switch (fhirVersion) {
-            case DSTU3:
-                return new org.hl7.fhir.dstu3.model.BooleanType(value);
-            case R4:
-                return new org.hl7.fhir.r4.model.BooleanType(value);
-            case R5:
-                return new org.hl7.fhir.r5.model.BooleanType(value);
-
-            default:
-                return null;
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> new org.hl7.fhir.dstu3.model.BooleanType(value);
+            case R4 -> new org.hl7.fhir.r4.model.BooleanType(value);
+            case R5 -> new org.hl7.fhir.r5.model.BooleanType(value);
+            default -> null;
+        };
     }
 
     @SuppressWarnings("unchecked")
     public static <T extends IBaseExtension<?, ?>> T buildBooleanExt(
             FhirVersionEnum fhirVersion, SimpleEntry<String, Boolean> entry) {
         var value = buildBooleanType(fhirVersion, entry.getValue());
-        switch (fhirVersion) {
-            case DSTU3:
-                return (T) new org.hl7.fhir.dstu3.model.Extension(entry.getKey(), value);
-            case R4:
-                return (T) new org.hl7.fhir.r4.model.Extension(entry.getKey(), value);
-            case R5:
-                return (T) new org.hl7.fhir.r5.model.Extension(entry.getKey(), value);
-
-            default:
-                return null;
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> (T) new org.hl7.fhir.dstu3.model.Extension(entry.getKey(), value);
+            case R4 -> (T) new org.hl7.fhir.r4.model.Extension(entry.getKey(), value);
+            case R5 -> (T) new org.hl7.fhir.r5.model.Extension(entry.getKey(), value);
+            default -> null;
+        };
     }
 
     public static <T extends IBaseExtension<?, ?>> T buildSdcLaunchContextExt(
@@ -145,14 +125,12 @@ public class ExtensionBuilders {
             case R4:
                 var r4Ext = new org.hl7.fhir.r4.model.Extension(Constants.SDC_QUESTIONNAIRE_LAUNCH_CONTEXT);
                 r4Ext.addExtension("name", new org.hl7.fhir.r4.model.Coding(system, code, display));
-                acceptedResourceTypes.stream()
-                        .forEach(r -> r4Ext.addExtension("type", new org.hl7.fhir.r4.model.CodeType(r)));
+                acceptedResourceTypes.forEach(r -> r4Ext.addExtension("type", new org.hl7.fhir.r4.model.CodeType(r)));
                 return (T) r4Ext;
             case R5:
                 var r5Ext = new org.hl7.fhir.r5.model.Extension(Constants.SDC_QUESTIONNAIRE_LAUNCH_CONTEXT);
                 r5Ext.addExtension("name", new org.hl7.fhir.r5.model.Coding(system, code, display));
-                acceptedResourceTypes.stream()
-                        .forEach(r -> r5Ext.addExtension("type", new org.hl7.fhir.r5.model.CodeType(r)));
+                acceptedResourceTypes.forEach(r -> r5Ext.addExtension("type", new org.hl7.fhir.r5.model.CodeType(r)));
                 return (T) r5Ext;
 
             default:

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/common/IOperationRequest.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/common/IOperationRequest.java
@@ -1,7 +1,7 @@
 package org.opencds.cqf.fhir.cr.common;
 
 import static org.opencds.cqf.fhir.cr.common.ExtensionBuilders.buildReferenceExt;
-import static org.opencds.cqf.fhir.cr.common.ExtensionBuilders.crmiMessagesExtension;
+import static org.opencds.cqf.fhir.cr.common.ExtensionBuilders.cqfMessagesExtension;
 import static org.opencds.cqf.fhir.utility.OperationOutcomes.addExceptionToOperationOutcome;
 import static org.opencds.cqf.fhir.utility.OperationOutcomes.newOperationOutcome;
 
@@ -68,7 +68,7 @@ public interface IOperationRequest {
                             "extension",
                             Collections.singletonList(buildReferenceExt(
                                     getFhirVersion(),
-                                    crmiMessagesExtension(
+                                    cqfMessagesExtension(
                                             getOperationOutcome().getIdElement().getIdPart()),
                                     true)));
         }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/common/IQuestionnaireRequest.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/common/IQuestionnaireRequest.java
@@ -66,12 +66,4 @@ public interface IQuestionnaireRequest extends ICqlOperationRequest {
             }
         });
     }
-
-    //    default List<IBaseBackboneElement> getItems(IBase base) {
-    //        return resolvePathList(base, "item", IBaseBackboneElement.class);
-    //    }
-    //
-    //    default boolean hasItems(IBase base) {
-    //        return !getItems(base).isEmpty();
-    //    }
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/common/IQuestionnaireRequest.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/common/IQuestionnaireRequest.java
@@ -5,7 +5,6 @@ import static org.opencds.cqf.fhir.utility.VersionUtilities.canonicalTypeForVers
 import java.util.Collections;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
-import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -68,15 +67,11 @@ public interface IQuestionnaireRequest extends ICqlOperationRequest {
         });
     }
 
-    default List<IBaseBackboneElement> getItems(IBase base) {
-        return resolvePathList(base, "item", IBaseBackboneElement.class);
-    }
-
-    default boolean hasItems(IBase base) {
-        return !getItems(base).isEmpty();
-    }
-
-    default String getItemLinkId(IBaseBackboneElement item) {
-        return resolvePathString(item, "linkId");
-    }
+    //    default List<IBaseBackboneElement> getItems(IBase base) {
+    //        return resolvePathList(base, "item", IBaseBackboneElement.class);
+    //    }
+    //
+    //    default boolean hasItems(IBase base) {
+    //        return !getItems(base).isEmpty();
+    //    }
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/common/IQuestionnaireRequest.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/common/IQuestionnaireRequest.java
@@ -2,16 +2,15 @@ package org.opencds.cqf.fhir.cr.common;
 
 import static org.opencds.cqf.fhir.utility.VersionUtilities.canonicalTypeForVersion;
 
-import java.util.Collections;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IDomainResource;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
 
 /**
  * This interface exposes common functionality across Operations that use Questionnaires
@@ -21,8 +20,10 @@ public interface IQuestionnaireRequest extends ICqlOperationRequest {
 
     IQuestionnaireAdapter getQuestionnaireAdapter();
 
-    default void addQuestionnaireItem(IBaseBackboneElement item) {
-        getModelResolver().setValue(getQuestionnaire(), "item", Collections.singletonList(item));
+    default void addQuestionnaireItem(IQuestionnaireItemComponentAdapter item) {
+        if (getQuestionnaireAdapter() != null) {
+            getQuestionnaireAdapter().addItem(item);
+        }
     }
 
     default <T extends IBaseExtension<?, ?>> void addLaunchContextExtensions(List<T> launchContextExts) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/common/ItemValueTransformer.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/common/ItemValueTransformer.java
@@ -2,9 +2,19 @@ package org.opencds.cqf.fhir.cr.common;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseDatatype;
 
 public class ItemValueTransformer {
     private ItemValueTransformer() {}
+
+    public static IBaseDatatype transformValueToItem(FhirVersionEnum fhirVersion, IBase value) {
+        return switch (fhirVersion) {
+            case DSTU3 -> transformValueToItem((org.hl7.fhir.dstu3.model.Type) value);
+            case R4 -> transformValueToItem((org.hl7.fhir.r4.model.Type) value);
+            case R5 -> transformValueToItem((org.hl7.fhir.r5.model.DataType) value);
+            default -> null;
+        };
+    }
 
     public static org.hl7.fhir.dstu3.model.Type transformValueToItem(org.hl7.fhir.dstu3.model.Type value) {
         if (value instanceof org.hl7.fhir.dstu3.model.CodeableConcept codeType) {
@@ -55,17 +65,12 @@ public class ItemValueTransformer {
     }
 
     public static IBase transformValueToResource(FhirVersionEnum fhirVersion, IBase value) {
-        switch (fhirVersion) {
-            case DSTU3:
-                return transformValueToResource((org.hl7.fhir.dstu3.model.Type) value);
-            case R4:
-                return transformValueToResource((org.hl7.fhir.r4.model.Type) value);
-            case R5:
-                return transformValueToResource((org.hl7.fhir.r5.model.DataType) value);
-
-            default:
-                return null;
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> transformValueToResource((org.hl7.fhir.dstu3.model.Type) value);
+            case R4 -> transformValueToResource((org.hl7.fhir.r4.model.Type) value);
+            case R5 -> transformValueToResource((org.hl7.fhir.r5.model.DataType) value);
+            default -> null;
+        };
     }
 
     public static org.hl7.fhir.dstu3.model.Type transformValueToResource(org.hl7.fhir.dstu3.model.Type value) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/PlanDefinitionProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/PlanDefinitionProcessor.java
@@ -36,7 +36,7 @@ import org.opencds.cqf.fhir.utility.client.TerminologyServerClientSettings;
 import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 import org.opencds.cqf.fhir.utility.monad.Either3;
 
-@SuppressWarnings({"squid:S107", "squid:S1172"})
+@SuppressWarnings({"squid:S107", "squid:S1172", "UnstableApiUsage"})
 public class PlanDefinitionProcessor {
     protected final ModelResolver modelResolver;
     protected final FhirVersionEnum fhirVersion;

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ApplyProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ApplyProcessor.java
@@ -109,8 +109,8 @@ public class ApplyProcessor implements IApplyProcessor {
         for (var resource : request.getRequestResources()) {
             addEntry(resultBundle, newEntryWithResource(resource));
         }
-        // if (!request.getItems(request.getQuestionnaire()).isEmpty()) {
-        if (!request.getQuestionnaireAdapter().getItem().isEmpty()) {
+        if (request.getQuestionnaireAdapter() != null
+                && !request.getQuestionnaireAdapter().getItem().isEmpty()) {
             addEntry(resultBundle, newEntryWithResource(request.getQuestionnaire()));
             addEntry(resultBundle, newEntryWithResource(populateProcessor.populate(request.toPopulateRequest())));
         }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ApplyProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ApplyProcessor.java
@@ -32,6 +32,7 @@ import org.opencds.cqf.fhir.utility.monad.Eithers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("UnstableApiUsage")
 public class ApplyProcessor implements IApplyProcessor {
     private static final Logger logger = LoggerFactory.getLogger(ApplyProcessor.class);
     protected static final List<String> EXCLUDED_EXTENSION_LIST = Arrays.asList(
@@ -108,7 +109,8 @@ public class ApplyProcessor implements IApplyProcessor {
         for (var resource : request.getRequestResources()) {
             addEntry(resultBundle, newEntryWithResource(resource));
         }
-        if (!request.getItems(request.getQuestionnaire()).isEmpty()) {
+        // if (!request.getItems(request.getQuestionnaire()).isEmpty()) {
+        if (!request.getQuestionnaireAdapter().getItem().isEmpty()) {
             addEntry(resultBundle, newEntryWithResource(request.getQuestionnaire()));
             addEntry(resultBundle, newEntryWithResource(populateProcessor.populate(request.toPopulateRequest())));
         }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ApplyRequest.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ApplyRequest.java
@@ -28,7 +28,6 @@ import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.ICompositeType;
-import org.hl7.fhir.instance.model.api.IDomainResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.fhir.cql.LibraryEngine;
@@ -62,7 +61,6 @@ public class ApplyRequest implements ICpgRequest {
     private final Collection<IBaseResource> requestResources;
     private final Collection<IBaseResource> extractedResources;
     private IBaseOperationOutcome operationOutcome;
-    private IBaseResource questionnaire;
     private IQuestionnaireAdapter questionnaireAdapter;
     private Boolean containResources;
 
@@ -140,7 +138,7 @@ public class ApplyRequest implements ICpgRequest {
                         libraryEngine,
                         modelResolver,
                         inputParameterResolver)
-                .setQuestionnaire(questionnaire)
+                .setQuestionnaire(getQuestionnaire())
                 .setContainResources(containResources);
     }
 
@@ -166,7 +164,7 @@ public class ApplyRequest implements ICpgRequest {
     public GenerateRequest toGenerateRequest(IBaseResource profile) {
         return new GenerateRequest(profile, false, true, libraryEngine, modelResolver)
                 .setReferencedLibraries(referencedLibraries)
-                .setQuestionnaire(questionnaire);
+                .setQuestionnaire(getQuestionnaire());
     }
 
     public PopulateRequest toPopulateRequest() {
@@ -201,7 +199,7 @@ public class ApplyRequest implements ICpgRequest {
                     newPart(getFhirContext(), "Reference", "content", value)));
         });
         return new PopulateRequest(
-                questionnaire, subjectId, context, null, parameters, data, libraryEngine, modelResolver);
+                questionnaireAdapter.get(), subjectId, context, null, parameters, data, libraryEngine, modelResolver);
     }
 
     public IBaseResource getPlanDefinition() {
@@ -305,20 +303,17 @@ public class ApplyRequest implements ICpgRequest {
 
     @Override
     public IBaseResource getQuestionnaire() {
-        return questionnaire;
+        return questionnaireAdapter == null ? null : questionnaireAdapter.get();
     }
 
     @Override
     public IQuestionnaireAdapter getQuestionnaireAdapter() {
-        if (questionnaireAdapter == null && questionnaire != null) {
-            questionnaireAdapter = (IQuestionnaireAdapter)
-                    getAdapterFactory().createKnowledgeArtifactAdapter((IDomainResource) questionnaire);
-        }
         return questionnaireAdapter;
     }
 
     public ApplyRequest setQuestionnaire(IBaseResource questionnaire) {
-        this.questionnaire = questionnaire;
+        questionnaireAdapter =
+                questionnaire == null ? null : getAdapterFactory().createQuestionnaire(questionnaire);
         return this;
     }
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ProcessAction.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ProcessAction.java
@@ -26,6 +26,7 @@ import org.opencds.cqf.fhir.utility.Constants.CqfApplicabilityBehavior;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("UnstableApiUsage")
 public class ProcessAction {
     private static final Logger logger = LoggerFactory.getLogger(ProcessAction.class);
 
@@ -124,10 +125,11 @@ public class ProcessAction {
                 if (item != null) {
                     // If input has text extension use it to override
                     if (request.hasExtension(input, Constants.CPG_INPUT_TEXT)) {
-                        var itemText =
-                                ((IPrimitiveType<String>) request.getExtensionByUrl(input, Constants.CPG_INPUT_TEXT)
-                                        .getValue());
-                        request.getModelResolver().setValue(item.getLeft(), "text", itemText);
+                        item.getLeft()
+                                .setText(((IPrimitiveType<String>)
+                                                request.getExtensionByUrl(input, Constants.CPG_INPUT_TEXT)
+                                                        .getValue())
+                                        .getValueAsString());
                         // item Constants.CPG_INPUT_DESCRIPTION
                     }
                     request.addQuestionnaireItem(item.getLeft());

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ResponseBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ResponseBuilder.java
@@ -153,7 +153,7 @@ public class ResponseBuilder {
                 .toList();
         for (var operationOutcome : operationOutcomes) {
             carePlan.addExtension(
-                    Constants.EXT_CRMI_MESSAGES,
+                    Constants.CQF_MESSAGES,
                     new org.hl7.fhir.dstu3.model.Reference(
                             "#" + operationOutcome.getIdElement().getIdPart()));
         }
@@ -204,7 +204,7 @@ public class ResponseBuilder {
                 .toList();
         for (var operationOutcome : operationOutcomes) {
             carePlan.addExtension(
-                    Constants.EXT_CRMI_MESSAGES,
+                    Constants.CQF_MESSAGES,
                     new org.hl7.fhir.r4.model.Reference(
                             "#" + operationOutcome.getIdElement().getIdPart()));
         }
@@ -259,7 +259,7 @@ public class ResponseBuilder {
                 .toList();
         for (var operationOutcome : operationOutcomes) {
             carePlan.addExtension(
-                    Constants.EXT_CRMI_MESSAGES,
+                    Constants.CQF_MESSAGES,
                     new org.hl7.fhir.r5.model.Reference(
                             "#" + operationOutcome.getIdElement().getIdPart()));
         }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/Helpers.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/Helpers.java
@@ -1,103 +1,44 @@
 package org.opencds.cqf.fhir.cr.questionnaire;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
+import org.apache.commons.lang3.StringUtils;
 
 public class Helpers {
+    private static final String CHOICE = "choice";
+    private static final String QUESTION = "question";
+    private static final String GROUP = "group";
+    private static final String URL = "url";
+    private static final String QUANTITY = "quantity";
+    private static final String REFERENCE = "reference";
+    private static final String STRING = "string";
+    private static final String INTEGER = "integer";
+    private static final String DATETIME = "dateTime";
+
     private Helpers() {}
 
-    public static Object parseItemTypeForVersion(
+    public static String parseItemTypeForVersion(
             FhirVersionEnum fhirVersion, String typeCode, Boolean hasBinding, Boolean isGroup) {
-        switch (fhirVersion) {
-            case R4:
-                return parseR4ItemType(typeCode, hasBinding, isGroup);
-            case R5:
-                return parseR5ItemType(typeCode, hasBinding, isGroup);
-
-            default:
-                throw new IllegalArgumentException("unsupported FHIR version: %s".formatted(fhirVersion));
-        }
-    }
-
-    public static org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType parseR4ItemType(
-            String elementType, Boolean hasBinding, Boolean isGroup) {
         if (Boolean.TRUE.equals(hasBinding)) {
-            return org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.CHOICE;
+            return fhirVersion.isEqualOrNewerThan(FhirVersionEnum.R5) ? QUESTION : CHOICE;
         }
         if (Boolean.TRUE.equals(isGroup)) {
-            return org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.GROUP;
+            return GROUP;
         }
-        if (elementType == null) {
+        if (StringUtils.isBlank(typeCode)) {
             return null;
         }
-        switch (elementType) {
-            case "code", "coding", "CodeableConcept":
-                return org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.CHOICE;
-            case "uri", "url", "canonical":
-                return org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.URL;
-            case "Quantity":
-                return org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.QUANTITY;
-            case "Reference":
-                return org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.REFERENCE;
-            case "id", "oid", "uuid", "base64Binary", "Identifier", "Extension":
-                return org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.STRING;
-            case "positiveInt", "unsignedInt":
-                return org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.INTEGER;
-            case "instant":
-                return org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.DATETIME;
-            default:
-                return org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.fromCode(elementType);
-        }
-    }
-
-    public static org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType parseR5ItemType(
-            String elementType, Boolean hasBinding, Boolean isGroup) {
-        if (Boolean.TRUE.equals(hasBinding)) {
-            return org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.QUESTION;
-        }
-        if (Boolean.TRUE.equals(isGroup)) {
-            return org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.GROUP;
-        }
-        if (elementType == null) {
-            return null;
-        }
-        switch (elementType) {
-            case "code", "coding", "CodeableConcept":
-                return org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.QUESTION;
-            case "uri", "url", "canonical":
-                return org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.URL;
-            case "Quantity":
-                return org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.QUANTITY;
-            case "Reference":
-                return org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.REFERENCE;
-            case "id", "oid", "uuid", "base64Binary", "Identifier", "Extension":
-                return org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.STRING;
-            case "positiveInt", "unsignedInt":
-                return org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.INTEGER;
-            case "instant":
-                return org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.DATETIME;
-            default:
-                return org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.fromCode(elementType);
-        }
-    }
-
-    public static boolean isGroupItemType(Object itemType) {
-        if (itemType instanceof org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType r4ItemType) {
-            return r4ItemType == org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.GROUP;
-        }
-        if (itemType instanceof org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType r5ItemType) {
-            return r5ItemType == org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.GROUP;
-        }
-        return false;
-    }
-
-    public static boolean isChoiceItemType(Object itemType) {
-        if (itemType instanceof org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType r4ItemType) {
-            return r4ItemType == org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.CHOICE;
-        }
-        if (itemType instanceof org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType r5ItemType) {
-            return r5ItemType == org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.QUESTION;
-        }
-        return false;
+        return switch (typeCode) {
+            case "code", "coding", "CodeableConcept" -> fhirVersion.isEqualOrNewerThan(FhirVersionEnum.R5)
+                    ? QUESTION
+                    : CHOICE;
+            case "uri", "url", "canonical" -> URL;
+            case "Quantity" -> QUANTITY;
+            case "Reference" -> REFERENCE;
+            case "id", "oid", "uuid", "base64Binary", "Identifier", "Extension" -> STRING;
+            case "positiveInt", "unsignedInt" -> INTEGER;
+            case "instant" -> DATETIME;
+            default -> typeCode;
+        };
     }
 
     public static String getSliceName(String elementId) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/ElementHasCaseFeature.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/ElementHasCaseFeature.java
@@ -3,24 +3,24 @@ package org.opencds.cqf.fhir.cr.questionnaire.generate;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.ArrayList;
 import org.apache.commons.lang3.StringUtils;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.opencds.cqf.fhir.cr.questionnaire.Helpers;
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.CqfExpression;
 import org.opencds.cqf.fhir.utility.adapter.IElementDefinitionAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IStructureDefinitionAdapter;
 
 public class ElementHasCaseFeature {
-    public IBaseBackboneElement addProperties(
+    public void addProperties(
             GenerateRequest request,
             CqfExpression caseFeature,
             IStructureDefinitionAdapter profile,
             IElementDefinitionAdapter element,
-            IBaseBackboneElement questionnaireItem) {
+            IQuestionnaireItemComponentAdapter questionnaireItem) {
         var elementId = element.getId();
         var elementIdentifiers = element.getPath().split("\\.");
-        var path = elementId.substring(elementId.indexOf(".")).replaceAll("\\[[^\\[]*\\]", "");
+        var path = elementId.substring(elementId.indexOf(".")).replaceAll("\\[[^\\[]*]", "");
         var sliceName = Helpers.getSliceName(elementId);
         if (StringUtils.isNotBlank(sliceName)) {
             var sliceElements = profile.getSliceElements(sliceName);
@@ -51,25 +51,22 @@ public class ElementHasCaseFeature {
             }
         }
         var expression = "%" + "%s%s".formatted(caseFeature.getName(), path);
-        var expressionType = createExpression(request.getFhirVersion(), expression, null);
+        var expressionType = createExpression(request.getFhirVersion(), expression);
         if (expressionType != null) {
             var initialExpressionExt = questionnaireItem.addExtension();
             initialExpressionExt.setUrl(Constants.SDC_QUESTIONNAIRE_INITIAL_EXPRESSION);
             initialExpressionExt.setValue(expressionType);
         }
-        return questionnaireItem;
     }
 
-    private ICompositeType createExpression(FhirVersionEnum fhirVersion, String expression, String name) {
+    private ICompositeType createExpression(FhirVersionEnum fhirVersion, String expression) {
         return switch (fhirVersion) {
             case R4 -> new org.hl7.fhir.r4.model.Expression()
                     .setLanguage("text/cql-expression")
-                    .setExpression(expression)
-                    .setName(name);
+                    .setExpression(expression);
             case R5 -> new org.hl7.fhir.r5.model.Expression()
                     .setLanguage("text/cql-expression")
-                    .setExpression(expression)
-                    .setName(name);
+                    .setExpression(expression);
             default -> null;
         };
     }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/ElementHasCaseFeature.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/ElementHasCaseFeature.java
@@ -61,22 +61,16 @@ public class ElementHasCaseFeature {
     }
 
     private ICompositeType createExpression(FhirVersionEnum fhirVersion, String expression, String name) {
-        switch (fhirVersion) {
-            case R4:
-                var r4Expression = new org.hl7.fhir.r4.model.Expression()
-                        .setLanguage("text/cql-expression")
-                        .setExpression(expression)
-                        .setName(name);
-                return r4Expression;
-            case R5:
-                var r5Expression = new org.hl7.fhir.r5.model.Expression()
-                        .setLanguage("text/cql-expression")
-                        .setExpression(expression)
-                        .setName(name);
-                return r5Expression;
-
-            default:
-                return null;
-        }
+        return switch (fhirVersion) {
+            case R4 -> new org.hl7.fhir.r4.model.Expression()
+                    .setLanguage("text/cql-expression")
+                    .setExpression(expression)
+                    .setName(name);
+            case R5 -> new org.hl7.fhir.r5.model.Expression()
+                    .setLanguage("text/cql-expression")
+                    .setExpression(expression)
+                    .setName(name);
+            default -> null;
+        };
     }
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/ElementHasCaseFeature.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/ElementHasCaseFeature.java
@@ -1,9 +1,7 @@
 package org.opencds.cqf.fhir.cr.questionnaire.generate;
 
-import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.ArrayList;
 import org.apache.commons.lang3.StringUtils;
-import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.opencds.cqf.fhir.cr.questionnaire.Helpers;
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.CqfExpression;
@@ -51,23 +49,9 @@ public class ElementHasCaseFeature {
             }
         }
         var expression = "%" + "%s%s".formatted(caseFeature.getName(), path);
-        var expressionType = createExpression(request.getFhirVersion(), expression);
-        if (expressionType != null) {
-            var initialExpressionExt = questionnaireItem.addExtension();
-            initialExpressionExt.setUrl(Constants.SDC_QUESTIONNAIRE_INITIAL_EXPRESSION);
-            initialExpressionExt.setValue(expressionType);
-        }
-    }
-
-    private ICompositeType createExpression(FhirVersionEnum fhirVersion, String expression) {
-        return switch (fhirVersion) {
-            case R4 -> new org.hl7.fhir.r4.model.Expression()
-                    .setLanguage("text/cql-expression")
-                    .setExpression(expression);
-            case R5 -> new org.hl7.fhir.r5.model.Expression()
-                    .setLanguage("text/cql-expression")
-                    .setExpression(expression);
-            default -> null;
-        };
+        var expressionType = questionnaireItem.newExpression(expression);
+        var initialExpressionExt = questionnaireItem.addExtension();
+        initialExpressionExt.setUrl(Constants.SDC_QUESTIONNAIRE_INITIAL_EXPRESSION);
+        initialExpressionExt.setValue(expressionType);
     }
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/GenerateProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/GenerateProcessor.java
@@ -5,6 +5,7 @@ import static org.opencds.cqf.fhir.utility.SearchHelper.searchRepositoryByCanoni
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.repository.IRepository;
 import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import org.apache.commons.lang3.tuple.Pair;
@@ -87,7 +88,7 @@ public class GenerateProcessor implements IGenerateProcessor {
                     return baseProfile.getSnapshotElements();
                 }
             }
-            return null;
+            return Collections.emptyList();
         } else {
             return request.getProfileAdapter().getSnapshotElements();
         }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/GenerateProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/GenerateProcessor.java
@@ -21,10 +21,11 @@ import org.opencds.cqf.fhir.utility.adapter.IElementDefinitionAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("UnstableApiUsage")
 public class GenerateProcessor implements IGenerateProcessor {
     protected static final Logger logger = LoggerFactory.getLogger(GenerateProcessor.class);
     protected static final String NO_BASE_DEFINITION_ERROR =
-            "An error occurred searching for base definition with url (%s): %s";
+            "An error occurred searching for base definition with url ({}): {}";
     protected final IRepository repository;
     protected final FhirVersionEnum fhirVersion;
     protected final ItemGenerator itemGenerator;
@@ -98,7 +99,7 @@ public class GenerateProcessor implements IGenerateProcessor {
                 try {
                     baseProfile = searchRepositoryByCanonical(repository, baseUrl);
                 } catch (Exception e) {
-                    logger.debug(NO_BASE_DEFINITION_ERROR, baseUrl.getValueAsString(), e);
+                    logger.debug(NO_BASE_DEFINITION_ERROR, baseUrl.getValueAsString(), e.getMessage());
                 }
                 if (baseProfile != null) {
                     snapshot = request.resolvePath(baseProfile, "snapshot");
@@ -109,16 +110,12 @@ public class GenerateProcessor implements IGenerateProcessor {
     }
 
     protected IBaseResource createQuestionnaire() {
-        switch (fhirVersion) {
-            case R4:
-                return new org.hl7.fhir.r4.model.Questionnaire()
-                        .setStatus(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.ACTIVE);
-            case R5:
-                return new org.hl7.fhir.r5.model.Questionnaire()
-                        .setStatus(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.ACTIVE);
-
-            default:
-                return null;
-        }
+        return switch (fhirVersion) {
+            case R4 -> new org.hl7.fhir.r4.model.Questionnaire()
+                    .setStatus(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.ACTIVE);
+            case R5 -> new org.hl7.fhir.r5.model.Questionnaire()
+                    .setStatus(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.ACTIVE);
+            default -> null;
+        };
     }
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/GenerateRequest.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/GenerateRequest.java
@@ -27,7 +27,6 @@ public class GenerateRequest implements IQuestionnaireRequest {
     private final ModelResolver modelResolver;
     private final FhirVersionEnum fhirVersion;
     private Map<String, String> referencedLibraries;
-    private IBaseResource questionnaire;
     private IQuestionnaireAdapter questionnaireAdapter;
     private List<IElementDefinitionAdapter> differentialElements;
     private List<IElementDefinitionAdapter> snapshotElements;
@@ -60,10 +59,6 @@ public class GenerateRequest implements IQuestionnaireRequest {
     }
 
     public IQuestionnaireAdapter getQuestionnaireAdapter() {
-        if (questionnaireAdapter == null && questionnaire != null) {
-            questionnaireAdapter = (IQuestionnaireAdapter)
-                    getAdapterFactory().createKnowledgeArtifactAdapter((IDomainResource) questionnaire);
-        }
         return questionnaireAdapter;
     }
 
@@ -84,7 +79,9 @@ public class GenerateRequest implements IQuestionnaireRequest {
     }
 
     public GenerateRequest setQuestionnaire(IBaseResource questionnaire) {
-        this.questionnaire = questionnaire;
+        if (questionnaire != null) {
+            questionnaireAdapter = getAdapterFactory().createQuestionnaire(questionnaire);
+        }
         return this;
     }
 
@@ -148,7 +145,7 @@ public class GenerateRequest implements IQuestionnaireRequest {
 
     @Override
     public IBaseResource getQuestionnaire() {
-        return questionnaire;
+        return questionnaireAdapter.get();
     }
 
     @Override

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/GenerateRequest.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/GenerateRequest.java
@@ -145,7 +145,7 @@ public class GenerateRequest implements IQuestionnaireRequest {
 
     @Override
     public IBaseResource getQuestionnaire() {
-        return questionnaireAdapter.get();
+        return questionnaireAdapter == null ? null : questionnaireAdapter.get();
     }
 
     @Override

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/IGenerateProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/IGenerateProcessor.java
@@ -14,8 +14,8 @@ public interface IGenerateProcessor {
     /**
      * Generates a Questionnaire item from a StructureDefinition Profile and returns
      * a Pair containing the Questionnaire item and the url of the supporting CQL Library if present
-     * @param request
-     * @return
+     * @param request GenerateRequest
+     * @return Pair
      */
     <T extends IBaseExtension<?, ?>> Pair<IBaseBackboneElement, List<T>> generateItem(GenerateRequest request);
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/IGenerateProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/IGenerateProcessor.java
@@ -2,9 +2,9 @@ package org.opencds.cqf.fhir.cr.questionnaire.generate;
 
 import java.util.List;
 import org.apache.commons.lang3.tuple.Pair;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
 
 public interface IGenerateProcessor {
     IBaseResource generate(String id);
@@ -17,5 +17,6 @@ public interface IGenerateProcessor {
      * @param request GenerateRequest
      * @return Pair
      */
-    <T extends IBaseExtension<?, ?>> Pair<IBaseBackboneElement, List<T>> generateItem(GenerateRequest request);
+    <T extends IBaseExtension<?, ?>> Pair<IQuestionnaireItemComponentAdapter, List<T>> generateItem(
+            GenerateRequest request);
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/ItemGenerator.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/ItemGenerator.java
@@ -35,6 +35,7 @@ import org.opencds.cqf.fhir.utility.adapter.IStructureDefinitionAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("UnstableApiUsage")
 public class ItemGenerator {
     protected static final Logger logger = LoggerFactory.getLogger(ItemGenerator.class);
     protected static final String NO_PROFILE_ERROR = "No profile defined for input. Unable to generate item.";
@@ -60,7 +61,7 @@ public class ItemGenerator {
     @Nullable
     public <T extends IBaseExtension<?, ?>> Pair<IBaseBackboneElement, List<T>> generate(GenerateRequest request) {
         final String linkId =
-                String.valueOf(request.getItems(request.getQuestionnaire()).size() + 1);
+                String.valueOf(request.getQuestionnaireAdapter().getItem().size() + 1);
         try {
             int childCount = 0;
             var caseFeature = getFeatureExpression(request);

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/ItemTypeIsChoice.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/ItemTypeIsChoice.java
@@ -16,6 +16,7 @@ import org.opencds.cqf.fhir.utility.adapter.IValueSetExpansionContainsAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("UnstableApiUsage")
 public class ItemTypeIsChoice {
     protected static final Logger logger = LoggerFactory.getLogger(ItemTypeIsChoice.class);
     protected final IRepository repository;

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/ItemTypeIsChoice.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/generate/ItemTypeIsChoice.java
@@ -1,15 +1,16 @@
 package org.opencds.cqf.fhir.cr.questionnaire.generate;
 
+import static org.opencds.cqf.fhir.utility.Resources.newBaseForVersion;
 import static org.opencds.cqf.fhir.utility.SearchHelper.searchRepositoryByCanonical;
 import static org.opencds.cqf.fhir.utility.VersionUtilities.canonicalTypeForVersion;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.repository.IRepository;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IDomainResource;
 import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
 import org.opencds.cqf.fhir.utility.adapter.ICodingAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IElementDefinitionAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetConceptReferenceAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetExpansionContainsAdapter;
@@ -31,7 +32,7 @@ public class ItemTypeIsChoice {
         return repository.fhirContext().getVersion().getVersion();
     }
 
-    public IBaseBackboneElement addProperties(IElementDefinitionAdapter element, IBaseBackboneElement item) {
+    public void addProperties(IElementDefinitionAdapter element, IQuestionnaireItemComponentAdapter item) {
         final IValueSetAdapter valueSet = getValueSet(element);
         if (valueSet != null) {
             if (valueSet.hasExpansion()) {
@@ -39,75 +40,48 @@ public class ItemTypeIsChoice {
             } else {
                 addAnswerOptionsForValueSetWithComposeComponent(valueSet, item);
             }
-        } else {
-            // Is it possible to get the binding without the value set?
         }
-        return item;
     }
 
     protected void addAnswerOptionsForValueSetWithExpansionComponent(
-            IValueSetAdapter valueSet, IBaseBackboneElement item) {
+            IValueSetAdapter valueSet, IQuestionnaireItemComponentAdapter item) {
         var expansionList = valueSet.getExpansionContains();
         expansionList.forEach(expansion -> {
             var coding = getCodingFromExpansion(expansion);
             if (coding != null) {
-                addAnswerOption(item, coding);
+                item.addAnswerOption(coding);
             }
         });
     }
 
     protected void addAnswerOptionsForValueSetWithComposeComponent(
-            IValueSetAdapter valueSet, IBaseBackboneElement item) {
+            IValueSetAdapter valueSet, IQuestionnaireItemComponentAdapter item) {
         var conceptSets = valueSet.getComposeInclude();
         conceptSets.forEach(conceptSet -> {
             var systemUri = conceptSet.getSystem();
             conceptSet.getConcept().forEach(concept -> {
                 var coding = getCodingFromConcept(concept, systemUri);
                 if (coding != null) {
-                    addAnswerOption(item, coding);
+                    item.addAnswerOption(coding);
                 }
             });
         });
     }
 
-    protected void addAnswerOption(IBaseBackboneElement item, ICodingAdapter coding) {
-        if (item instanceof org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent r4Item) {
-            r4Item.addAnswerOption().setValue((org.hl7.fhir.r4.model.Coding) coding.get());
-        } else if (item instanceof org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemComponent r5Item) {
-            r5Item.addAnswerOption().setValue((org.hl7.fhir.r5.model.Coding) coding.get());
-        }
-    }
-
     protected ICodingAdapter getCodingFromConcept(IValueSetConceptReferenceAdapter code, String systemUri) {
-        if (code instanceof org.hl7.fhir.r4.model.ValueSet.ConceptReferenceComponent r4Code) {
-            return adapterFactory.createCoding(new org.hl7.fhir.r4.model.Coding()
-                    .setCode(r4Code.getCode())
-                    .setSystem(systemUri)
-                    .setDisplay(r4Code.getDisplay()));
-        }
-        if (code instanceof org.hl7.fhir.r5.model.ValueSet.ConceptReferenceComponent r5Code) {
-            return adapterFactory.createCoding(new org.hl7.fhir.r5.model.Coding()
-                    .setCode(r5Code.getCode())
-                    .setSystem(systemUri)
-                    .setDisplay(r5Code.getDisplay()));
-        }
-        return null;
+        return adapterFactory
+                .createCoding(newBaseForVersion("Coding", fhirVersion()))
+                .setCode(code.getCode())
+                .setSystem(systemUri)
+                .setDisplay(code.getDisplay());
     }
 
     protected ICodingAdapter getCodingFromExpansion(IValueSetExpansionContainsAdapter code) {
-        if (code instanceof org.hl7.fhir.r4.model.ValueSet.ValueSetExpansionContainsComponent r4Code) {
-            return adapterFactory.createCoding(new org.hl7.fhir.r4.model.Coding()
-                    .setCode(r4Code.getCode())
-                    .setSystem(r4Code.getSystem())
-                    .setDisplay(r4Code.getDisplay()));
-        }
-        if (code instanceof org.hl7.fhir.r5.model.ValueSet.ValueSetExpansionContainsComponent r5Code) {
-            return adapterFactory.createCoding(new org.hl7.fhir.r5.model.Coding()
-                    .setCode(r5Code.getCode())
-                    .setSystem(r5Code.getSystem())
-                    .setDisplay(r5Code.getDisplay()));
-        }
-        return null;
+        return adapterFactory
+                .createCoding(newBaseForVersion("Coding", fhirVersion()))
+                .setCode(code.getCode())
+                .setSystem(code.getSystem())
+                .setDisplay(code.getDisplay());
     }
 
     protected IValueSetAdapter getValueSet(IElementDefinitionAdapter element) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/PopulateRequest.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/PopulateRequest.java
@@ -194,28 +194,15 @@ public class PopulateRequest implements IQuestionnaireRequest {
     }
 
     protected IQuestionnaireResponseAdapter createQuestionnaireResponse() {
-        var response =
-                switch (fhirVersion) {
-                    case R4 -> new org.hl7.fhir.r4.model.QuestionnaireResponse()
-                            .setStatus(
-                                    org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseStatus.INPROGRESS)
-                            .setQuestionnaire(questionnaireAdapter.getCanonical())
-                            .setSubject(new org.hl7.fhir.r4.model.Reference(subjectId))
-                            .setAuthored(new Date());
-                    case R5 -> new org.hl7.fhir.r5.model.QuestionnaireResponse()
-                            .setStatus(
-                                    org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseStatus.INPROGRESS)
-                            .setQuestionnaire(questionnaireAdapter.getCanonical())
-                            .setSubject(new org.hl7.fhir.r5.model.Reference(subjectId))
-                            .setAuthored(new Date());
-                    default -> null;
-                };
-        if (response == null) {
-            throw new IllegalArgumentException(
-                    "Unsupported FHIR version: %s".formatted(fhirVersion.getFhirVersionString()));
-        }
-        response.setId("%s-%s".formatted(questionnaireAdapter.getId().getIdPart(), subjectId.getIdPart()));
-        return getAdapterFactory().createQuestionnaireResponse(response);
+        return getAdapterFactory()
+                .createQuestionnaireResponse(getFhirContext()
+                        .getResourceDefinition("QuestionnaireResponse")
+                        .newInstance())
+                .setId("%s-%s".formatted(questionnaireAdapter.getId().getIdPart(), subjectId.getIdPart()))
+                .setQuestionnaire(questionnaireAdapter.getCanonical())
+                .setSubject(subjectId)
+                .setAuthored(new Date())
+                .setStatus("in-progress");
     }
 
     public IQuestionnaireResponseAdapter getQuestionnaireResponseAdapter() {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/PopulateRequest.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/PopulateRequest.java
@@ -27,10 +27,12 @@ import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.Resources;
 import org.opencds.cqf.fhir.utility.adapter.IParametersParameterComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
 
 public class PopulateRequest implements IQuestionnaireRequest {
     private final IQuestionnaireAdapter questionnaireAdapter;
-    private final IBaseResource questionnaireResponse;
+    private final IQuestionnaireResponseAdapter questionnaireResponseAdapter;
     private final IIdType subjectId;
     private final List<IParametersParameterComponentAdapter> context;
     private final IBaseBundle data;
@@ -74,8 +76,8 @@ public class PopulateRequest implements IQuestionnaireRequest {
             parameters = (IBaseParameters) Resources.newBaseForVersion("Parameters", fhirVersion);
         }
         getAdapterFactory().createParameters(parameters).addParameter("%questionnaire", questionnaireAdapter.get());
-        questionnaireResponse = createQuestionnaireResponse();
-        contextVariable = questionnaireResponse;
+        questionnaireResponseAdapter = createQuestionnaireResponse();
+        contextVariable = questionnaireResponseAdapter.get();
         referencedLibraries = questionnaireAdapter.getReferencedLibraries();
         inputParameterResolver = IInputParameterResolver.createResolver(
                 libraryEngine.getRepository(),
@@ -131,7 +133,7 @@ public class PopulateRequest implements IQuestionnaireRequest {
 
     @Override
     public IBase getResourceVariable() {
-        return getQuestionnaireResponse();
+        return questionnaireResponseAdapter.get();
     }
 
     @Override
@@ -191,7 +193,7 @@ public class PopulateRequest implements IQuestionnaireRequest {
         this.operationOutcome = operationOutcome;
     }
 
-    protected IBaseResource createQuestionnaireResponse() {
+    protected IQuestionnaireResponseAdapter createQuestionnaireResponse() {
         var response =
                 switch (fhirVersion) {
                     case R4 -> new org.hl7.fhir.r4.model.QuestionnaireResponse()
@@ -213,14 +215,14 @@ public class PopulateRequest implements IQuestionnaireRequest {
                     "Unsupported FHIR version: %s".formatted(fhirVersion.getFhirVersionString()));
         }
         response.setId("%s-%s".formatted(questionnaireAdapter.getId().getIdPart(), subjectId.getIdPart()));
-        return response;
+        return getAdapterFactory().createQuestionnaireResponse(response);
     }
 
-    public IBaseResource getQuestionnaireResponse() {
-        return questionnaireResponse;
+    public IQuestionnaireResponseAdapter getQuestionnaireResponseAdapter() {
+        return questionnaireResponseAdapter;
     }
 
-    public void addQuestionnaireResponseItems(List<IBaseBackboneElement> items) {
-        getModelResolver().setValue(getQuestionnaireResponse(), "item", items);
+    public void addQuestionnaireResponseItems(List<IQuestionnaireResponseItemComponentAdapter> items) {
+        questionnaireResponseAdapter.addItems(items);
     }
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessItem.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessItem.java
@@ -51,7 +51,7 @@ public class ProcessItem {
                         childItems.stream().map(c -> processItem(request, c)).toList();
                 var answers = responseItem.getAnswer();
                 if (answers.isEmpty()) {
-                    answers.add(responseItem.createAnswer(null));
+                    answers.add(responseItem.newAnswer(null));
                     responseItem.setAnswer(answers);
                 }
                 answers.forEach(a -> a.setItem(childResponseItems));
@@ -67,7 +67,7 @@ public class ProcessItem {
         }
         var answers = new ArrayList<IQuestionnaireResponseItemAnswerComponentAdapter>();
         for (var value : answerValue) {
-            answers.add(responseItem.createAnswer(transformValueToItem(request.getFhirVersion(), value)));
+            answers.add(responseItem.newAnswer(transformValueToItem(request.getFhirVersion(), value)));
         }
         responseItem.setAnswer(answers);
     }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessItem.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessItem.java
@@ -4,15 +4,15 @@ import static org.opencds.cqf.fhir.cr.common.ExtensionBuilders.QUESTIONNAIRE_RES
 import static org.opencds.cqf.fhir.cr.common.ExtensionBuilders.buildReferenceExt;
 import static org.opencds.cqf.fhir.cr.common.ItemValueTransformer.transformValueToItem;
 
-import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.hl7.fhir.instance.model.api.IBase;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.opencds.cqf.fhir.cr.common.ExpressionProcessor;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemAnswerComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,55 +28,59 @@ public class ProcessItem {
         this.expressionProcessor = expressionProcessor;
     }
 
-    public IBaseBackboneElement processItem(PopulateRequest request, IBaseBackboneElement item) {
-        final var responseItem = createResponseItem(request.getFhirVersion(), item);
-        var childItems = request.getItems(item);
-        if ("group".equals(request.resolvePathString(item, "type"))) {
-            final List<IBaseBackboneElement> groupChildItems = new ArrayList<>();
+    public IQuestionnaireResponseItemComponentAdapter processItem(
+            PopulateRequest request, IQuestionnaireItemComponentAdapter item) {
+        final var responseItem = item.newResponseItem();
+        var childItems = item.getItem().stream()
+                .map(IQuestionnaireItemComponentAdapter.class::cast)
+                .toList();
+        if (item.isGroupItem()) {
+            final List<IQuestionnaireResponseItemComponentAdapter> groupChildItems = new ArrayList<>();
             childItems.forEach(childItem -> {
                 groupChildItems.add(processItem(request, childItem));
             });
-            request.getModelResolver().setValue(responseItem, "item", groupChildItems);
+            responseItem.setItem(groupChildItems);
         } else {
-            request.setContextVariable(responseItem);
+            request.setContextVariable(responseItem.get());
             var rawParams = request.getRawParameters();
-            rawParams.put("%qitem", item);
+            rawParams.put("%qitem", item.get());
             populateAnswer(request, responseItem, getInitialValue(request, item, responseItem, rawParams));
             if (!childItems.isEmpty()) {
                 //  child items go under each answer
                 var childResponseItems =
                         childItems.stream().map(c -> processItem(request, c)).toList();
-                var answers = request.resolvePathList(responseItem, "answer");
+                var answers = responseItem.getAnswer();
                 if (answers.isEmpty()) {
-                    answers.add(createAnswer(request.getFhirVersion(), null));
-                    request.getModelResolver().setValue(responseItem, "answer", answers);
+                    answers.add(responseItem.createAnswer(null));
+                    responseItem.setAnswer(answers);
                 }
-                answers.forEach(a -> request.getModelResolver().setValue(a, "item", childResponseItems));
+                answers.forEach(a -> a.setItem(childResponseItems));
             }
         }
         return responseItem;
     }
 
-    protected void populateAnswer(PopulateRequest request, IBaseBackboneElement responseItem, List<IBase> answerValue) {
+    protected void populateAnswer(
+            PopulateRequest request, IQuestionnaireResponseItemComponentAdapter responseItem, List<IBase> answerValue) {
         if (answerValue == null || answerValue.isEmpty()) {
             return;
         }
-        var answers = new ArrayList<>();
+        var answers = new ArrayList<IQuestionnaireResponseItemAnswerComponentAdapter>();
         for (var value : answerValue) {
-            answers.add(createAnswer(request.getFhirVersion(), value));
+            answers.add(responseItem.createAnswer(transformValueToItem(request.getFhirVersion(), value)));
         }
-        request.getModelResolver().setValue(responseItem, "answer", answers);
+        responseItem.setAnswer(answers);
     }
 
     protected List<IBase> getInitialValue(
             PopulateRequest request,
-            IBaseBackboneElement item,
-            IBaseBackboneElement responseItem,
+            IQuestionnaireItemComponentAdapter item,
+            IQuestionnaireResponseItemComponentAdapter responseItem,
             Map<String, Object> rawParameters) {
         List<IBase> results;
         var expression = expressionProcessor.getItemInitialExpression(request, item);
         if (expression != null) {
-            var itemLinkId = request.getItemLinkId(item);
+            var itemLinkId = item.getLinkId();
             try {
                 results = expressionProcessor.getExpressionResultForItem(
                         request, expression, itemLinkId, null, rawParameters);
@@ -91,49 +95,14 @@ public class ProcessItem {
                 results = new ArrayList<>();
             }
         } else {
-            results = request.resolvePathList(item, "initial", IBaseBackboneElement.class).stream()
+            results = item.getInitial().stream()
                     .map(i -> request.resolvePath(i, "value", IBase.class))
                     .collect(Collectors.toList());
         }
         return results;
     }
 
-    protected void addAuthorExtension(PopulateRequest request, IBaseBackboneElement item) {
-        request.getModelResolver()
-                .setValue(
-                        item,
-                        "extension",
-                        Collections.singletonList(buildReferenceExt(
-                                request.getFhirVersion(), QUESTIONNAIRE_RESPONSE_AUTHOR_EXTENSION, false)));
-    }
-
-    protected IBaseBackboneElement createAnswer(FhirVersionEnum fhirVersion, IBase value) {
-        return switch (fhirVersion) {
-            case R4 -> new org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent()
-                    .setValue(transformValueToItem((org.hl7.fhir.r4.model.Type) value));
-            case R5 -> new org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent()
-                    .setValue(transformValueToItem((org.hl7.fhir.r5.model.DataType) value));
-            default -> null;
-        };
-    }
-
-    protected IBaseBackboneElement createResponseItem(FhirVersionEnum fhirVersion, IBaseBackboneElement item) {
-        return switch (fhirVersion) {
-            case R4 -> {
-                var r4Item = (org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent) item;
-                yield new org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent(
-                                r4Item.getLinkIdElement())
-                        .setDefinitionElement(r4Item.getDefinitionElement())
-                        .setTextElement(r4Item.getTextElement());
-            }
-            case R5 -> {
-                var r5Item = (org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemComponent) item;
-                yield new org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemComponent(
-                                r5Item.getLinkId())
-                        .setDefinitionElement(r5Item.getDefinitionElement())
-                        .setTextElement(r5Item.getTextElement());
-            }
-            default -> null;
-        };
+    protected void addAuthorExtension(PopulateRequest request, IQuestionnaireResponseItemComponentAdapter item) {
+        item.addExtension(buildReferenceExt(request.getFhirVersion(), QUESTIONNAIRE_RESPONSE_AUTHOR_EXTENSION, false));
     }
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessItemWithContext.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessItemWithContext.java
@@ -119,17 +119,11 @@ public class ProcessItemWithContext extends ProcessItem {
                     if (!childItems.isEmpty()) {
                         var childGroupItem = processPopulationContext(request, item, contextName, context, profile);
                         contextItem.addItem(childGroupItem);
-                        //                        request.getModelResolver()
-                        //                                .setValue(contextItem, "item",
-                        // Collections.singletonList(childGroupItem));
                     } else {
                         try {
                             var processedSubItem =
                                     createResponseContextItem(request, item, contextName, context, profile);
                             contextItem.addItem(processedSubItem);
-                            //                            request.getModelResolver()
-                            //                                    .setValue(contextItem, "item",
-                            // Collections.singletonList(processedSubItem));
                         } catch (Exception e) {
                             logger.error(e.getMessage());
                             request.logException(e.getMessage());

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessItemWithContext.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessItemWithContext.java
@@ -6,24 +6,22 @@ import static org.opencds.cqf.fhir.utility.VersionUtilities.stringTypeForVersion
 
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBase;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IDomainResource;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
-import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
-import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType;
 import org.opencds.cqf.fhir.cr.common.ExpressionProcessor;
 import org.opencds.cqf.fhir.cr.common.IOperationRequest;
 import org.opencds.cqf.fhir.cr.questionnaire.Helpers;
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.CqfExpression;
 import org.opencds.cqf.fhir.utility.adapter.IElementDefinitionAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IStructureDefinitionAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,14 +37,15 @@ public class ProcessItemWithContext extends ProcessItem {
         super(expressionProcessor);
     }
 
-    List<IBaseBackboneElement> processContextItem(PopulateRequest request, IBaseBackboneElement item) {
-        var itemLinkId = request.getItemLinkId(item);
-        if (!((QuestionnaireItemComponent) item).getType().equals(QuestionnaireItemType.GROUP)) {
+    List<IQuestionnaireResponseItemComponentAdapter> processContextItem(
+            PopulateRequest request, IQuestionnaireItemComponentAdapter item) {
+        var itemLinkId = item.getLinkId();
+        if (!item.isGroupItem()) {
             throw new UnprocessableEntityException(
                     "Encountered Item Population Context extension on a non group item: {}", itemLinkId);
         }
         IBaseResource profile = null;
-        var definition = request.resolvePathString(item, "definition");
+        var definition = item.getDefinition();
         if (StringUtils.isNotBlank(definition)) {
             var profileUrl = definition.split("#")[0];
             try {
@@ -95,7 +94,7 @@ public class ProcessItemWithContext extends ProcessItem {
             // We always want to return a responseItem even if we have nothing to populate
             populationContext.add(null);
         }
-        if (populationContext.size() > 1 && !((QuestionnaireItemComponent) item).getRepeats()) {
+        if (populationContext.size() > 1 && !item.getRepeats()) {
             throw new UnprocessableEntityException(
                     "Population context expression resulted in multiple values for a non repeating group: {}",
                     contextExpression.getExpression());
@@ -106,46 +105,54 @@ public class ProcessItemWithContext extends ProcessItem {
                 .collect(Collectors.toList());
     }
 
-    IBaseBackboneElement processPopulationContext(
+    IQuestionnaireResponseItemComponentAdapter processPopulationContext(
             PopulateRequest request,
-            IBaseBackboneElement groupItem,
+            IQuestionnaireItemComponentAdapter groupItem,
             String contextName,
             IBaseResource context,
             IStructureDefinitionAdapter profile) {
-        final var contextItem = createResponseItem(request.getFhirVersion(), groupItem);
-        request.getItems(groupItem).forEach(item -> {
-            var childItems = request.getItems(item);
-            if (!childItems.isEmpty()) {
-                var childGroupItem = processPopulationContext(request, item, contextName, context, profile);
-                request.getModelResolver().setValue(contextItem, "item", Collections.singletonList(childGroupItem));
-            } else {
-                try {
-                    var processedSubItem = createResponseContextItem(request, item, contextName, context, profile);
-                    request.getModelResolver()
-                            .setValue(contextItem, "item", Collections.singletonList(processedSubItem));
-                } catch (Exception e) {
-                    logger.error(e.getMessage());
-                    request.logException(e.getMessage());
-                }
-            }
-        });
+        final var contextItem = groupItem.newResponseItem();
+        groupItem.getItem().stream()
+                .map(IQuestionnaireItemComponentAdapter.class::cast)
+                .forEach(item -> {
+                    var childItems = item.getItem();
+                    if (!childItems.isEmpty()) {
+                        var childGroupItem = processPopulationContext(request, item, contextName, context, profile);
+                        contextItem.addItem(childGroupItem);
+                        //                        request.getModelResolver()
+                        //                                .setValue(contextItem, "item",
+                        // Collections.singletonList(childGroupItem));
+                    } else {
+                        try {
+                            var processedSubItem =
+                                    createResponseContextItem(request, item, contextName, context, profile);
+                            contextItem.addItem(processedSubItem);
+                            //                            request.getModelResolver()
+                            //                                    .setValue(contextItem, "item",
+                            // Collections.singletonList(processedSubItem));
+                        } catch (Exception e) {
+                            logger.error(e.getMessage());
+                            request.logException(e.getMessage());
+                        }
+                    }
+                });
         return contextItem;
     }
 
     @SuppressWarnings("unchecked")
-    IBaseBackboneElement createResponseContextItem(
+    IQuestionnaireResponseItemComponentAdapter createResponseContextItem(
             PopulateRequest request,
-            IBaseBackboneElement item,
+            IQuestionnaireItemComponentAdapter item,
             String contextName,
             IBaseResource context,
             IStructureDefinitionAdapter profile) {
-        if (request.resolveRawPath(item, "initial") != null) {
+        if (item.hasInitial()) {
             return processItem(request, item);
         }
-        final var responseItem = createResponseItem(request.getFhirVersion(), item);
-        request.setContextVariable(responseItem);
+        final var responseItem = item.newResponseItem();
+        request.setContextVariable(responseItem.get());
         // if we have a definition use it to populate
-        var definition = request.resolvePathString(item, "definition");
+        var definition = item.getDefinition();
         if (StringUtils.isNotBlank(definition) && profile != null) {
             final var pathValue = getPathValue(request, context, definition, profile);
             if (pathValue != null) {
@@ -157,13 +164,13 @@ public class ProcessItemWithContext extends ProcessItem {
                 populateAnswer(request, responseItem, answerValue);
             }
         } else {
-            var extension = request.getExtensionByUrl(item, Constants.SDC_QUESTIONNAIRE_INITIAL_EXPRESSION);
+            var extension = item.getExtensionByUrl(Constants.SDC_QUESTIONNAIRE_INITIAL_EXPRESSION);
             // populate using expected initial expression extensions
             if (extension != null) {
                 // pass the context resource(s) as a parameter to the evaluation
                 var rawParams = request.getRawParameters();
                 rawParams.put("%" + contextName, context);
-                rawParams.put("%qitem", item);
+                rawParams.put("%qitem", item.get());
                 populateAnswer(request, responseItem, getInitialValue(request, item, responseItem, rawParams));
             }
         }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/QuestionnaireResponseProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/QuestionnaireResponseProcessor.java
@@ -26,6 +26,7 @@ import org.opencds.cqf.fhir.utility.monad.Either;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("UnstableApiUsage")
 public class QuestionnaireResponseProcessor {
     protected static final Logger logger = LoggerFactory.getLogger(QuestionnaireResponseProcessor.class);
     protected static final String QUESTIONNAIRE = "Questionnaire";

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/extract/ItemPair.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/extract/ItemPair.java
@@ -11,11 +11,6 @@ import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentA
 public class ItemPair
         extends ImmutablePair<IQuestionnaireItemComponentAdapter, IQuestionnaireResponseItemComponentAdapter> {
 
-    public ItemPair(FhirVersionEnum fhirVersion, IItemComponentAdapter item, IBaseBackboneElement responseItem) {
-        this(item, (IQuestionnaireResponseItemComponentAdapter)
-                IAdapterFactory.createAdapterForBase(fhirVersion, responseItem));
-    }
-
     public ItemPair(FhirVersionEnum fhirVersion, IBaseBackboneElement item, IBaseBackboneElement responseItem) {
         this(
                 (IQuestionnaireItemComponentAdapter) IAdapterFactory.createAdapterForBase(fhirVersion, item),

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/extract/ItemPair.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/extract/ItemPair.java
@@ -1,19 +1,37 @@
 package org.opencds.cqf.fhir.cr.questionnaireresponse.extract;
 
+import ca.uhn.fhir.context.FhirVersionEnum;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
+import org.opencds.cqf.fhir.utility.adapter.IItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
 
-public class ItemPair extends ImmutablePair<IBaseBackboneElement, IBaseBackboneElement> {
+public class ItemPair
+        extends ImmutablePair<IQuestionnaireItemComponentAdapter, IQuestionnaireResponseItemComponentAdapter> {
 
-    public ItemPair(IBaseBackboneElement item, IBaseBackboneElement responseItem) {
-        super(item, responseItem);
+    public ItemPair(FhirVersionEnum fhirVersion, IItemComponentAdapter item, IBaseBackboneElement responseItem) {
+        this(item, (IQuestionnaireResponseItemComponentAdapter)
+                IAdapterFactory.createAdapterForBase(fhirVersion, responseItem));
     }
 
-    public IBaseBackboneElement getItem() {
+    public ItemPair(FhirVersionEnum fhirVersion, IBaseBackboneElement item, IBaseBackboneElement responseItem) {
+        this(
+                (IQuestionnaireItemComponentAdapter) IAdapterFactory.createAdapterForBase(fhirVersion, item),
+                (IQuestionnaireResponseItemComponentAdapter)
+                        IAdapterFactory.createAdapterForBase(fhirVersion, responseItem));
+    }
+
+    public <T extends IItemComponentAdapter> ItemPair(T item, T responseItem) {
+        super((IQuestionnaireItemComponentAdapter) item, (IQuestionnaireResponseItemComponentAdapter) responseItem);
+    }
+
+    public IQuestionnaireItemComponentAdapter getItem() {
         return left;
     }
 
-    public IBaseBackboneElement getResponseItem() {
+    public IQuestionnaireResponseItemComponentAdapter getResponseItem() {
         return right;
     }
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/extract/ProcessDefinitionItem.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/extract/ProcessDefinitionItem.java
@@ -15,16 +15,15 @@ import ca.uhn.fhir.context.RuntimeChildExtension;
 import ca.uhn.fhir.context.RuntimeChildPrimitiveDatatypeDefinition;
 import ca.uhn.fhir.context.RuntimeChildPrimitiveEnumerationDatatypeDefinition;
 import ca.uhn.fhir.context.RuntimeChildResourceBlockDefinition;
+import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.hl7.fhir.instance.model.api.IBase;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IDomainResource;
@@ -35,10 +34,13 @@ import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.CqfExpression;
 import org.opencds.cqf.fhir.utility.Ids;
 import org.opencds.cqf.fhir.utility.adapter.IElementDefinitionAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemAnswerComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IStructureDefinitionAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class ProcessDefinitionItem {
     protected static final String ID_PATH = "id";
     protected static final String DEFINITION_PATH = "definition";
@@ -58,13 +60,12 @@ public class ProcessDefinitionItem {
         // Definition-based extraction -
         // http://build.fhir.org/ig/HL7/sdc/extraction.html#definition-based-extraction
 
-        var linkId = request.getItemLinkId(item.getResponseItem());
-        if (StringUtils.isBlank(linkId)) {
-            linkId = "Questionnaire.root";
-        }
+        var linkId = item.getResponseItem() == null
+                ? "Questionnaire.root"
+                : item.getResponseItem().getLinkId();
         var definitionProfile = getDefinitionProfile(request, item);
         var valueExtensions = getValueExtensions(request, item);
-        var definition = getDefinition(request, item);
+        var definition = getDefinition(item);
         var profileUrl = definitionProfile.right == null ? definition : definitionProfile.right;
         var profile = getProfile(request, profileUrl);
         var resourceType = getResourceType(linkId, definitionProfile, definition, profile);
@@ -87,7 +88,7 @@ public class ProcessDefinitionItem {
             if (profile.isPresent()) {
                 resourceType = profile.get().getType();
             } else if (definitionProfile.right != null) {
-                var split = definitionProfile.right.split("\\/");
+                var split = definitionProfile.right.split("/");
                 resourceType = split[split.length - 1];
             } else {
                 if (definition == null) {
@@ -119,10 +120,11 @@ public class ProcessDefinitionItem {
         // Second, check the QuestionnaireResponse.item
         // Third, check the Questionnaire
         IBase element;
-        if (request.hasExtension(item.getItem(), url)) {
-            element = item.getItem();
-        } else if (request.hasExtension(item.getResponseItem(), url)) {
-            element = item.getResponseItem();
+        // if (request.hasExtension(item.getItem(), url)) {
+        if (item.getItem() != null && item.getItem().hasExtension(url)) {
+            element = item.getItem().get();
+        } else if (item.getResponseItem() != null && item.getResponseItem().hasExtension(url)) {
+            element = item.getResponseItem().get();
         } else {
             element = request.getQuestionnaire();
         }
@@ -166,7 +168,9 @@ public class ProcessDefinitionItem {
         var resourceDefinition = request.getFhirContext().getElementDefinition(resource.getClass());
         if (isCreatedResource) {
             var id = request.getExtractId();
-            var linkId = request.getItemLinkId(item.getResponseItem());
+            var linkId = item.getResponseItem() == null
+                    ? null
+                    : item.getResponseItem().getLinkId();
             if (StringUtils.isNotBlank(linkId)) {
                 id = id.concat("-%s".formatted(linkId));
             }
@@ -175,16 +179,20 @@ public class ProcessDefinitionItem {
             resolveMeta(resource, profile);
         }
         valueExtensions.forEach(valueExt -> processValueExtension(request, resource, profile, valueExt));
-        List<IBaseBackboneElement> responseItems;
-        List<IBaseBackboneElement> questionnaireItems;
-        if (item.getResponseItem() != null
-                && request.getItems(item.getResponseItem()).isEmpty()) {
-            responseItems = Arrays.asList(item.getResponseItem());
-            questionnaireItems = Arrays.asList(item.getItem());
+        List<? extends IItemComponentAdapter> responseItems;
+        List<? extends IItemComponentAdapter> questionnaireItems;
+        if (item.getResponseItem() != null && !item.getResponseItem().hasItem()) {
+            responseItems = List.of(item.getResponseItem());
+            questionnaireItems = List.of(item.getItem());
         } else {
-            responseItems = request.getItems(
-                    item.getResponseItem() == null ? request.getQuestionnaireResponse() : item.getResponseItem());
-            questionnaireItems = request.getItems(item.getItem() == null ? request.getQuestionnaire() : item.getItem());
+            responseItems = item.getResponseItem() != null
+                    ? item.getResponseItem().getItem()
+                    : request.getQuestionnaireResponseAdapter().getItem();
+            questionnaireItems = item.getItem() != null
+                    ? item.getItem().getItem()
+                    : request.getQuestionnaireAdapter() != null
+                            ? request.getQuestionnaireAdapter().getItem()
+                            : List.of();
         }
         processItems(
                 request,
@@ -202,8 +210,8 @@ public class ProcessDefinitionItem {
         // If we have the profile go through each differential element and add any default values
         if (profile.isPresent()) {
             var defaultElements = profile.get().getDifferentialElements().stream()
-                    .filter(e -> e.hasDefaultOrFixedOrPattern())
-                    .collect(Collectors.toList());
+                    .filter(IElementDefinitionAdapter::hasDefaultOrFixedOrPattern)
+                    .toList();
             defaultElements.forEach(e -> {
                 var value = e.getDefaultOrFixedOrPattern();
                 if (value != null) {
@@ -271,7 +279,7 @@ public class ProcessDefinitionItem {
             BaseRuntimeElementDefinition<?> resourceDefinition,
             Optional<IStructureDefinitionAdapter> profile,
             IBase resource,
-            ImmutablePair<List<IBaseBackboneElement>, List<IBaseBackboneElement>> items,
+            ImmutablePair<List<? extends IItemComponentAdapter>, List<? extends IItemComponentAdapter>> items,
             boolean isNestedRepeating,
             String parentPath) {
         var responseItems = items.left;
@@ -280,12 +288,6 @@ public class ProcessDefinitionItem {
             var itemPair = new ItemPair(request.getQuestionnaireItem(childItem, questionnaireItems), childItem);
             processChildItem(request, resourceDefinition, profile, resource, itemPair, isNestedRepeating, parentPath);
         });
-    }
-
-    @SuppressWarnings("unchecked")
-    protected boolean getIsRepeating(ExtractRequest request, IBaseBackboneElement questionnaireItem) {
-        var repeats = request.resolvePath(questionnaireItem, "repeats");
-        return repeats != null && ((IPrimitiveType<Boolean>) repeats).getValue();
     }
 
     protected String stripTypeFromPath(String path) {
@@ -317,23 +319,23 @@ public class ProcessDefinitionItem {
             ItemPair itemPair,
             boolean isNestedRepeating,
             String parentPath) {
-        var definition = getDefinition(request, itemPair);
-        var children = request.getItems(itemPair.getResponseItem());
-        var repeats = getIsRepeating(request, itemPair.getItem());
+        var definition = getDefinition(itemPair);
+        var children = itemPair.getResponseItem().getItem();
+        var repeats = itemPair.getItem() != null && itemPair.getItem().getRepeats();
         if (StringUtils.isBlank(definition)) {
             processItems(
                     request,
                     resourceDefinition,
                     profile,
                     parent,
-                    new ImmutablePair<>(children, request.getItems(itemPair.getItem())),
+                    new ImmutablePair<>(children, itemPair.getItem().getItem()),
                     repeats,
                     parentPath);
             return;
         }
         if (!definition.contains("#")) {
             throw new IllegalArgumentException("Invalid definition encountered for item %s"
-                    .formatted(request.getItemLinkId(itemPair.getResponseItem())));
+                    .formatted(itemPair.getResponseItem().getLinkId()));
         }
         var pathAdapter = getPathAdapter(request, profile, definition);
         var path = pathAdapter.left;
@@ -355,6 +357,10 @@ public class ProcessDefinitionItem {
                     element = newBaseForVersion(elementDef.getTypeCode(), request.getFhirVersion());
                 } else if (propertyDefs.get(prop) instanceof RuntimeChildChoiceDefinition choiceDef) {
                     element = newBase(getChoices(choiceDef).get(0));
+                } else {
+                    throw new UnprocessableEntityException(String.format(
+                            "Unable to determine type for item: %s",
+                            itemPair.getResponseItem().getLinkId()));
                 }
             }
             processItems(
@@ -362,18 +368,17 @@ public class ProcessDefinitionItem {
                     resourceDefinition,
                     profile,
                     element,
-                    new ImmutablePair<>(children, request.getItems(itemPair.getItem())),
+                    new ImmutablePair<>(children, itemPair.getItem().getItem()),
                     repeats,
                     path);
             request.getModelResolver().setValue(parent, prop, List.of(element));
         } else {
-            var answers = request.resolvePathList(itemPair.getResponseItem(), "answer", IBaseBackboneElement.class);
             processItem(
                     request,
                     parent,
                     isNestedRepeating,
                     parentPath,
-                    answers,
+                    itemPair.getResponseItem().getAnswer(),
                     repeats,
                     adapter,
                     path,
@@ -388,7 +393,7 @@ public class ProcessDefinitionItem {
             IBase parent,
             boolean isNestedRepeating,
             String parentPath,
-            List<IBaseBackboneElement> answers,
+            List<IQuestionnaireResponseItemAnswerComponentAdapter> answers,
             boolean repeats,
             IStructureDefinitionAdapter profile,
             String path,
@@ -400,8 +405,8 @@ public class ProcessDefinitionItem {
             processRepeatingWithNested(request, parent, isNestedRepeating, answers, identifiers, propertyDefs, profile);
         } else {
             var answerPath = StringUtils.isBlank(parentPath) ? path : path.replace(parentPath + ".", "");
-            answers.stream().forEach(answer -> {
-                var answerValue = request.resolvePath(answer, VALUE_PATH);
+            answers.forEach(answer -> {
+                var answerValue = answer.getValue();
                 if (answerValue != null) {
                     setAnswerValue(request, parent, propertyDefs.get(answerPath), answerPath, answerValue, profile);
                 }
@@ -413,7 +418,7 @@ public class ProcessDefinitionItem {
             ExtractRequest request,
             IBase parent,
             boolean isNestedRepeating,
-            List<IBaseBackboneElement> answers,
+            List<IQuestionnaireResponseItemAnswerComponentAdapter> answers,
             String[] identifiers,
             HashMap<String, BaseRuntimeChildDefinition> propertyDefs,
             IStructureDefinitionAdapter profile) {
@@ -424,8 +429,8 @@ public class ProcessDefinitionItem {
         // element
         // otherwise we will create a new value for each answer and add that to the parent
         var useParent = isNestedRepeating || isChildList;
-        answers.stream().forEach(answer -> {
-            var answerValue = request.resolvePath(answer, VALUE_PATH);
+        answers.forEach(answer -> {
+            var answerValue = answer.getValue();
             if (answerValue != null) {
                 var parentValue = useParent
                         ? parent
@@ -445,7 +450,7 @@ public class ProcessDefinitionItem {
             ExtractRequest request,
             IStructureDefinitionAdapter profile,
             IBase parent,
-            List<IBaseBackboneElement> answers,
+            List<IQuestionnaireResponseItemAnswerComponentAdapter> answers,
             String[] identifiers,
             HashMap<String, BaseRuntimeChildDefinition> propertyDefs) {
         if (profile == null) {
@@ -470,8 +475,8 @@ public class ProcessDefinitionItem {
         var sliceElements = profile.getSliceElements(sliceName);
         var answerPath = getChildProperty(identifiers, sliceIndex + 1);
         var extensionUrl = getExtensionUrl(profile, sliceName);
-        answers.stream().forEach(answer -> {
-            var answerValue = request.resolvePath(answer, VALUE_PATH);
+        answers.forEach(answer -> {
+            var answerValue = answer.getValue();
             if (answerValue != null) {
                 var sliceValue = newBase(sliceClass);
                 setAnswerValue(request, sliceValue, propertyDefs.get(answerPath), answerPath, answerValue, profile);
@@ -603,16 +608,16 @@ public class ProcessDefinitionItem {
             }
         }
         return pathDefinition != null && pathDefinition.isMultipleCardinality()
-                ? Arrays.asList(answerValue)
+                ? Collections.singletonList(answerValue)
                 : answerValue;
     }
 
-    protected String getDefinition(ExtractRequest request, ItemPair itemPair) {
-        var definition = request.resolvePathString(itemPair.getItem(), DEFINITION_PATH);
-        if (definition == null) {
-            definition = request.resolvePathString(itemPair.getResponseItem(), DEFINITION_PATH);
-        }
-        return definition;
+    protected String getDefinition(ItemPair itemPair) {
+        return itemPair.getItem() != null && itemPair.getItem().hasDefinition()
+                ? itemPair.getItem().getDefinition()
+                : itemPair.getResponseItem() != null
+                        ? itemPair.getResponseItem().getDefinition()
+                        : null;
     }
 
     protected String getDefinitionType(String definition) {
@@ -626,8 +631,6 @@ public class ProcessDefinitionItem {
     protected void resolveMeta(IBaseResource resource, Optional<IStructureDefinitionAdapter> profile) {
         var meta = resource.getMeta();
         // Consider setting source and lastUpdated here?
-        if (profile.isPresent()) {
-            meta.addProfile(profile.get().getCanonical());
-        }
+        profile.ifPresent(iStructureDefinitionAdapter -> meta.addProfile(iStructureDefinitionAdapter.getCanonical()));
     }
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/extract/ProcessDefinitionItem.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/extract/ProcessDefinitionItem.java
@@ -120,7 +120,6 @@ public class ProcessDefinitionItem {
         // Second, check the QuestionnaireResponse.item
         // Third, check the Questionnaire
         IBase element;
-        // if (request.hasExtension(item.getItem(), url)) {
         if (item.getItem() != null && item.getItem().hasExtension(url)) {
             element = item.getItem().get();
         } else if (item.getResponseItem() != null && item.getResponseItem().hasExtension(url)) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/extract/ProcessItem.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/extract/ProcessItem.java
@@ -2,18 +2,20 @@ package org.opencds.cqf.fhir.cr.questionnaireresponse.extract;
 
 import java.util.List;
 import java.util.Map;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
 import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseReference;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.opencds.cqf.fhir.utility.Constants;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemAnswerComponentAdapter;
 
 public class ProcessItem {
     public void processItem(
             ExtractRequest request,
-            IBaseBackboneElement answerItem,
-            IBaseBackboneElement questionnaireItem,
+            ItemPair itemPair,
+            //            IBaseBackboneElement answerItem,
+            //            IBaseBackboneElement questionnaireItem,
             Map<String, List<IBaseCoding>> questionnaireCodeMap,
             List<IBaseResource> resources,
             IBaseReference subject) {
@@ -22,16 +24,19 @@ public class ProcessItem {
                     "Unable to retrieve Questionnaire code map for Observation based extraction");
         }
         var categoryExt =
-                request.getExtensionByUrl(answerItem, Constants.SDC_QUESTIONNAIRE_OBSERVATION_EXTRACT_CATEGORY);
-        var answers = request.resolvePathList(answerItem, "answer", IBaseBackboneElement.class);
+                itemPair.getResponseItem().getExtensionByUrl(Constants.SDC_QUESTIONNAIRE_OBSERVATION_EXTRACT_CATEGORY);
+        var answers = itemPair.getResponseItem().getAnswer();
+        var questionnaireItem = itemPair.getItem();
         if (!answers.isEmpty()) {
             answers.forEach(answer -> {
-                var answerItems = request.getItems(answer);
+                var answerItems = answer.getItem();
                 if (!answerItems.isEmpty()) {
-                    answerItems.forEach(answerChild -> processItem(
-                            request, answerChild, questionnaireItem, questionnaireCodeMap, resources, subject));
+                    answerItems.forEach(answerChild -> {
+                        var childPair = new ItemPair(itemPair.getItem(), answerChild);
+                        processItem(request, childPair, questionnaireCodeMap, resources, subject);
+                    });
                 } else {
-                    var linkId = request.resolvePathString(answerItem, "linkId");
+                    var linkId = itemPair.getResponseItem().getLinkId();
                     if (questionnaireCodeMap.get(linkId) != null
                             && !questionnaireCodeMap.get(linkId).isEmpty()) {
                         resources.add(createObservationFromItemAnswer(
@@ -50,26 +55,20 @@ public class ProcessItem {
 
     private IBaseResource createObservationFromItemAnswer(
             ExtractRequest request,
-            IBaseBackboneElement answer,
-            IBaseBackboneElement questionnaireItem,
+            IQuestionnaireResponseItemAnswerComponentAdapter answer,
+            IQuestionnaireItemComponentAdapter questionnaireItem,
             String linkId,
             IBaseReference subject,
             Map<String, List<IBaseCoding>> questionnaireCodeMap,
             IBaseExtension<?, ?> categoryExt) {
         // Observation-based extraction -
         // http://build.fhir.org/ig/HL7/sdc/extraction.html#observation-based-extraction
-        switch (request.getFhirVersion()) {
-            case R4:
-                return new org.opencds.cqf.fhir.cr.questionnaireresponse.extract.r4.ObservationResolver()
-                        .resolve(
-                                request, answer, questionnaireItem, linkId, subject, questionnaireCodeMap, categoryExt);
-            case R5:
-                return new org.opencds.cqf.fhir.cr.questionnaireresponse.extract.r5.ObservationResolver()
-                        .resolve(
-                                request, answer, questionnaireItem, linkId, subject, questionnaireCodeMap, categoryExt);
-
-            default:
-                return null;
-        }
+        return switch (request.getFhirVersion()) {
+            case R4 -> new org.opencds.cqf.fhir.cr.questionnaireresponse.extract.r4.ObservationResolver()
+                    .resolve(request, answer, questionnaireItem, linkId, subject, questionnaireCodeMap, categoryExt);
+            case R5 -> new org.opencds.cqf.fhir.cr.questionnaireresponse.extract.r5.ObservationResolver()
+                    .resolve(request, answer, questionnaireItem, linkId, subject, questionnaireCodeMap, categoryExt);
+            default -> null;
+        };
     }
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/extract/ProcessItem.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/extract/ProcessItem.java
@@ -14,8 +14,6 @@ public class ProcessItem {
     public void processItem(
             ExtractRequest request,
             ItemPair itemPair,
-            //            IBaseBackboneElement answerItem,
-            //            IBaseBackboneElement questionnaireItem,
             Map<String, List<IBaseCoding>> questionnaireCodeMap,
             List<IBaseResource> resources,
             IBaseReference subject) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/extract/r4/ObservationResolver.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/extract/r4/ObservationResolver.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
 import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseReference;
@@ -25,19 +24,21 @@ import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.StringType;
 import org.opencds.cqf.fhir.cr.questionnaireresponse.extract.ExtractRequest;
 import org.opencds.cqf.fhir.utility.Constants;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemAnswerComponentAdapter;
 
 public class ObservationResolver {
     public IBaseResource resolve(
             ExtractRequest request,
-            IBaseBackboneElement baseAnswer,
-            IBaseBackboneElement baseItem,
+            IQuestionnaireResponseItemAnswerComponentAdapter answerAdapter,
+            IQuestionnaireItemComponentAdapter itemAdapter,
             String linkId,
             IBaseReference subject,
             Map<String, List<IBaseCoding>> questionnaireCodeMap,
             IBaseExtension<?, ?> categoryExt) {
         var questionnaireResponse = (QuestionnaireResponse) request.getQuestionnaireResponse();
-        var answer = (QuestionnaireResponseItemAnswerComponent) baseAnswer;
-        var item = (QuestionnaireItemComponent) baseItem;
+        var answer = (QuestionnaireResponseItemAnswerComponent) answerAdapter.get();
+        var item = (QuestionnaireItemComponent) (itemAdapter == null ? null : itemAdapter.get());
         var obs = new Observation();
         obs.setId(request.getExtractId() + "." + linkId);
         obs.setBasedOn(questionnaireResponse.getBasedOn());
@@ -74,7 +75,7 @@ public class ObservationResolver {
                 obs.setValue(new DateTimeType(((DateType) answer.getValue()).getValue()));
                 break;
             case "decimal", "integer":
-                if (item.hasExtension(Constants.QUESTIONNAIRE_UNIT)) {
+                if (item != null && item.hasExtension(Constants.QUESTIONNAIRE_UNIT)) {
                     obs.setValue(getQuantity(answer, item));
                 } else {
                     obs.setValue(answer.getValue());

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/extract/r5/ObservationResolver.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/extract/r5/ObservationResolver.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
 import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseReference;
@@ -26,19 +25,21 @@ import org.hl7.fhir.r5.model.Reference;
 import org.hl7.fhir.r5.model.StringType;
 import org.opencds.cqf.fhir.cr.questionnaireresponse.extract.ExtractRequest;
 import org.opencds.cqf.fhir.utility.Constants;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemAnswerComponentAdapter;
 
 public class ObservationResolver {
     public IBaseResource resolve(
             ExtractRequest request,
-            IBaseBackboneElement baseAnswer,
-            IBaseBackboneElement baseItem,
+            IQuestionnaireResponseItemAnswerComponentAdapter answerAdapter,
+            IQuestionnaireItemComponentAdapter itemAdapter,
             String linkId,
             IBaseReference subject,
             Map<String, List<IBaseCoding>> questionnaireCodeMap,
             IBaseExtension<?, ?> categoryExt) {
         var questionnaireResponse = (QuestionnaireResponse) request.getQuestionnaireResponse();
-        var answer = (QuestionnaireResponseItemAnswerComponent) baseAnswer;
-        var item = (QuestionnaireItemComponent) baseItem;
+        var answer = (QuestionnaireResponseItemAnswerComponent) answerAdapter.get();
+        var item = (QuestionnaireItemComponent) (itemAdapter == null ? null : itemAdapter.get());
         var obs = new Observation();
         obs.setId(request.getExtractId() + "." + linkId);
         obs.setBasedOn(questionnaireResponse.getBasedOn());
@@ -75,7 +76,7 @@ public class ObservationResolver {
                 obs.setValue(new DateTimeType(((DateType) answer.getValue()).getValue()));
                 break;
             case "decimal", "integer":
-                if (item.hasExtension(Constants.QUESTIONNAIRE_UNIT)) {
+                if (item != null && item.hasExtension(Constants.QUESTIONNAIRE_UNIT)) {
                     obs.setValue(getQuantity(answer, item));
                 } else {
                     obs.setValue(answer.getValue());

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/DataRequirementsVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/DataRequirementsVisitor.java
@@ -34,6 +34,7 @@ import org.opencds.cqf.fhir.cql.EvaluationSettings;
 import org.opencds.cqf.fhir.cql.cql2elm.content.RepositoryFhirLibrarySourceProvider;
 import org.opencds.cqf.fhir.cql.cql2elm.util.LibraryVersionSelector;
 import org.opencds.cqf.fhir.utility.Libraries;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
 import org.opencds.cqf.fhir.utility.adapter.IKnowledgeArtifactAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ILibraryAdapter;
@@ -86,7 +87,10 @@ public class DataRequirementsVisitor extends BaseKnowledgeArtifactVisitor {
                         true,
                         true);
                 var convertedLibrary = convertAndCreateAdapter(r5Library);
-                convertedLibrary.getDataRequirement().forEach(dataReq -> library.addDataRequirement(dataReq.get()));
+                convertedLibrary.getDataRequirement().stream()
+                        .map(IAdapter::get)
+                        .map(ICompositeType.class::cast)
+                        .forEach(library::addDataRequirement);
                 convertedLibrary.getRelatedArtifact().forEach(library::addRelatedArtifact);
             });
         }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/common/ItemValueTransformerTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/common/ItemValueTransformerTests.java
@@ -3,6 +3,7 @@ package org.opencds.cqf.fhir.cr.common;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.opencds.cqf.fhir.cr.common.ItemValueTransformer.transformValueToItem;
 import static org.opencds.cqf.fhir.cr.common.ItemValueTransformer.transformValueToResource;
 
@@ -12,10 +13,20 @@ import org.junit.jupiter.api.Test;
 class ItemValueTransformerTests {
 
     @Test
+    void testUnsupportedVersion() {
+        var fhirVersion = FhirVersionEnum.DSTU2;
+        var stringType = new org.hl7.fhir.dstu2.model.StringType("test");
+        var transformStringTypeItem = transformValueToItem(fhirVersion, stringType);
+        assertNull(transformStringTypeItem);
+        var transformStringTypeResource = transformValueToResource(fhirVersion, stringType);
+        assertNull(transformStringTypeResource);
+    }
+
+    @Test
     void transformValueToItemDstu3() {
         var fhirVersion = FhirVersionEnum.DSTU3;
         var stringType = new org.hl7.fhir.dstu3.model.StringType("test");
-        var transformStringType = transformValueToItem(stringType);
+        var transformStringType = transformValueToItem(fhirVersion, stringType);
         assertEquals(stringType, transformStringType);
 
         var coding = new org.hl7.fhir.dstu3.model.Coding("test", "test", "test");

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/common/ItemValueTransformerTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/common/ItemValueTransformerTests.java
@@ -2,129 +2,146 @@ package org.opencds.cqf.fhir.cr.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.opencds.cqf.fhir.cr.common.ItemValueTransformer.transformValueToItem;
 import static org.opencds.cqf.fhir.cr.common.ItemValueTransformer.transformValueToResource;
 
+import ca.uhn.fhir.context.FhirVersionEnum;
 import org.junit.jupiter.api.Test;
 
 class ItemValueTransformerTests {
 
     @Test
     void transformValueToItemDstu3() {
+        var fhirVersion = FhirVersionEnum.DSTU3;
         var stringType = new org.hl7.fhir.dstu3.model.StringType("test");
         var transformStringType = transformValueToItem(stringType);
         assertEquals(stringType, transformStringType);
 
         var coding = new org.hl7.fhir.dstu3.model.Coding("test", "test", "test");
         var code = new org.hl7.fhir.dstu3.model.CodeableConcept().addCoding(coding);
-        var transformValue = transformValueToItem(code);
+        var transformValue = transformValueToItem(fhirVersion, code);
         assertEquals(coding, transformValue);
 
         var enumeration =
                 new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Patient.LinkTypeEnumFactory());
         enumeration.setValue(org.hl7.fhir.dstu3.model.Patient.LinkType.REFER);
-        var transformEnum = transformValueToItem(enumeration);
+        var transformEnum = transformValueToItem(fhirVersion, enumeration);
+        assertNotNull(transformEnum);
         var expected = org.hl7.fhir.dstu3.model.Patient.LinkType.REFER.toCode();
         var actual = ((org.hl7.fhir.dstu3.model.StringType) transformEnum).getValue();
         assertEquals(expected, actual);
 
         var idType = new org.hl7.fhir.dstu3.model.IdType("test");
-        var transformIdType = transformValueToItem(idType);
+        var transformIdType = transformValueToItem(fhirVersion, idType);
+        assertNotNull(transformIdType);
         assertEquals(idType.getValueAsString(), ((org.hl7.fhir.dstu3.model.StringType) transformIdType).getValue());
 
         var identifier = new org.hl7.fhir.dstu3.model.Identifier().setValue("test");
-        var transformIdentifier = transformValueToItem(identifier);
+        var transformIdentifier = transformValueToItem(fhirVersion, identifier);
+        assertNotNull(transformIdentifier);
         assertEquals(identifier.getValue(), ((org.hl7.fhir.dstu3.model.StringType) transformIdentifier).getValue());
     }
 
     @Test
     void transformValueToItemR4() {
+        var fhirVersion = FhirVersionEnum.R4;
         var stringType = new org.hl7.fhir.r4.model.StringType("test");
-        var transformStringType = transformValueToItem(stringType);
+        var transformStringType = transformValueToItem(fhirVersion, stringType);
         assertEquals(stringType, transformStringType);
 
         var coding = new org.hl7.fhir.r4.model.Coding("test", "test", "test");
         var code = new org.hl7.fhir.r4.model.CodeableConcept().addCoding(coding);
-        var transformValue = transformValueToItem(code);
+        var transformValue = transformValueToItem(fhirVersion, code);
         assertEquals(coding, transformValue);
 
         var enumeration =
                 new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Patient.LinkTypeEnumFactory());
         enumeration.setValue(org.hl7.fhir.r4.model.Patient.LinkType.REFER);
-        var transformEnum = transformValueToItem(enumeration);
+        var transformEnum = transformValueToItem(fhirVersion, enumeration);
+        assertNotNull(transformEnum);
         var expected = org.hl7.fhir.r4.model.Patient.LinkType.REFER.toCode();
         var actual = ((org.hl7.fhir.r4.model.StringType) transformEnum).getValue();
         assertEquals(expected, actual);
 
         var idType = new org.hl7.fhir.r4.model.IdType("test");
-        var transformIdType = transformValueToItem(idType);
+        var transformIdType = transformValueToItem(fhirVersion, idType);
+        assertNotNull(transformIdType);
         assertEquals(idType.getValueAsString(), ((org.hl7.fhir.r4.model.StringType) transformIdType).getValue());
 
         var identifier = new org.hl7.fhir.r4.model.Identifier().setValue("test");
-        var transformIdentifier = transformValueToItem(identifier);
+        var transformIdentifier = transformValueToItem(fhirVersion, identifier);
+        assertNotNull(transformIdentifier);
         assertEquals(identifier.getValue(), ((org.hl7.fhir.r4.model.StringType) transformIdentifier).getValue());
     }
 
     @Test
     void transformValueToItemR5() {
+        var fhirVersion = FhirVersionEnum.R5;
         var stringType = new org.hl7.fhir.r5.model.StringType("test");
-        var transformStringType = transformValueToItem(stringType);
+        var transformStringType = transformValueToItem(fhirVersion, stringType);
         assertEquals(stringType, transformStringType);
 
         var coding = new org.hl7.fhir.r5.model.Coding("test", "test", "test");
         var code = new org.hl7.fhir.r5.model.CodeableConcept().addCoding(coding);
-        var transformValue = transformValueToItem(code);
+        var transformValue = transformValueToItem(fhirVersion, code);
         assertEquals(coding, transformValue);
 
         var enumeration =
                 new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Patient.LinkTypeEnumFactory());
         enumeration.setValue(org.hl7.fhir.r5.model.Patient.LinkType.REFER);
-        var transformEnum = transformValueToItem(enumeration);
+        var transformEnum = transformValueToItem(fhirVersion, enumeration);
+        assertNotNull(transformEnum);
         var expected = org.hl7.fhir.r5.model.Patient.LinkType.REFER.toCode();
         var actual = ((org.hl7.fhir.r5.model.StringType) transformEnum).getValue();
         assertEquals(expected, actual);
 
         var idType = new org.hl7.fhir.r5.model.IdType("test");
-        var transformIdType = transformValueToItem(idType);
+        var transformIdType = transformValueToItem(fhirVersion, idType);
+        assertNotNull(transformIdType);
         assertEquals(idType.getValueAsString(), ((org.hl7.fhir.r5.model.StringType) transformIdType).getValue());
 
         var identifier = new org.hl7.fhir.r5.model.Identifier().setValue("test");
-        var transformIdentifier = transformValueToItem(identifier);
+        var transformIdentifier = transformValueToItem(fhirVersion, identifier);
+        assertNotNull(transformIdentifier);
         assertEquals(identifier.getValue(), ((org.hl7.fhir.r5.model.StringType) transformIdentifier).getValue());
     }
 
     @Test
     void transformValueToResourceDstu3() {
+        var fhirVersion = FhirVersionEnum.DSTU3;
         var stringType = new org.hl7.fhir.dstu3.model.StringType("test");
-        var transformStringType = transformValueToResource(stringType);
+        var transformStringType = transformValueToResource(fhirVersion, stringType);
         assertEquals(stringType, transformStringType);
 
         var coding = new org.hl7.fhir.dstu3.model.Coding("test", "test", "test");
-        var transformCoding = transformValueToResource(coding);
+        var transformCoding = transformValueToResource(fhirVersion, coding);
         assertInstanceOf(org.hl7.fhir.dstu3.model.CodeableConcept.class, transformCoding);
         assertEquals(((org.hl7.fhir.dstu3.model.CodeableConcept) transformCoding).getCodingFirstRep(), coding);
     }
 
     @Test
     void transformValueToResourceR4() {
+        var fhirVersion = FhirVersionEnum.R4;
         var stringType = new org.hl7.fhir.r4.model.StringType("test");
-        var transformStringType = transformValueToResource(stringType);
+        var transformStringType = transformValueToResource(fhirVersion, stringType);
         assertEquals(stringType, transformStringType);
 
         var coding = new org.hl7.fhir.r4.model.Coding("test", "test", "test");
-        var transformCoding = transformValueToResource(coding);
+        var transformCoding = transformValueToResource(fhirVersion, coding);
         assertInstanceOf(org.hl7.fhir.r4.model.CodeableConcept.class, transformCoding);
         assertEquals(((org.hl7.fhir.r4.model.CodeableConcept) transformCoding).getCodingFirstRep(), coding);
     }
 
     @Test
     void transformValueToResourceR5() {
+        var fhirVersion = FhirVersionEnum.R5;
         var stringType = new org.hl7.fhir.r5.model.StringType("test");
-        var transformStringType = transformValueToResource(stringType);
+        var transformStringType = transformValueToResource(fhirVersion, stringType);
         assertEquals(stringType, transformStringType);
 
         var coding = new org.hl7.fhir.r5.model.Coding("test", "test", "test");
-        var transformCoding = transformValueToResource(coding);
+        var transformCoding = transformValueToResource(fhirVersion, coding);
         assertInstanceOf(org.hl7.fhir.r5.model.CodeableConcept.class, transformCoding);
         assertEquals(((org.hl7.fhir.r5.model.CodeableConcept) transformCoding).getCodingFirstRep(), coding);
     }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/PlanDefinitionProcessorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/PlanDefinitionProcessorTests.java
@@ -397,8 +397,8 @@ class PlanDefinitionProcessorTests {
                 .parameters(parameters)
                 .thenApplyR5()
                 .hasEntry(4)
-                .hasQuestionnaire()
-                .hasQuestionnaireResponse()
+                .hasQuestionnaire(true)
+                .hasQuestionnaireResponse(true)
                 .hasQuestionnaireResponseItemValue("1.1", "Claim/OPA-Claim1")
                 .hasQuestionnaireResponseItemValue("2.1", "Acme Clinic")
                 .hasQuestionnaireResponseItemValue("2.2.1", "1407071236")
@@ -416,8 +416,8 @@ class PlanDefinitionProcessorTests {
                 .additionalData(bundle)
                 .thenApplyR5()
                 .hasEntry(4)
-                .hasQuestionnaire()
-                .hasQuestionnaireResponse();
+                .hasQuestionnaire(true)
+                .hasQuestionnaireResponse(true);
     }
 
     @Test
@@ -435,8 +435,8 @@ class PlanDefinitionProcessorTests {
                 .parameters(parameters)
                 .thenApplyR5()
                 .hasEntry(3)
-                .hasQuestionnaire()
-                .hasQuestionnaireResponse()
+                .hasQuestionnaire(true)
+                .hasQuestionnaireResponse(true)
                 .questionnaireResponse;
         // First response Item is correct
         var responseItem1 = questionnaireResponse.getItem().get(0);
@@ -476,8 +476,25 @@ class PlanDefinitionProcessorTests {
                 .parameters(parameters)
                 .thenApplyR5()
                 .hasEntry(4)
-                .hasQuestionnaire()
-                .hasQuestionnaireResponse();
+                .hasQuestionnaire(true)
+                .hasQuestionnaireResponse(true);
+    }
+
+    @Test
+    void noUrl_DoesNotGenerate() {
+        var planDefinitionID = "no-url";
+        var patientID = "OPA-Patient1";
+        var parameters = org.opencds.cqf.fhir.utility.r5.Parameters.parameters(
+                org.opencds.cqf.fhir.utility.r5.Parameters.stringPart("ClaimId", "OPA-Claim1"));
+        given().repositoryFor(fhirContextR5, "r5")
+                .when()
+                .planDefinitionId(planDefinitionID)
+                .subjectId(patientID)
+                .parameters(parameters)
+                .thenApplyR5()
+                .hasEntry(2)
+                .hasQuestionnaire(false)
+                .hasQuestionnaireResponse(false);
     }
 
     @Test

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/TestPlanDefinition.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/TestPlanDefinition.java
@@ -3,6 +3,7 @@ package org.opencds.cqf.fhir.cr.plandefinition;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.opencds.cqf.fhir.test.Resources.getResourcePath;
@@ -401,13 +402,21 @@ public class TestPlanDefinition {
             return this;
         }
 
-        public GeneratedBundle hasQuestionnaire() {
-            assertNotNull(questionnaire);
+        public GeneratedBundle hasQuestionnaire(boolean value) {
+            if (value) {
+                assertNotNull(questionnaire);
+            } else {
+                assertNull(questionnaire);
+            }
             return this;
         }
 
-        public GeneratedBundle hasQuestionnaireResponse() {
-            assertNotNull(questionnaireResponse);
+        public GeneratedBundle hasQuestionnaireResponse(boolean value) {
+            if (value) {
+                assertNotNull(questionnaireResponse);
+            } else {
+                assertNull(questionnaireResponse);
+            }
             return this;
         }
 

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/HelperTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/HelperTests.java
@@ -1,141 +1,121 @@
 package org.opencds.cqf.fhir.cr.questionnaire;
 
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import org.junit.jupiter.api.Test;
 
 class HelperTests {
-    @Test
-    void testUnsupportedVersion() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> Helpers.parseItemTypeForVersion(FhirVersionEnum.DSTU3, "code", false, false));
-    }
+    FhirVersionEnum fhirVersionR4 = FhirVersionEnum.R4;
+    FhirVersionEnum fhirVersionR5 = FhirVersionEnum.R5;
 
     @Test
     void testNullElementType() {
-        assertNull(Helpers.parseR4ItemType(null, false, false));
-        assertNotNull(Helpers.parseR4ItemType(null, true, false));
-        assertNotNull(Helpers.parseR4ItemType(null, false, true));
-        assertNull(Helpers.parseR5ItemType(null, false, false));
-        assertNotNull(Helpers.parseR5ItemType(null, true, false));
-        assertNotNull(Helpers.parseR5ItemType(null, false, true));
+        assertNull(Helpers.parseItemTypeForVersion(fhirVersionR4, null, false, false));
+        assertNotNull(Helpers.parseItemTypeForVersion(fhirVersionR4, null, true, false));
+        assertNotNull(Helpers.parseItemTypeForVersion(fhirVersionR4, null, false, true));
+        assertNull(Helpers.parseItemTypeForVersion(fhirVersionR5, null, false, false));
+        assertNotNull(Helpers.parseItemTypeForVersion(fhirVersionR5, null, true, false));
+        assertNotNull(Helpers.parseItemTypeForVersion(fhirVersionR5, null, false, true));
     }
 
     @Test
     void r4ItemTypes() {
         assertEquals(
-                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.CHOICE,
-                Helpers.parseR4ItemType("code", false, false));
+                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.CHOICE.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR4, "code", false, false));
         assertEquals(
-                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.CHOICE,
-                Helpers.parseR4ItemType("coding", false, false));
+                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.CHOICE.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR4, "coding", false, false));
         assertEquals(
-                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.CHOICE,
-                Helpers.parseR4ItemType("CodeableConcept", false, false));
+                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.CHOICE.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR4, "CodeableConcept", false, false));
         assertEquals(
-                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.CHOICE,
-                Helpers.parseR4ItemType("uri", true, false));
+                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.CHOICE.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR4, "uri", true, false));
         assertEquals(
-                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.URL,
-                Helpers.parseR4ItemType("uri", false, false));
+                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.URL.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR4, "uri", false, false));
         assertEquals(
-                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.URL,
-                Helpers.parseR4ItemType("url", false, false));
+                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.URL.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR4, "url", false, false));
         assertEquals(
-                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.URL,
-                Helpers.parseR4ItemType("canonical", false, false));
+                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.URL.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR4, "canonical", false, false));
         assertEquals(
-                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.QUANTITY,
-                Helpers.parseR4ItemType("Quantity", false, false));
+                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.QUANTITY.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR4, "Quantity", false, false));
         assertEquals(
-                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.REFERENCE,
-                Helpers.parseR4ItemType("Reference", false, false));
+                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.REFERENCE.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR4, "Reference", false, false));
         assertEquals(
-                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.STRING,
-                Helpers.parseR4ItemType("oid", false, false));
+                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.STRING.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR4, "oid", false, false));
         assertEquals(
-                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.STRING,
-                Helpers.parseR4ItemType("uuid", false, false));
+                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.STRING.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR4, "uuid", false, false));
         assertEquals(
-                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.STRING,
-                Helpers.parseR4ItemType("base64Binary", false, false));
+                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.STRING.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR4, "base64Binary", false, false));
         assertEquals(
-                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.INTEGER,
-                Helpers.parseR4ItemType("positiveInt", false, false));
+                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.INTEGER.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR4, "positiveInt", false, false));
         assertEquals(
-                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.INTEGER,
-                Helpers.parseR4ItemType("unsignedInt", false, false));
+                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.INTEGER.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR4, "unsignedInt", false, false));
         assertEquals(
-                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.DATETIME,
-                Helpers.parseR4ItemType("instant", false, false));
-        var groupItem = new org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent()
-                .setLinkId("test")
-                .setType(org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.GROUP);
-        assertTrue(Helpers.isGroupItemType(groupItem.getType()));
-        var choiceItem = new org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent()
-                .setLinkId("test")
-                .setType(org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.CHOICE);
-        assertTrue(Helpers.isChoiceItemType(choiceItem.getType()));
+                org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType.DATETIME.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR4, "instant", false, false));
     }
 
     @Test
     void r5ItemTypes() {
         assertEquals(
-                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.QUESTION,
-                Helpers.parseR5ItemType("code", false, false));
+                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.QUESTION.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR5, "code", false, false));
         assertEquals(
-                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.QUESTION,
-                Helpers.parseR5ItemType("coding", false, false));
+                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.QUESTION.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR5, "coding", false, false));
         assertEquals(
-                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.QUESTION,
-                Helpers.parseR5ItemType("CodeableConcept", false, false));
+                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.QUESTION.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR5, "CodeableConcept", false, false));
         assertEquals(
-                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.QUESTION,
-                Helpers.parseR5ItemType("uri", true, false));
+                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.QUESTION.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR5, "uri", true, false));
         assertEquals(
-                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.URL,
-                Helpers.parseR5ItemType("uri", false, false));
+                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.URL.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR5, "uri", false, false));
         assertEquals(
-                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.URL,
-                Helpers.parseR5ItemType("url", false, false));
+                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.URL.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR5, "url", false, false));
         assertEquals(
-                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.URL,
-                Helpers.parseR5ItemType("canonical", false, false));
+                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.URL.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR5, "canonical", false, false));
         assertEquals(
-                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.QUANTITY,
-                Helpers.parseR5ItemType("Quantity", false, false));
+                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.QUANTITY.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR5, "Quantity", false, false));
         assertEquals(
-                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.REFERENCE,
-                Helpers.parseR5ItemType("Reference", false, false));
+                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.REFERENCE.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR5, "Reference", false, false));
         assertEquals(
-                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.STRING,
-                Helpers.parseR5ItemType("oid", false, false));
+                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.STRING.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR5, "oid", false, false));
         assertEquals(
-                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.STRING,
-                Helpers.parseR5ItemType("uuid", false, false));
+                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.STRING.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR5, "uuid", false, false));
         assertEquals(
-                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.STRING,
-                Helpers.parseR5ItemType("base64Binary", false, false));
+                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.STRING.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR5, "base64Binary", false, false));
         assertEquals(
-                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.INTEGER,
-                Helpers.parseR5ItemType("positiveInt", false, false));
+                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.INTEGER.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR5, "positiveInt", false, false));
         assertEquals(
-                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.INTEGER,
-                Helpers.parseR5ItemType("unsignedInt", false, false));
+                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.INTEGER.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR5, "unsignedInt", false, false));
         assertEquals(
-                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.DATETIME,
-                Helpers.parseR5ItemType("instant", false, false));
-        var groupItem = new org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemComponent(
-                "test", org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.GROUP);
-        assertTrue(Helpers.isGroupItemType(groupItem.getType()));
-        var choiceItem = new org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemComponent(
-                "test", org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.QUESTION);
-        assertTrue(Helpers.isChoiceItemType(choiceItem.getType()));
+                org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType.DATETIME.toCode(),
+                Helpers.parseItemTypeForVersion(fhirVersionR5, "instant", false, false));
     }
 }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/QuestionnaireProcessorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/QuestionnaireProcessorTests.java
@@ -32,7 +32,7 @@ import org.opencds.cqf.fhir.utility.BundleHelper;
 import org.opencds.cqf.fhir.utility.Ids;
 import org.opencds.cqf.fhir.utility.repository.ig.IgRepository;
 
-@SuppressWarnings("squid:S2699")
+@SuppressWarnings({"squid:S2699", "UnstableApiUsage"})
 class QuestionnaireProcessorTests {
     private final FhirContext fhirContextR4 = FhirContext.forR4Cached();
     private final FhirContext fhirContextR5 = FhirContext.forR5Cached();
@@ -272,7 +272,8 @@ class QuestionnaireProcessorTests {
                 .profileId(Ids.newId(fhirContextR4, "StructureDefinition", "LaunchContexts"))
                 .thenGenerate()
                 .hasItems(2)
-                .questionnaire;
+                .questionnaire
+                .get();
         var questionnaireResponse = (QuestionnaireResponse) given().repository(repositoryR4)
                 .when()
                 .questionnaire(questionnaire)
@@ -293,7 +294,8 @@ class QuestionnaireProcessorTests {
                 .hasItems(2)
                 .itemHasAnswer("1.1")
                 .itemHasAuthorExt("1.1")
-                .questionnaireResponse;
+                .questionnaireResponse
+                .get();
         assertEquals("Patient/" + patientId, questionnaireResponse.getSubject().getReference());
         assertNotNull(questionnaireResponse.getAuthored());
         var bundle = TestQuestionnaireResponse.given()

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/TestQuestionnaire.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/TestQuestionnaire.java
@@ -331,7 +331,6 @@ public class TestQuestionnaire {
                     .toList();
             for (var item : matchingItems) {
                 assertTrue(item.hasInitial());
-                // assertFalse(request.resolvePathList(item, "initial").isEmpty());
             }
 
             return this;

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessItemWithContextTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ProcessItemWithContextTests.java
@@ -19,7 +19,6 @@ import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Questionnaire;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType;
-import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,7 +30,10 @@ import org.opencds.cqf.fhir.cql.LibraryEngine;
 import org.opencds.cqf.fhir.cr.common.ExpressionProcessor;
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.CqfExpression;
+import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
 
+@SuppressWarnings("UnstableApiUsage")
 @ExtendWith(MockitoExtension.class)
 class ProcessItemWithContextTests {
     @Mock
@@ -76,7 +78,9 @@ class ProcessItemWithContextTests {
         doReturn(expressionResults)
                 .when(expressionProcessor)
                 .getExpressionResultForItem(eq(populateRequest), eq(expression), eq("1"), any(), any());
-        processItemWithContext.processContextItem(populateRequest, questionnaireItem);
+        var adapter = (IQuestionnaireItemComponentAdapter)
+                IAdapterFactory.createAdapterForBase(populateRequest.getFhirVersion(), questionnaireItem);
+        processItemWithContext.processContextItem(populateRequest, adapter);
         var operationOutcome = (OperationOutcome) populateRequest.getOperationOutcome();
         assertTrue(operationOutcome.hasIssue());
         assertEquals(2, operationOutcome.getIssue().size());
@@ -101,9 +105,10 @@ class ProcessItemWithContextTests {
         doReturn(expressionResults)
                 .when(expressionProcessor)
                 .getExpressionResultForItem(eq(populateRequest), eq(expression), eq("1"), any(), any());
-        var actual = processItemWithContext.processContextItem(populateRequest, questionnaireItem);
+        var adapter = (IQuestionnaireItemComponentAdapter)
+                IAdapterFactory.createAdapterForBase(populateRequest.getFhirVersion(), questionnaireItem);
+        var actual = processItemWithContext.processContextItem(populateRequest, adapter);
         assertEquals(1, actual.size());
-        assertTrue(
-                ((QuestionnaireResponseItemComponent) actual.get(0)).getAnswer().isEmpty());
+        assertTrue(actual.get(0).getAnswer().isEmpty());
     }
 }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaireresponse/extract/ProcessDefinitionItemTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaireresponse/extract/ProcessDefinitionItemTests.java
@@ -11,7 +11,7 @@ import static org.opencds.cqf.fhir.cr.questionnaireresponse.TestQuestionnaireRes
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.repository.IRepository;
-import java.util.Arrays;
+import java.util.List;
 import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.Condition;
@@ -19,6 +19,7 @@ import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Questionnaire;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType;
 import org.hl7.fhir.r4.model.QuestionnaireResponse;
 import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent;
 import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
@@ -32,6 +33,7 @@ import org.opencds.cqf.fhir.cql.LibraryEngine;
 import org.opencds.cqf.fhir.cr.common.ExpressionProcessor;
 import org.opencds.cqf.fhir.utility.Constants;
 
+@SuppressWarnings("UnstableApiUsage")
 @ExtendWith(MockitoExtension.class)
 class ProcessDefinitionItemTests {
     private final FhirContext fhirContextR4 = FhirContext.forR4Cached();
@@ -59,7 +61,7 @@ class ProcessDefinitionItemTests {
         var fhirVersion = FhirVersionEnum.R4;
         var item = new QuestionnaireItemComponent();
         var responseItem = new QuestionnaireResponseItemComponent();
-        var itemPair = new ItemPair(item, responseItem);
+        var itemPair = new ItemPair(fhirVersion, item, responseItem);
         var questionnaire = new Questionnaire();
         var response = new QuestionnaireResponse();
         var request = newExtractRequestForVersion(fhirVersion, libraryEngine, response, questionnaire);
@@ -72,7 +74,7 @@ class ProcessDefinitionItemTests {
         var item = new QuestionnaireItemComponent();
         item.setDefinition("http://hl7.org/fhir/StructureDefinition/RelatedPerson.name.text");
         var responseItem = new QuestionnaireResponseItemComponent();
-        var itemPair = new ItemPair(item, responseItem);
+        var itemPair = new ItemPair(fhirVersion, item, responseItem);
         var questionnaire = new Questionnaire();
         var response = new QuestionnaireResponse();
         var request = newExtractRequestForVersion(fhirVersion, libraryEngine, response, questionnaire);
@@ -85,7 +87,7 @@ class ProcessDefinitionItemTests {
         var item = new QuestionnaireItemComponent().setLinkId("1");
         item.addExtension(Constants.SDC_QUESTIONNAIRE_ITEM_EXTRACTION_CONTEXT, new CodeType("Condition"));
         var responseItem = new QuestionnaireResponseItemComponent().setLinkId("1");
-        var itemPair = new ItemPair(item, responseItem);
+        var itemPair = new ItemPair(fhirVersion, item, responseItem);
         var questionnaire = new Questionnaire();
         var response = new QuestionnaireResponse();
         var request = newExtractRequestForVersion(fhirVersion, libraryEngine, response, questionnaire);
@@ -102,7 +104,7 @@ class ProcessDefinitionItemTests {
                 .setValue(new CanonicalType().setValue(profile));
         item.addExtension(extension);
         var responseItem = new QuestionnaireResponseItemComponent().setLinkId("1");
-        var itemPair = new ItemPair(item, responseItem);
+        var itemPair = new ItemPair(fhirVersion, item, responseItem);
         var questionnaire = new Questionnaire();
         var response = new QuestionnaireResponse();
         var request = newExtractRequestForVersion(fhirVersion, libraryEngine, response, questionnaire);
@@ -113,16 +115,16 @@ class ProcessDefinitionItemTests {
     @Test
     void testItemWithContextExtensionWithMultipleAnswers() {
         var fhirVersion = FhirVersionEnum.R4;
-        var item = new QuestionnaireItemComponent().setLinkId("1");
+        var item = new QuestionnaireItemComponent().setLinkId("1").setType(QuestionnaireItemType.STRING);
         item.setDefinition("http://hl7.org/fhir/Patient#Patient.name.given");
         var responseItem = new QuestionnaireResponseItemComponent().setLinkId("1");
         responseItem.addAnswer(new QuestionnaireResponseItemAnswerComponent().setValue(new StringType("test1")));
         responseItem.addAnswer(new QuestionnaireResponseItemAnswerComponent().setValue(new StringType("test2")));
-        var questionnaire = new Questionnaire().setItem(Arrays.asList(item));
+        var questionnaire = new Questionnaire().setItem(List.of(item));
         var extension =
                 new Extension(Constants.SDC_QUESTIONNAIRE_ITEM_EXTRACTION_CONTEXT).setValue(new CodeType("Patient"));
         questionnaire.addExtension(extension);
-        var response = new QuestionnaireResponse().setItem(Arrays.asList(responseItem));
+        var response = new QuestionnaireResponse().setItem(List.of(responseItem));
         var request = newExtractRequestForVersion(fhirVersion, libraryEngine, response, questionnaire);
         var itemPair = new ItemPair(null, null);
         var actual = fixture.processDefinitionItem(request, itemPair);
@@ -162,11 +164,11 @@ class ProcessDefinitionItemTests {
         var responseItem = new QuestionnaireResponseItemComponent().setLinkId("1");
         responseItem.addAnswer(new QuestionnaireResponseItemAnswerComponent().setValue(new StringType("test1")));
         responseItem.addAnswer(new QuestionnaireResponseItemAnswerComponent().setValue(new StringType("test2")));
-        var questionnaire = new Questionnaire().setItem(Arrays.asList(item));
+        var questionnaire = new Questionnaire().setItem(List.of(item));
         var extension =
                 new Extension(Constants.SDC_QUESTIONNAIRE_ITEM_EXTRACTION_CONTEXT).setValue(new CodeType("Patient"));
         questionnaire.addExtension(extension);
-        var response = new QuestionnaireResponse().setItem(Arrays.asList(responseItem));
+        var response = new QuestionnaireResponse().setItem(List.of(responseItem));
         var request = newExtractRequestForVersion(fhirVersion, libraryEngine, response, questionnaire);
         var itemPair = new ItemPair(null, null);
         var actual = fixture.processDefinitionItem(request, itemPair);

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/shared/r4/input/tests/QuestionnaireResponse-sigmoidoscopy-complication-casefeature-definition.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/shared/r4/input/tests/QuestionnaireResponse-sigmoidoscopy-complication-casefeature-definition.json
@@ -115,6 +115,7 @@
       }
     }
   ],
+  "questionnaire": "#sigmoidoscopy-complication-casefeature-definition",
   "status": "in-progress",
   "subject": {
     "reference": "Patient/nocoverageconcern-sedconcern-sigcomp"

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/shared/r4/opioid-Rec10-patient-view/input/tests/Bundle-opioidcds-10-patient-view.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/shared/r4/opioid-Rec10-patient-view/input/tests/Bundle-opioidcds-10-patient-view.json
@@ -22,7 +22,7 @@
         ],
         "extension": [
           {
-            "url": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-messages",
+            "url": "http://hl7.org/fhir/StructureDefinition/cqf-messages",
             "valueReference": {
               "reference": "#apply-outcome-opioidcds-10-patient-view"
             }

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/shared/r4/opioid-Rec10-patient-view/input/tests/CarePlan-opioidcds-10-patient-view.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/shared/r4/opioid-Rec10-patient-view/input/tests/CarePlan-opioidcds-10-patient-view.json
@@ -7,7 +7,7 @@
       "id": "opioidcds-10-patient-view",
       "extension": [
         {
-          "url": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-messages",
+          "url": "http://hl7.org/fhir/StructureDefinition/cqf-messages",
           "valueReference": {
             "reference": "#apply-outcome-opioidcds-10-patient-view"
           }
@@ -144,7 +144,7 @@
   ],
   "extension": [
     {
-      "url": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-messages",
+      "url": "http://hl7.org/fhir/StructureDefinition/cqf-messages",
       "valueReference": {
         "reference": "#apply-outcome-opioidcds-10-patient-view"
       }

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/shared/r5/input/resources/PlanDefinition-no-url.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/shared/r5/input/resources/PlanDefinition-no-url.json
@@ -1,0 +1,100 @@
+{
+  "resourceType": "PlanDefinition",
+  "id": "no-url",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-recommendationdefinition"
+    ]
+  },
+  "version": "1.0.0",
+  "name": "No Url",
+  "title": "No Url",
+  "type": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/plan-definition-type",
+        "code": "eca-rule",
+        "display": "ECA Rule"
+      }
+    ]
+  },
+  "status": "draft",
+  "experimental": true,
+  "date": "2021-05-26T00:00:00-08:00",
+  "publisher": "Alphora",
+  "useContext": [
+    {
+      "code": {
+        "system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+        "version": "4.0.1",
+        "code": "focus",
+        "display": "Clinical Focus"
+      }
+    }
+  ],
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "system": "http://hl7.org/fhir/ValueSet/iso3166-1-3",
+          "version": "4.0.1",
+          "code": "USA",
+          "display": "United States of America"
+        }
+      ]
+    }
+  ],
+  "purpose": "The purpose of this is to test the system to make sure we have complete end-to-end functionality",
+  "usage": "This is to be used in conjunction with a patient-facing FHIR application.",
+  "copyright": "© CDC 2016+.",
+  "relatedArtifact": [
+    {
+      "type": "depends-on",
+      "resource": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/PAClaim"
+    },
+    {
+      "type": "depends-on",
+      "resource": "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/route-one"
+    }
+  ],
+  "library": [
+    "http://somewhere.org/fhir/uv/mycontentig/Library/OutpatientPriorAuthorizationPrepopulation"
+  ],
+  "action": [
+    {
+      "extension": [],
+      "title": "Prior Auth Route One",
+      "description": "",
+      "condition": [
+        {
+          "kind": "applicability",
+          "expression": {
+            "language": "text/cql.identifier",
+            "expression": "Claim Is Applicable"
+          }
+        }
+      ],
+      "input": [
+        {
+          "requirement": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-featureExpression",
+                "valueExpression": {
+                  "language": "text/cql.identifier",
+                  "expression": "ClaimResource",
+                  "reference": "http://somewhere.org/fhir/uv/mycontentig/Library/OutpatientPriorAuthorizationPrepopulation"
+                }
+              }
+            ],
+            "type": "Claim",
+            "profile": [
+              "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/PAClaim"
+            ]
+          }
+        }
+      ],
+      "definitionCanonical": "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/route-one"
+    }
+  ]
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/BundleHelper.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/BundleHelper.java
@@ -555,9 +555,6 @@ public class BundleHelper {
      */
     public static IBaseBackboneElement setRequestUrl(
             FhirVersionEnum fhirVersion, IBaseBackboneElement request, String url) {
-        if (request == null) {
-            request = newRequest(fhirVersion, null);
-        }
         return switch (fhirVersion) {
             case DSTU3 -> ((Bundle.BundleEntryRequestComponent) request).setUrl(url);
             case R4 -> ((BundleEntryRequestComponent) request).setUrl(url);
@@ -576,9 +573,6 @@ public class BundleHelper {
      */
     public static IBaseBackboneElement setRequestIfNoneExist(
             FhirVersionEnum fhirVersion, IBaseBackboneElement request, String ifNoneExist) {
-        if (request == null) {
-            request = newRequest(fhirVersion, null);
-        }
         return switch (fhirVersion) {
             case DSTU3 -> ((Bundle.BundleEntryRequestComponent) request).setIfNoneExist(ifNoneExist);
             case R4 -> ((BundleEntryRequestComponent) request).setIfNoneExist(ifNoneExist);
@@ -597,9 +591,6 @@ public class BundleHelper {
      */
     public static IBaseBackboneElement setEntryFullUrl(
             FhirVersionEnum fhirVersion, IBaseBackboneElement entry, String fullUrl) {
-        if (entry == null) {
-            entry = newEntry(fhirVersion);
-        }
         return switch (fhirVersion) {
             case DSTU3 -> ((Bundle.BundleEntryComponent) entry).setFullUrl(fullUrl);
             case R4 -> ((BundleEntryComponent) entry).setFullUrl(fullUrl);
@@ -618,12 +609,6 @@ public class BundleHelper {
      */
     public static IBaseBackboneElement setEntryRequest(
             FhirVersionEnum fhirVersion, IBaseBackboneElement entry, IBaseBackboneElement request) {
-        if (entry == null) {
-            entry = newEntry(fhirVersion);
-        }
-        if (request == null) {
-            request = newRequest(fhirVersion, null);
-        }
         String requestTypeError = "Request should be of type: %s";
         return switch (fhirVersion) {
             case DSTU3 -> {

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/BundleHelper.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/BundleHelper.java
@@ -30,47 +30,43 @@ public class BundleHelper {
      * Returns the resource of the first entry in a Bundle
      *
      * @param bundle IBaseBundle type
-     * @return
+     * @return IBaseBackboneElement
      */
     public static IBaseBackboneElement getEntryFirstRep(IBaseBundle bundle) {
         var fhirVersion = bundle.getStructureFhirVersionEnum();
-        switch (fhirVersion) {
-            case DSTU3:
-                return ((org.hl7.fhir.dstu3.model.Bundle) bundle).getEntryFirstRep();
-            case R4:
-                return ((org.hl7.fhir.r4.model.Bundle) bundle).getEntryFirstRep();
-            case R5:
-                return ((org.hl7.fhir.r5.model.Bundle) bundle).getEntryFirstRep();
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> ((Bundle) bundle).getEntryFirstRep();
+            case R4 -> ((org.hl7.fhir.r4.model.Bundle) bundle).getEntryFirstRep();
+            case R5 -> ((org.hl7.fhir.r5.model.Bundle) bundle).getEntryFirstRep();
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
      * Returns the resource of the first entry in a Bundle
      *
      * @param bundle IBaseBundle type
-     * @return
+     * @return IBaseResource
      */
     public static IBaseResource getEntryResourceFirstRep(IBaseBundle bundle) {
         var fhirVersion = bundle.getStructureFhirVersionEnum();
-        switch (fhirVersion) {
-            case DSTU3:
-                var dstu3Entry = ((org.hl7.fhir.dstu3.model.Bundle) bundle).getEntryFirstRep();
-                return dstu3Entry != null && dstu3Entry.hasResource() ? dstu3Entry.getResource() : null;
-            case R4:
+        return switch (fhirVersion) {
+            case DSTU3 -> {
+                var dstu3Entry = ((Bundle) bundle).getEntryFirstRep();
+                yield dstu3Entry != null && dstu3Entry.hasResource() ? dstu3Entry.getResource() : null;
+            }
+            case R4 -> {
                 var r4Entry = ((org.hl7.fhir.r4.model.Bundle) bundle).getEntryFirstRep();
-                return r4Entry != null && r4Entry.hasResource() ? r4Entry.getResource() : null;
-            case R5:
+                yield r4Entry != null && r4Entry.hasResource() ? r4Entry.getResource() : null;
+            }
+            case R5 -> {
                 var r5Entry = ((org.hl7.fhir.r5.model.Bundle) bundle).getEntryFirstRep();
-                return r5Entry != null && r5Entry.hasResource() ? r5Entry.getResource() : null;
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+                yield r5Entry != null && r5Entry.hasResource() ? r5Entry.getResource() : null;
+            }
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
@@ -115,21 +111,16 @@ public class BundleHelper {
      *
      * @param fhirVersion FhirVersionEnum
      * @param entry IBaseBackboneElement type
-     * @return
+     * @return IBaseResource
      */
     public static IBaseResource getEntryResource(FhirVersionEnum fhirVersion, IBaseBackboneElement entry) {
-        switch (fhirVersion) {
-            case DSTU3:
-                return ((org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent) entry).getResource();
-            case R4:
-                return ((org.hl7.fhir.r4.model.Bundle.BundleEntryComponent) entry).getResource();
-            case R5:
-                return ((org.hl7.fhir.r5.model.Bundle.BundleEntryComponent) entry).getResource();
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> ((Bundle.BundleEntryComponent) entry).getResource();
+            case R4 -> ((BundleEntryComponent) entry).getResource();
+            case R5 -> ((org.hl7.fhir.r5.model.Bundle.BundleEntryComponent) entry).getResource();
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
@@ -137,30 +128,25 @@ public class BundleHelper {
      *
      * @param fhirVersion FhirVersionEnum
      * @param entry IBaseBackboneElement type
-     * @return
+     * @return boolean
      */
     public static boolean isEntryRequestPut(FhirVersionEnum fhirVersion, IBaseBackboneElement entry) {
-        switch (fhirVersion) {
-            case DSTU3:
-                return Optional.ofNullable(((org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent) entry).getRequest())
-                        .map(r -> r.getMethod())
-                        .filter(r -> r == org.hl7.fhir.dstu3.model.Bundle.HTTPVerb.PUT)
-                        .isPresent();
-            case R4:
-                return Optional.ofNullable(((org.hl7.fhir.r4.model.Bundle.BundleEntryComponent) entry).getRequest())
-                        .map(r -> r.getMethod())
-                        .filter(r -> r == org.hl7.fhir.r4.model.Bundle.HTTPVerb.PUT)
-                        .isPresent();
-            case R5:
-                return Optional.ofNullable(((org.hl7.fhir.r5.model.Bundle.BundleEntryComponent) entry).getRequest())
-                        .map(r -> r.getMethod())
-                        .filter(r -> r == org.hl7.fhir.r5.model.Bundle.HTTPVerb.PUT)
-                        .isPresent();
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> Optional.ofNullable(((Bundle.BundleEntryComponent) entry).getRequest())
+                    .map(Bundle.BundleEntryRequestComponent::getMethod)
+                    .filter(r -> r == Bundle.HTTPVerb.PUT)
+                    .isPresent();
+            case R4 -> Optional.ofNullable(((BundleEntryComponent) entry).getRequest())
+                    .map(BundleEntryRequestComponent::getMethod)
+                    .filter(r -> r == org.hl7.fhir.r4.model.Bundle.HTTPVerb.PUT)
+                    .isPresent();
+            case R5 -> Optional.ofNullable(((org.hl7.fhir.r5.model.Bundle.BundleEntryComponent) entry).getRequest())
+                    .map(org.hl7.fhir.r5.model.Bundle.BundleEntryRequestComponent::getMethod)
+                    .filter(r -> r == org.hl7.fhir.r5.model.Bundle.HTTPVerb.PUT)
+                    .isPresent();
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
@@ -168,30 +154,25 @@ public class BundleHelper {
      *
      * @param fhirVersion FhirVersionEnum
      * @param entry IBaseBackboneElement type
-     * @return
+     * @return boolean
      */
     public static boolean isEntryRequestPost(FhirVersionEnum fhirVersion, IBaseBackboneElement entry) {
-        switch (fhirVersion) {
-            case DSTU3:
-                return Optional.ofNullable(((org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent) entry).getRequest())
-                        .map(r -> r.getMethod())
-                        .filter(r -> r == org.hl7.fhir.dstu3.model.Bundle.HTTPVerb.POST)
-                        .isPresent();
-            case R4:
-                return Optional.ofNullable(((org.hl7.fhir.r4.model.Bundle.BundleEntryComponent) entry).getRequest())
-                        .map(r -> r.getMethod())
-                        .filter(r -> r == org.hl7.fhir.r4.model.Bundle.HTTPVerb.POST)
-                        .isPresent();
-            case R5:
-                return Optional.ofNullable(((org.hl7.fhir.r5.model.Bundle.BundleEntryComponent) entry).getRequest())
-                        .map(r -> r.getMethod())
-                        .filter(r -> r == org.hl7.fhir.r5.model.Bundle.HTTPVerb.POST)
-                        .isPresent();
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> Optional.ofNullable(((Bundle.BundleEntryComponent) entry).getRequest())
+                    .map(Bundle.BundleEntryRequestComponent::getMethod)
+                    .filter(r -> r == Bundle.HTTPVerb.POST)
+                    .isPresent();
+            case R4 -> Optional.ofNullable(((BundleEntryComponent) entry).getRequest())
+                    .map(BundleEntryRequestComponent::getMethod)
+                    .filter(r -> r == org.hl7.fhir.r4.model.Bundle.HTTPVerb.POST)
+                    .isPresent();
+            case R5 -> Optional.ofNullable(((org.hl7.fhir.r5.model.Bundle.BundleEntryComponent) entry).getRequest())
+                    .map(org.hl7.fhir.r5.model.Bundle.BundleEntryRequestComponent::getMethod)
+                    .filter(r -> r == org.hl7.fhir.r5.model.Bundle.HTTPVerb.POST)
+                    .isPresent();
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
@@ -199,53 +180,43 @@ public class BundleHelper {
      *
      * @param fhirVersion FhirVersionEnum
      * @param entry IBaseBackboneElement type
-     * @return
+     * @return boolean
      */
     public static boolean isEntryRequestDelete(FhirVersionEnum fhirVersion, IBaseBackboneElement entry) {
-        switch (fhirVersion) {
-            case DSTU3:
-                return Optional.ofNullable(((org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent) entry).getRequest())
-                        .map(Bundle.BundleEntryRequestComponent::getMethod)
-                        .filter(r -> r == org.hl7.fhir.dstu3.model.Bundle.HTTPVerb.DELETE)
-                        .isPresent();
-            case R4:
-                return Optional.ofNullable(((org.hl7.fhir.r4.model.Bundle.BundleEntryComponent) entry).getRequest())
-                        .map(BundleEntryRequestComponent::getMethod)
-                        .filter(r -> r == org.hl7.fhir.r4.model.Bundle.HTTPVerb.DELETE)
-                        .isPresent();
-            case R5:
-                return Optional.ofNullable(((org.hl7.fhir.r5.model.Bundle.BundleEntryComponent) entry).getRequest())
-                        .map(org.hl7.fhir.r5.model.Bundle.BundleEntryRequestComponent::getMethod)
-                        .filter(r -> r == org.hl7.fhir.r5.model.Bundle.HTTPVerb.DELETE)
-                        .isPresent();
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> Optional.ofNullable(((Bundle.BundleEntryComponent) entry).getRequest())
+                    .map(Bundle.BundleEntryRequestComponent::getMethod)
+                    .filter(r -> r == Bundle.HTTPVerb.DELETE)
+                    .isPresent();
+            case R4 -> Optional.ofNullable(((BundleEntryComponent) entry).getRequest())
+                    .map(BundleEntryRequestComponent::getMethod)
+                    .filter(r -> r == org.hl7.fhir.r4.model.Bundle.HTTPVerb.DELETE)
+                    .isPresent();
+            case R5 -> Optional.ofNullable(((org.hl7.fhir.r5.model.Bundle.BundleEntryComponent) entry).getRequest())
+                    .map(org.hl7.fhir.r5.model.Bundle.BundleEntryRequestComponent::getMethod)
+                    .filter(r -> r == org.hl7.fhir.r5.model.Bundle.HTTPVerb.DELETE)
+                    .isPresent();
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
      * Returns the list of entries from the Bundle
      *
      * @param bundle IBaseBundle type
-     * @return
+     * @return IBaseBackboneElement
      */
     @SuppressWarnings("unchecked")
     public static <T extends IBaseBackboneElement> List<T> getEntry(IBaseBundle bundle) {
         var fhirVersion = bundle.getStructureFhirVersionEnum();
-        switch (fhirVersion) {
-            case DSTU3:
-                return (List<T>) ((org.hl7.fhir.dstu3.model.Bundle) bundle).getEntry();
-            case R4:
-                return (List<T>) ((org.hl7.fhir.r4.model.Bundle) bundle).getEntry();
-            case R5:
-                return (List<T>) ((org.hl7.fhir.r5.model.Bundle) bundle).getEntry();
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> (List<T>) ((Bundle) bundle).getEntry();
+            case R4 -> (List<T>) ((org.hl7.fhir.r4.model.Bundle) bundle).getEntry();
+            case R5 -> (List<T>) ((org.hl7.fhir.r5.model.Bundle) bundle).getEntry();
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
@@ -253,33 +224,26 @@ public class BundleHelper {
      *
      * @param fhirVersion FhirVersionEnum
      * @param entry IBaseBackboneElement type
-     * @return
+     * @return Optional IIdType
      */
     public static Optional<IIdType> getEntryRequestId(FhirVersionEnum fhirVersion, IBaseBackboneElement entry) {
-        switch (fhirVersion) {
-            case DSTU3:
-                return Optional.ofNullable(((org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent) entry)
-                                .getRequest()
-                                .getUrl())
-                        .map(Canonicals::getIdPart)
-                        .map(IdType::new);
-            case R4:
-                return Optional.ofNullable(((org.hl7.fhir.r4.model.Bundle.BundleEntryComponent) entry)
-                                .getRequest()
-                                .getUrl())
-                        .map(Canonicals::getIdPart)
-                        .map(org.hl7.fhir.r4.model.IdType::new);
-            case R5:
-                return Optional.ofNullable(((org.hl7.fhir.r5.model.Bundle.BundleEntryComponent) entry)
-                                .getRequest()
-                                .getUrl())
-                        .map(Canonicals::getIdPart)
-                        .map(org.hl7.fhir.r5.model.IdType::new);
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> Optional.ofNullable(
+                            ((Bundle.BundleEntryComponent) entry).getRequest().getUrl())
+                    .map(Canonicals::getIdPart)
+                    .map(IdType::new);
+            case R4 -> Optional.ofNullable(
+                            ((BundleEntryComponent) entry).getRequest().getUrl())
+                    .map(Canonicals::getIdPart)
+                    .map(org.hl7.fhir.r4.model.IdType::new);
+            case R5 -> Optional.ofNullable(((org.hl7.fhir.r5.model.Bundle.BundleEntryComponent) entry)
+                            .getRequest()
+                            .getUrl())
+                    .map(Canonicals::getIdPart)
+                    .map(org.hl7.fhir.r5.model.IdType::new);
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
@@ -336,7 +300,7 @@ public class BundleHelper {
      *
      * @param bundle IBaseBundle type
      * @param entry IBaseBackboneElement type
-     * @return
+     * @return IBaseBundle
      */
     public static IBaseBundle addEntry(IBaseBundle bundle, IBaseBackboneElement entry) {
         var fhirVersion = bundle.getStructureFhirVersionEnum();
@@ -366,7 +330,7 @@ public class BundleHelper {
      * Returns a new Bundle for the given version of FHIR
      *
      * @param fhirVersion FhirVersionEnum
-     * @return
+     * @return IBaseBundle
      */
     public static IBaseBundle newBundle(FhirVersionEnum fhirVersion) {
         return newBundle(fhirVersion, null, null);
@@ -377,7 +341,7 @@ public class BundleHelper {
      *
      * @param fhirVersion FhirVersionEnum
      * @param type The type of Bundle to return, defaults to COLLECTION
-     * @return
+     * @return IBaseBundle
      */
     public static IBaseBundle newBundle(FhirVersionEnum fhirVersion, String type) {
         return newBundle(fhirVersion, null, type);
@@ -389,21 +353,16 @@ public class BundleHelper {
      * @param fhirVersion FhirVersionEnum
      * @param id Id to set on the Bundle, will ignore if null
      * @param type The type of Bundle to return, defaults to COLLECTION
-     * @return
+     * @return IBaseBundle
      */
     public static IBaseBundle newBundle(FhirVersionEnum fhirVersion, String id, String type) {
-        switch (fhirVersion) {
-            case DSTU3:
-                return newDstu3Bundle(id, type);
-            case R4:
-                return newR4Bundle(id, type);
-            case R5:
-                return newR5Bundle(id, type);
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> newDstu3Bundle(id, type);
+            case R4 -> newR4Bundle(id, type);
+            case R5 -> newR5Bundle(id, type);
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     @Nonnull
@@ -445,278 +404,217 @@ public class BundleHelper {
 
     /**
      * Sets the BundleType of the Bundle and returns the Bundle
-     * @param bundle
-     * @param bundleType
-     * @return
+     * @param bundle IBaseBundle
+     * @param bundleType String
+     * @return IBaseBundle
      */
     public static IBaseBundle setBundleType(IBaseBundle bundle, String bundleType) {
         var fhirVersion = bundle.getStructureFhirVersionEnum();
-        switch (fhirVersion) {
-            case DSTU3:
-                return ((org.hl7.fhir.dstu3.model.Bundle) bundle)
-                        .setType(org.hl7.fhir.dstu3.model.Bundle.BundleType.fromCode(bundleType));
-            case R4:
-                return ((org.hl7.fhir.r4.model.Bundle) bundle)
-                        .setType(org.hl7.fhir.r4.model.Bundle.BundleType.fromCode(bundleType));
-            case R5:
-                return ((org.hl7.fhir.r5.model.Bundle) bundle)
-                        .setType(org.hl7.fhir.r5.model.Bundle.BundleType.fromCode(bundleType));
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> ((Bundle) bundle).setType(Bundle.BundleType.fromCode(bundleType));
+            case R4 -> ((org.hl7.fhir.r4.model.Bundle) bundle)
+                    .setType(org.hl7.fhir.r4.model.Bundle.BundleType.fromCode(bundleType));
+            case R5 -> ((org.hl7.fhir.r5.model.Bundle) bundle)
+                    .setType(org.hl7.fhir.r5.model.Bundle.BundleType.fromCode(bundleType));
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
      * Sets the total property of the Bundle and returns the Bundle
-     * @param bundle
-     * @param total
-     * @return
+     * @param bundle IBaseBundle
+     * @param total int
+     * @return IBaseBundle
      */
     public static IBaseBundle setBundleTotal(IBaseBundle bundle, int total) {
         var fhirVersion = bundle.getStructureFhirVersionEnum();
-        switch (fhirVersion) {
-            case DSTU3:
-                return ((org.hl7.fhir.dstu3.model.Bundle) bundle).setTotal(total);
-            case R4:
-                return ((org.hl7.fhir.r4.model.Bundle) bundle).setTotal(total);
-            case R5:
-                return ((org.hl7.fhir.r5.model.Bundle) bundle).setTotal(total);
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> ((Bundle) bundle).setTotal(total);
+            case R4 -> ((org.hl7.fhir.r4.model.Bundle) bundle).setTotal(total);
+            case R5 -> ((org.hl7.fhir.r5.model.Bundle) bundle).setTotal(total);
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
      * Returns a new entry element
-     * @param fhirVersion
-     * @return
+     * @param fhirVersion FhirVersionEnum
+     * @return IBaseBackboneElement
      */
     public static IBaseBackboneElement newEntry(FhirVersionEnum fhirVersion) {
-        switch (fhirVersion) {
-            case DSTU3:
-                return new org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent();
-            case R4:
-                return new org.hl7.fhir.r4.model.Bundle.BundleEntryComponent();
-            case R5:
-                return new org.hl7.fhir.r5.model.Bundle.BundleEntryComponent();
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> new Bundle.BundleEntryComponent();
+            case R4 -> new BundleEntryComponent();
+            case R5 -> new org.hl7.fhir.r5.model.Bundle.BundleEntryComponent();
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
      * Returns a new entry element with the Resource
-     * @param resource
-     * @return
+     * @param resource IBaseResource
+     * @return IBaseBackboneElement
      */
     public static IBaseBackboneElement newEntryWithResource(IBaseResource resource) {
         var fhirVersion = resource.getStructureFhirVersionEnum();
-        switch (fhirVersion) {
-            case DSTU3:
-                return new org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent()
-                        .setResource((org.hl7.fhir.dstu3.model.Resource) resource);
-            case R4:
-                return new org.hl7.fhir.r4.model.Bundle.BundleEntryComponent()
-                        .setResource((org.hl7.fhir.r4.model.Resource) resource);
-            case R5:
-                return new org.hl7.fhir.r5.model.Bundle.BundleEntryComponent()
-                        .setResource((org.hl7.fhir.r5.model.Resource) resource);
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> new Bundle.BundleEntryComponent().setResource((org.hl7.fhir.dstu3.model.Resource) resource);
+            case R4 -> new BundleEntryComponent().setResource((org.hl7.fhir.r4.model.Resource) resource);
+            case R5 -> new org.hl7.fhir.r5.model.Bundle.BundleEntryComponent()
+                    .setResource((org.hl7.fhir.r5.model.Resource) resource);
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
      * Returns a new entry element with the Response
-     * @param fhirVersion
-     * @param response
-     * @return
+     * @param fhirVersion FhirVersionEnum
+     * @param response IBaseBackboneElement
+     * @return IBaseBackboneElement
      */
     public static IBaseBackboneElement newEntryWithResponse(
             FhirVersionEnum fhirVersion, IBaseBackboneElement response) {
-        switch (fhirVersion) {
-            case DSTU3:
-                return new org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent()
-                        .setResponse((org.hl7.fhir.dstu3.model.Bundle.BundleEntryResponseComponent) response);
-            case R4:
-                return new org.hl7.fhir.r4.model.Bundle.BundleEntryComponent()
-                        .setResponse((org.hl7.fhir.r4.model.Bundle.BundleEntryResponseComponent) response);
-            case R5:
-                return new org.hl7.fhir.r5.model.Bundle.BundleEntryComponent()
-                        .setResponse((org.hl7.fhir.r5.model.Bundle.BundleEntryResponseComponent) response);
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> new Bundle.BundleEntryComponent().setResponse((Bundle.BundleEntryResponseComponent) response);
+            case R4 -> new BundleEntryComponent()
+                    .setResponse((org.hl7.fhir.r4.model.Bundle.BundleEntryResponseComponent) response);
+            case R5 -> new org.hl7.fhir.r5.model.Bundle.BundleEntryComponent()
+                    .setResponse((org.hl7.fhir.r5.model.Bundle.BundleEntryResponseComponent) response);
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
      * Returns a new BundleEntryResponse element with the location
-     * @param fhirVersion
-     * @param location
-     * @return
+     * @param fhirVersion FhirVersionEnum
+     * @param location String
+     * @return IBaseBackboneElement
      */
     public static IBaseBackboneElement newResponseWithLocation(FhirVersionEnum fhirVersion, String location) {
-        switch (fhirVersion) {
-            case DSTU3:
-                return new org.hl7.fhir.dstu3.model.Bundle.BundleEntryResponseComponent().setLocation(location);
-            case R4:
-                return new org.hl7.fhir.r4.model.Bundle.BundleEntryResponseComponent().setLocation(location);
-            case R5:
-                return new org.hl7.fhir.r5.model.Bundle.BundleEntryResponseComponent().setLocation(location);
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> new Bundle.BundleEntryResponseComponent().setLocation(location);
+            case R4 -> new org.hl7.fhir.r4.model.Bundle.BundleEntryResponseComponent().setLocation(location);
+            case R5 -> new org.hl7.fhir.r5.model.Bundle.BundleEntryResponseComponent().setLocation(location);
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
      * Returns a new BundleEntryRequest element with the method and url
-     * @param fhirVersion
-     * @param method
-     * @param url
-     * @return
+     * @param fhirVersion FhirVersionEnum
+     * @param method String
+     * @param url String
+     * @return IBaseBackboneElement
      */
     public static IBaseBackboneElement newRequest(FhirVersionEnum fhirVersion, String method, String url) {
-        switch (fhirVersion) {
-            case DSTU3:
-                return new org.hl7.fhir.dstu3.model.Bundle.BundleEntryRequestComponent()
-                        .setMethod(org.hl7.fhir.dstu3.model.Bundle.HTTPVerb.fromCode(method))
-                        .setUrl(url);
-            case R4:
-                return new org.hl7.fhir.r4.model.Bundle.BundleEntryRequestComponent()
-                        .setMethod(org.hl7.fhir.r4.model.Bundle.HTTPVerb.fromCode(method))
-                        .setUrl(url);
-            case R5:
-                return new org.hl7.fhir.r5.model.Bundle.BundleEntryRequestComponent()
-                        .setMethod(org.hl7.fhir.r5.model.Bundle.HTTPVerb.fromCode(method))
-                        .setUrl(url);
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> new Bundle.BundleEntryRequestComponent()
+                    .setMethod(Bundle.HTTPVerb.fromCode(method))
+                    .setUrl(url);
+            case R4 -> new BundleEntryRequestComponent()
+                    .setMethod(org.hl7.fhir.r4.model.Bundle.HTTPVerb.fromCode(method))
+                    .setUrl(url);
+            case R5 -> new org.hl7.fhir.r5.model.Bundle.BundleEntryRequestComponent()
+                    .setMethod(org.hl7.fhir.r5.model.Bundle.HTTPVerb.fromCode(method))
+                    .setUrl(url);
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
      * Returns a new BundleEntryRequest element with the method
-     * @param fhirVersion
-     * @param method
-     * @return
+     * @param fhirVersion FhirVersionEnum
+     * @param method String
+     * @return IBaseBackboneElement
      */
     public static IBaseBackboneElement newRequest(FhirVersionEnum fhirVersion, String method) {
-        switch (fhirVersion) {
-            case DSTU3:
-                return new org.hl7.fhir.dstu3.model.Bundle.BundleEntryRequestComponent()
-                        .setMethod(org.hl7.fhir.dstu3.model.Bundle.HTTPVerb.fromCode(method));
-            case R4:
-                return new org.hl7.fhir.r4.model.Bundle.BundleEntryRequestComponent()
-                        .setMethod(org.hl7.fhir.r4.model.Bundle.HTTPVerb.fromCode(method));
-            case R5:
-                return new org.hl7.fhir.r5.model.Bundle.BundleEntryRequestComponent()
-                        .setMethod(org.hl7.fhir.r5.model.Bundle.HTTPVerb.fromCode(method));
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> new Bundle.BundleEntryRequestComponent().setMethod(Bundle.HTTPVerb.fromCode(method));
+            case R4 -> new BundleEntryRequestComponent()
+                    .setMethod(org.hl7.fhir.r4.model.Bundle.HTTPVerb.fromCode(method));
+            case R5 -> new org.hl7.fhir.r5.model.Bundle.BundleEntryRequestComponent()
+                    .setMethod(org.hl7.fhir.r5.model.Bundle.HTTPVerb.fromCode(method));
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
      * Sets the BundleEntryRequest url
-     * @param fhirVersion
-     * @param request
-     * @param url
-     * @return
+     * @param fhirVersion FhirVersionEnum
+     * @param request IBaseBackboneElement
+     * @param url String
+     * @return IBaseBackboneElement
      */
     public static IBaseBackboneElement setRequestUrl(
             FhirVersionEnum fhirVersion, IBaseBackboneElement request, String url) {
         if (request == null) {
             request = newRequest(fhirVersion, null);
         }
-        switch (fhirVersion) {
-            case DSTU3:
-                return ((org.hl7.fhir.dstu3.model.Bundle.BundleEntryRequestComponent) request).setUrl(url);
-            case R4:
-                return ((org.hl7.fhir.r4.model.Bundle.BundleEntryRequestComponent) request).setUrl(url);
-            case R5:
-                return ((org.hl7.fhir.r5.model.Bundle.BundleEntryRequestComponent) request).setUrl(url);
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> ((Bundle.BundleEntryRequestComponent) request).setUrl(url);
+            case R4 -> ((BundleEntryRequestComponent) request).setUrl(url);
+            case R5 -> ((org.hl7.fhir.r5.model.Bundle.BundleEntryRequestComponent) request).setUrl(url);
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
      * Sets the BundleEntryRequest ifNoneExist property
-     * @param fhirVersion
-     * @param request
-     * @param ifNoneExist
-     * @return
+     * @param fhirVersion FhirVersionEnum
+     * @param request IBaseBackboneElement
+     * @param ifNoneExist String
+     * @return IBaseBackboneElement
      */
     public static IBaseBackboneElement setRequestIfNoneExist(
             FhirVersionEnum fhirVersion, IBaseBackboneElement request, String ifNoneExist) {
         if (request == null) {
             request = newRequest(fhirVersion, null);
         }
-        switch (fhirVersion) {
-            case DSTU3:
-                return ((org.hl7.fhir.dstu3.model.Bundle.BundleEntryRequestComponent) request)
-                        .setIfNoneExist(ifNoneExist);
-            case R4:
-                return ((org.hl7.fhir.r4.model.Bundle.BundleEntryRequestComponent) request).setIfNoneExist(ifNoneExist);
-            case R5:
-                return ((org.hl7.fhir.r5.model.Bundle.BundleEntryRequestComponent) request).setIfNoneExist(ifNoneExist);
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> ((Bundle.BundleEntryRequestComponent) request).setIfNoneExist(ifNoneExist);
+            case R4 -> ((BundleEntryRequestComponent) request).setIfNoneExist(ifNoneExist);
+            case R5 -> ((org.hl7.fhir.r5.model.Bundle.BundleEntryRequestComponent) request).setIfNoneExist(ifNoneExist);
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
      * Sets the BundleEntry fullUrl property
-     * @param fhirVersion
-     * @param entry
-     * @param fullUrl
-     * @return
+     * @param fhirVersion FhirVersionEnum
+     * @param entry IBaseBackboneElement
+     * @param fullUrl String
+     * @return IBaseBackboneElement
      */
     public static IBaseBackboneElement setEntryFullUrl(
             FhirVersionEnum fhirVersion, IBaseBackboneElement entry, String fullUrl) {
         if (entry == null) {
             entry = newEntry(fhirVersion);
         }
-        switch (fhirVersion) {
-            case DSTU3:
-                return ((org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent) entry).setFullUrl(fullUrl);
-            case R4:
-                return ((org.hl7.fhir.r4.model.Bundle.BundleEntryComponent) entry).setFullUrl(fullUrl);
-            case R5:
-                return ((org.hl7.fhir.r5.model.Bundle.BundleEntryComponent) entry).setFullUrl(fullUrl);
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+        return switch (fhirVersion) {
+            case DSTU3 -> ((Bundle.BundleEntryComponent) entry).setFullUrl(fullUrl);
+            case R4 -> ((BundleEntryComponent) entry).setFullUrl(fullUrl);
+            case R5 -> ((org.hl7.fhir.r5.model.Bundle.BundleEntryComponent) entry).setFullUrl(fullUrl);
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     /**
      * Sets the BundleEntry request property
-     * @param fhirVersion
-     * @param entry
-     * @param request
-     * @return
+     * @param fhirVersion FhirVersionEnum
+     * @param entry IBaseBackboneElement
+     * @param request IBaseBackboneElement
+     * @return IBaseBackboneElement
      */
     public static IBaseBackboneElement setEntryRequest(
             FhirVersionEnum fhirVersion, IBaseBackboneElement entry, IBaseBackboneElement request) {
@@ -727,42 +625,40 @@ public class BundleHelper {
             request = newRequest(fhirVersion, null);
         }
         String requestTypeError = "Request should be of type: %s";
-        switch (fhirVersion) {
-            case DSTU3:
-                if (request != null
-                        && !(request instanceof org.hl7.fhir.dstu3.model.Bundle.BundleEntryRequestComponent)) {
+        return switch (fhirVersion) {
+            case DSTU3 -> {
+                if (request != null && !(request instanceof Bundle.BundleEntryRequestComponent)) {
                     throw new IllegalArgumentException(
                             requestTypeError.formatted("org.hl7.fhir.dstu3.model.Bundle.BundleEntryRequestComponent"));
                 }
-                return ((org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent) entry)
-                        .setRequest((org.hl7.fhir.dstu3.model.Bundle.BundleEntryRequestComponent) request);
-            case R4:
-                if (request != null && !(request instanceof org.hl7.fhir.r4.model.Bundle.BundleEntryRequestComponent)) {
+                yield ((Bundle.BundleEntryComponent) entry).setRequest((Bundle.BundleEntryRequestComponent) request);
+            }
+            case R4 -> {
+                if (request != null && !(request instanceof BundleEntryRequestComponent)) {
                     throw new IllegalArgumentException(
                             requestTypeError.formatted("org.hl7.fhir.r4.model.Bundle.BundleEntryRequestComponent"));
                 }
-                return ((org.hl7.fhir.r4.model.Bundle.BundleEntryComponent) entry)
-                        .setRequest((org.hl7.fhir.r4.model.Bundle.BundleEntryRequestComponent) request);
-            case R5:
+                yield ((BundleEntryComponent) entry).setRequest((BundleEntryRequestComponent) request);
+            }
+            case R5 -> {
                 if (request != null && !(request instanceof org.hl7.fhir.r5.model.Bundle.BundleEntryRequestComponent)) {
                     throw new IllegalArgumentException(
                             requestTypeError.formatted("org.hl7.fhir.r5.model.Bundle.BundleEntryRequestComponent"));
                 }
-                return ((org.hl7.fhir.r5.model.Bundle.BundleEntryComponent) entry)
+                yield ((org.hl7.fhir.r5.model.Bundle.BundleEntryComponent) entry)
                         .setRequest((org.hl7.fhir.r5.model.Bundle.BundleEntryRequestComponent) request);
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+            }
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 
     public static RuntimeSearchParam resourceToRuntimeSearchParam(IBaseResource resource) {
         var fhirVersion = resource.getStructureFhirVersionEnum();
-        switch (fhirVersion) {
-            case DSTU3:
+        return switch (fhirVersion) {
+            case DSTU3 -> {
                 var res = (SearchParameter) resource;
-                return new RuntimeSearchParam(
+                yield new RuntimeSearchParam(
                         res.getIdElement(),
                         res.getUrl(),
                         res.getCode(),
@@ -773,9 +669,10 @@ public class BundleHelper {
                         res.getTarget().stream().map(StringType::toString).collect(Collectors.toSet()),
                         RuntimeSearchParamStatusEnum.ACTIVE,
                         res.getBase().stream().map(StringType::toString).toList());
-            case R4:
+            }
+            case R4 -> {
                 var resR4 = (org.hl7.fhir.r4.model.SearchParameter) resource;
-                return new RuntimeSearchParam(
+                yield new RuntimeSearchParam(
                         resR4.getIdElement(),
                         resR4.getUrl(),
                         resR4.getCode(),
@@ -790,9 +687,10 @@ public class BundleHelper {
                         resR4.getBase().stream()
                                 .map(org.hl7.fhir.r4.model.StringType::toString)
                                 .toList());
-            case R5:
+            }
+            case R5 -> {
                 var resR5 = (org.hl7.fhir.r5.model.SearchParameter) resource;
-                return new RuntimeSearchParam(
+                yield new RuntimeSearchParam(
                         resR5.getIdElement(),
                         resR5.getUrl(),
                         resR5.getCode(),
@@ -803,10 +701,9 @@ public class BundleHelper {
                         resR5.getTarget().stream().map(PrimitiveType::toString).collect(Collectors.toSet()),
                         RuntimeSearchParamStatusEnum.ACTIVE,
                         resR5.getBase().stream().map(PrimitiveType::toString).toList());
-
-            default:
-                throw new IllegalArgumentException(
-                        UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
-        }
+            }
+            default -> throw new IllegalArgumentException(
+                    UNSUPPORTED_VERSION_OF_FHIR.formatted(fhirVersion.getFhirVersionString()));
+        };
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/Constants.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/Constants.java
@@ -108,6 +108,7 @@ public class Constants {
     public static final String CQF_FHIR_QUERY_PATTERN = "http://hl7.org/fhir/StructureDefinition/cqf-fhirQueryPattern";
     public static final String CQF_DIRECT_REFERENCE_EXTENSION =
             "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode";
+    public static final String CQF_MESSAGES = "http://hl7.org/fhir/StructureDefinition/cqf-messages";
 
     public static final String CQFM_EFFECTIVE_DATA_REQUIREMENTS =
             "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-effectiveDataRequirements";

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/Constants.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/Constants.java
@@ -128,7 +128,6 @@ public class Constants {
 
     public static final String DTR_QUESTIONNAIRE_RESPONSE_QUESTIONNAIRE =
             "http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-questionnaireresponse-questionnaire";
-    public static final String EXT_CRMI_MESSAGES = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-messages";
     public static final String SDC_QUESTIONNAIRE_HIDDEN =
             "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden";
     public static final String SDC_QUESTIONNAIRE_ITEM_EXTRACTION_CONTEXT =

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/BaseAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/BaseAdapter.java
@@ -4,6 +4,8 @@ import ca.uhn.fhir.context.BaseRuntimeElementDefinition;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseExtension;
+import org.hl7.fhir.instance.model.api.IBaseHasExtensions;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
@@ -40,5 +42,14 @@ public abstract class BaseAdapter implements IAdapter<IBase> {
 
     public IAdapterFactory getAdapterFactory() {
         return adapterFactory;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <E extends IBaseExtension<?, ?>> E addExtension() {
+        if (get() instanceof IBaseHasExtensions baseHasExtensions) {
+            return (E) baseHasExtensions.addExtension();
+        }
+        return null;
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/BaseAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/BaseAdapter.java
@@ -1,0 +1,44 @@
+package org.opencds.cqf.fhir.utility.adapter;
+
+import ca.uhn.fhir.context.BaseRuntimeElementDefinition;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
+
+public abstract class BaseAdapter implements IAdapter<IBase> {
+    protected final FhirContext fhirContext;
+    protected final BaseRuntimeElementDefinition<?> elementDefinition;
+    protected final IBase element;
+    protected final ModelResolver modelResolver;
+    protected final IAdapterFactory adapterFactory;
+
+    protected BaseAdapter(FhirVersionEnum fhirVersion, IBase element) {
+        if (element == null) {
+            throw new IllegalArgumentException("element can not be null");
+        }
+        this.element = element;
+        fhirContext = FhirContext.forCached(fhirVersion);
+        adapterFactory = IAdapterFactory.forFhirContext(fhirContext);
+        elementDefinition = fhirContext.getElementDefinition(this.element.getClass());
+        modelResolver = FhirModelResolverCache.resolverForVersion(
+                fhirContext.getVersion().getVersion());
+    }
+
+    public FhirContext fhirContext() {
+        return fhirContext;
+    }
+
+    public ModelResolver getModelResolver() {
+        return modelResolver;
+    }
+
+    public IBase get() {
+        return element;
+    }
+
+    public IAdapterFactory getAdapterFactory() {
+        return adapterFactory;
+    }
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/BaseAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/BaseAdapter.java
@@ -9,7 +9,7 @@ import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
 public abstract class BaseAdapter implements IAdapter<IBase> {
     protected final FhirContext fhirContext;
-    protected final BaseRuntimeElementDefinition<?> elementDefinition;
+    protected final BaseRuntimeElementDefinition<?> baseElementDefinition;
     protected final IBase element;
     protected final ModelResolver modelResolver;
     protected final IAdapterFactory adapterFactory;
@@ -21,7 +21,7 @@ public abstract class BaseAdapter implements IAdapter<IBase> {
         this.element = element;
         fhirContext = FhirContext.forCached(fhirVersion);
         adapterFactory = IAdapterFactory.forFhirContext(fhirContext);
-        elementDefinition = fhirContext.getElementDefinition(this.element.getClass());
+        baseElementDefinition = fhirContext.getElementDefinition(this.element.getClass());
         modelResolver = FhirModelResolverCache.resolverForVersion(
                 fhirContext.getVersion().getVersion());
     }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/BaseAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/BaseAdapter.java
@@ -36,10 +36,6 @@ public abstract class BaseAdapter implements IAdapter<IBase> {
         return modelResolver;
     }
 
-    public IBase get() {
-        return element;
-    }
-
     public IAdapterFactory getAdapterFactory() {
         return adapterFactory;
     }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/BaseResourceAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/BaseResourceAdapter.java
@@ -4,6 +4,8 @@ import ca.uhn.fhir.context.BaseRuntimeElementDefinition;
 import ca.uhn.fhir.context.FhirContext;
 import com.google.common.collect.Sets;
 import java.util.Set;
+import org.hl7.fhir.instance.model.api.IBaseExtension;
+import org.hl7.fhir.instance.model.api.IBaseHasExtensions;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.fhir.utility.Constants;
@@ -64,5 +66,14 @@ public abstract class BaseResourceAdapter implements IResourceAdapter {
 
     public IAdapterFactory getAdapterFactory() {
         return adapterFactory;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <E extends IBaseExtension<?, ?>> E addExtension() {
+        if (get() instanceof IBaseHasExtensions baseHasExtensions) {
+            return (E) baseHasExtensions.addExtension();
+        }
+        return null;
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IAdapter.java
@@ -53,6 +53,8 @@ public interface IAdapter<T extends IBase> {
         }
     }
 
+    <E extends IBaseExtension<?, ?>> E addExtension();
+
     default <E extends IBaseExtension<?, ?>> void addExtension(E extension) {
         try {
             getModelResolver().setValue(get(), "extension", Collections.singletonList(extension));

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IAdapter.java
@@ -26,62 +26,69 @@ public interface IAdapter<T extends IBase> {
     public static final Logger logger = LoggerFactory.getLogger(IAdapter.class);
 
     String UNSUPPORTED_VERSION = "Unsupported version: %s";
+    String MISSING_EXTENSION = "Field 'extension' does not exist on Element type {}";
 
     /**
      * @return returns the underlying HL7 Structure for this adapter
      */
     T get();
 
-    public FhirContext fhirContext();
+    FhirContext fhirContext();
 
-    public ModelResolver getModelResolver();
+    default FhirVersionEnum fhirVersion() {
+        return fhirContext().getVersion().getVersion();
+    }
 
-    public default void setExtension(List<? extends IBaseExtension<?, ?>> extensions) {
+    IAdapterFactory getAdapterFactory();
+
+    ModelResolver getModelResolver();
+
+    default void setExtension(List<? extends IBaseExtension<?, ?>> extensions) {
         try {
             getModelResolver().setValue(get(), "extension", null);
             getModelResolver().setValue(get(), "extension", extensions);
         } catch (Exception e) {
             // Do nothing
-            logger.debug("Field 'extension' does not exist on Element type {}", get().fhirType());
+            logger.debug(MISSING_EXTENSION, get().fhirType());
         }
     }
 
-    public default <E extends IBaseExtension<?, ?>> void addExtension(E extension) {
+    default <E extends IBaseExtension<?, ?>> void addExtension(E extension) {
         try {
             getModelResolver().setValue(get(), "extension", Collections.singletonList(extension));
         } catch (Exception e) {
             // Do nothing
-            logger.debug("Field 'extension' does not exist on Element type {}", get().fhirType());
+            logger.debug(MISSING_EXTENSION, get().fhirType());
         }
     }
 
-    public default boolean hasExtension() {
+    default boolean hasExtension() {
         return !getExtension().isEmpty();
     }
 
-    public default boolean hasExtension(String url) {
+    default boolean hasExtension(String url) {
         return hasExtension(get(), url);
     }
 
-    public default <E extends IBaseExtension<?, ?>> List<E> getExtension() {
+    default <E extends IBaseExtension<?, ?>> List<E> getExtension() {
         return getExtension(get());
     }
 
-    public default <E extends IBaseExtension<?, ?>> E getExtensionByUrl(String url) {
+    default <E extends IBaseExtension<?, ?>> E getExtensionByUrl(String url) {
         return getExtensionByUrl(get(), url);
     }
 
-    public default <E extends IBaseExtension<?, ?>> List<E> getExtensionsByUrl(String url) {
+    default <E extends IBaseExtension<?, ?>> List<E> getExtensionsByUrl(String url) {
         return getExtensionsByUrl(get(), url);
     }
 
     @SuppressWarnings("unchecked")
-    public default <E extends IBaseExtension<?, ?>> List<E> getExtension(IBase base) {
+    default <E extends IBaseExtension<?, ?>> List<E> getExtension(IBase base) {
         return resolvePathList(base, "extension").stream().map(e -> (E) e).collect(Collectors.toList());
     }
 
     @SuppressWarnings("unchecked")
-    public default <E extends IBaseExtension<?, ?>> List<E> getExtensionsByUrl(IBase base, String url) {
+    default <E extends IBaseExtension<?, ?>> List<E> getExtensionsByUrl(IBase base, String url) {
         return getExtension(base).stream()
                 .filter(e -> e.getUrl().equals(url))
                 .map(e -> (E) e)
@@ -89,29 +96,29 @@ public interface IAdapter<T extends IBase> {
     }
 
     @SuppressWarnings("unchecked")
-    public default <E extends IBaseExtension<?, ?>> E getExtensionByUrl(IBase base, String url) {
+    default <E extends IBaseExtension<?, ?>> E getExtensionByUrl(IBase base, String url) {
         return getExtensionsByUrl(base, url).stream()
                 .map(e -> (E) e)
                 .findFirst()
                 .orElse(null);
     }
 
-    public default Boolean hasExtension(IBase base, String url) {
+    default Boolean hasExtension(IBase base, String url) {
         return getExtension(base).stream().anyMatch(e -> e.getUrl().equals(url));
     }
 
     @SuppressWarnings("unchecked")
-    public default List<IBase> resolvePathList(IBase base, String path) {
+    default List<IBase> resolvePathList(IBase base, String path) {
         var pathResult = getModelResolver().resolvePath(base, path);
         return pathResult instanceof List ? (List<IBase>) pathResult : new ArrayList<>();
     }
 
     @SuppressWarnings("unchecked")
-    public default <B extends IBase> List<B> resolvePathList(IBase base, String path, Class<B> clazz) {
+    default <B extends IBase> List<B> resolvePathList(IBase base, String path, Class<B> clazz) {
         return resolvePathList(base, path).stream().map(i -> (B) i).collect(Collectors.toList());
     }
 
-    public default String resolvePathString(IBase base, String path) {
+    default String resolvePathString(IBase base, String path) {
         var result = resolvePath(base, path);
         if (result == null) {
             return null;
@@ -127,96 +134,72 @@ public interface IAdapter<T extends IBase> {
         }
     }
 
-    public default IBase resolvePath(IBase base, String path) {
+    default IBase resolvePath(IBase base, String path) {
         return (IBase) getModelResolver().resolvePath(base, path);
     }
 
     @SuppressWarnings("unchecked")
-    public default <B extends IBase> B resolvePath(IBase base, String path, Class<B> clazz) {
+    default <B extends IBase> B resolvePath(IBase base, String path, Class<B> clazz) {
         return (B) resolvePath(base, path);
     }
 
     @SuppressWarnings("unchecked")
     static <T extends ICompositeType> T newPeriod(FhirVersionEnum version) {
-        switch (version) {
-            case DSTU3:
-                return (T) new org.hl7.fhir.dstu3.model.Period();
-            case R4:
-                return (T) new org.hl7.fhir.r4.model.Period();
-            case R5:
-                return (T) new org.hl7.fhir.r5.model.Period();
-            default:
-                throw new UnprocessableEntityException(UNSUPPORTED_VERSION.formatted(version.toString()));
-        }
+        return switch (version) {
+            case DSTU3 -> (T) new org.hl7.fhir.dstu3.model.Period();
+            case R4 -> (T) new org.hl7.fhir.r4.model.Period();
+            case R5 -> (T) new org.hl7.fhir.r5.model.Period();
+            default -> throw new UnprocessableEntityException(UNSUPPORTED_VERSION.formatted(version.toString()));
+        };
     }
 
     @SuppressWarnings("unchecked")
     static <T extends IPrimitiveType<String>> T newStringType(FhirVersionEnum version, String string) {
-        switch (version) {
-            case DSTU3:
-                return (T) new org.hl7.fhir.dstu3.model.StringType(string);
-            case R4:
-                return (T) new org.hl7.fhir.r4.model.StringType(string);
-            case R5:
-                return (T) new org.hl7.fhir.r5.model.StringType(string);
-            default:
-                throw new UnprocessableEntityException(UNSUPPORTED_VERSION.formatted(version.toString()));
-        }
+        return switch (version) {
+            case DSTU3 -> (T) new org.hl7.fhir.dstu3.model.StringType(string);
+            case R4 -> (T) new org.hl7.fhir.r4.model.StringType(string);
+            case R5 -> (T) new org.hl7.fhir.r5.model.StringType(string);
+            default -> throw new UnprocessableEntityException(UNSUPPORTED_VERSION.formatted(version.toString()));
+        };
     }
 
     @SuppressWarnings("unchecked")
     static <T extends IPrimitiveType<String>> T newUriType(FhirVersionEnum version, String string) {
-        switch (version) {
-            case DSTU3:
-                return (T) new org.hl7.fhir.dstu3.model.UriType(string);
-            case R4:
-                return (T) new org.hl7.fhir.r4.model.UriType(string);
-            case R5:
-                return (T) new org.hl7.fhir.r5.model.UriType(string);
-            default:
-                throw new UnprocessableEntityException(UNSUPPORTED_VERSION.formatted(version.toString()));
-        }
+        return switch (version) {
+            case DSTU3 -> (T) new org.hl7.fhir.dstu3.model.UriType(string);
+            case R4 -> (T) new org.hl7.fhir.r4.model.UriType(string);
+            case R5 -> (T) new org.hl7.fhir.r5.model.UriType(string);
+            default -> throw new UnprocessableEntityException(UNSUPPORTED_VERSION.formatted(version.toString()));
+        };
     }
 
     @SuppressWarnings("unchecked")
     static <T extends IPrimitiveType<String>> T newUrlType(FhirVersionEnum version, String string) {
-        switch (version) {
-            case DSTU3:
-                return (T) new org.hl7.fhir.dstu3.model.UriType(string);
-            case R4:
-                return (T) new org.hl7.fhir.r4.model.UrlType(string);
-            case R5:
-                return (T) new org.hl7.fhir.r5.model.UrlType(string);
-            default:
-                throw new UnprocessableEntityException(UNSUPPORTED_VERSION.formatted(version.toString()));
-        }
+        return switch (version) {
+            case DSTU3 -> (T) new org.hl7.fhir.dstu3.model.UriType(string);
+            case R4 -> (T) new org.hl7.fhir.r4.model.UrlType(string);
+            case R5 -> (T) new org.hl7.fhir.r5.model.UrlType(string);
+            default -> throw new UnprocessableEntityException(UNSUPPORTED_VERSION.formatted(version.toString()));
+        };
     }
 
     @SuppressWarnings("unchecked")
     static <T extends IPrimitiveType<Date>> T newDateType(FhirVersionEnum version, Date date) {
-        switch (version) {
-            case DSTU3:
-                return (T) new org.hl7.fhir.dstu3.model.DateType(date);
-            case R4:
-                return (T) new org.hl7.fhir.r4.model.DateType(date);
-            case R5:
-                return (T) new org.hl7.fhir.r5.model.DateType(date);
-            default:
-                throw new UnprocessableEntityException(UNSUPPORTED_VERSION.formatted(version.toString()));
-        }
+        return switch (version) {
+            case DSTU3 -> (T) new org.hl7.fhir.dstu3.model.DateType(date);
+            case R4 -> (T) new org.hl7.fhir.r4.model.DateType(date);
+            case R5 -> (T) new org.hl7.fhir.r5.model.DateType(date);
+            default -> throw new UnprocessableEntityException(UNSUPPORTED_VERSION.formatted(version.toString()));
+        };
     }
 
     @SuppressWarnings("unchecked")
     static <T extends IPrimitiveType<Date>> T newDateTimeType(FhirVersionEnum version, Date date) {
-        switch (version) {
-            case DSTU3:
-                return (T) new org.hl7.fhir.dstu3.model.DateTimeType(date);
-            case R4:
-                return (T) new org.hl7.fhir.r4.model.DateTimeType(date);
-            case R5:
-                return (T) new org.hl7.fhir.r5.model.DateTimeType(date);
-            default:
-                throw new UnprocessableEntityException(UNSUPPORTED_VERSION.formatted(version.toString()));
-        }
+        return switch (version) {
+            case DSTU3 -> (T) new org.hl7.fhir.dstu3.model.DateTimeType(date);
+            case R4 -> (T) new org.hl7.fhir.r4.model.DateTimeType(date);
+            case R5 -> (T) new org.hl7.fhir.r5.model.DateTimeType(date);
+            default -> throw new UnprocessableEntityException(UNSUPPORTED_VERSION.formatted(version.toString()));
+        };
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IAdapterFactory.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IAdapterFactory.java
@@ -174,6 +174,14 @@ public interface IAdapterFactory {
 
     /**
      * Creates an adapter that exposes common Questionnaire item operations across multiple versions of FHIR
+     * Includes a newly created QuestionnaireItemComponent of the appropriate version
+     *
+     * @return an adapter exposing common api calls
+     */
+    IQuestionnaireItemComponentAdapter createQuestionnaireItem();
+
+    /**
+     * Creates an adapter that exposes common Questionnaire item operations across multiple versions of FHIR
      *
      * @param questionnaireItem a FHIR QuestionnaireItemComponent object
      * @return an adapter exposing common api calls
@@ -220,4 +228,12 @@ public interface IAdapterFactory {
      * @return an adapter exposing common api calls
      */
     IGraphDefinitionAdapter createGraphDefinition(IBaseResource graphDefinition);
+
+    /**
+     * Creates an adapter that exposes common StructureDefinition operations across multiple versions of FHIR
+     *
+     * @param structureDefinition a FHIR StructureDefinition Resource
+     * @return an adapter exposing common api calls
+     */
+    IStructureDefinitionAdapter createStructureDefinition(IBaseResource structureDefinition);
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IAdapterFactory.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IAdapterFactory.java
@@ -39,7 +39,7 @@ public interface IAdapterFactory {
      * @param element A FHIR BaseBackboneElement
      * @return an adapter exposing common api calls
      */
-    static IAdapter<? extends IBase> createAdapterForBase(FhirVersionEnum fhirVersion, IBase element) {
+    static IAdapter<IBase> createAdapterForBase(FhirVersionEnum fhirVersion, IBase element) {
         return forFhirVersion(fhirVersion).createBase(element);
     }
 
@@ -57,7 +57,7 @@ public interface IAdapterFactory {
      * @param element A FHIR Base Element
      * @return an adapter exposing common api calls
      */
-    IAdapter<? extends IBase> createBase(IBase element);
+    IAdapter<IBase> createBase(IBase element);
 
     /**
      * Creates an adapter that exposes common MetadataResource operations across multiple versions of FHIR

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IAdapterFactory.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IAdapterFactory.java
@@ -2,10 +2,9 @@ package org.opencds.cqf.fhir.utility.adapter;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.instance.model.api.IDomainResource;
 
 public interface IAdapterFactory {
@@ -35,12 +34,30 @@ public interface IAdapterFactory {
     }
 
     /**
+     * Creates an adapter that exposes common BackboneElement operations across multiple versions of FHIR
+     *
+     * @param element A FHIR BaseBackboneElement
+     * @return an adapter exposing common api calls
+     */
+    static IAdapter<? extends IBase> createAdapterForBase(FhirVersionEnum fhirVersion, IBase element) {
+        return forFhirVersion(fhirVersion).createBase(element);
+    }
+
+    /**
      * Creates an adapter that exposes common Resource operations across multiple versions of FHIR
      *
      * @param resource A FHIR Resource
      * @return an adapter exposing common api calls
      */
     IResourceAdapter createResource(IBaseResource resource);
+
+    /**
+     * Creates an adapter that exposes common Resource operations across multiple versions of FHIR
+     *
+     * @param element A FHIR Base Element
+     * @return an adapter exposing common api calls
+     */
+    IAdapter<? extends IBase> createBase(IBase element);
 
     /**
      * Creates an adapter that exposes common MetadataResource operations across multiple versions of FHIR
@@ -80,7 +97,7 @@ public interface IAdapterFactory {
      * @param attachment a FHIR Attachment Structure
      * @return an adapter exposing common api calls
      */
-    IAttachmentAdapter createAttachment(ICompositeType attachment);
+    IAttachmentAdapter createAttachment(IBase attachment);
 
     /**
      * Creates an adapter that exposes common Parameters operations across multiple versions of FHIR
@@ -97,7 +114,7 @@ public interface IAdapterFactory {
      * @param parametersParameterComponent a FHIR ParametersParameterComponent Structure
      * @return an adapter exposing common api calls
      */
-    IParametersParameterComponentAdapter createParametersParameter(IBaseBackboneElement parametersParameterComponent);
+    IParametersParameterComponentAdapter createParametersParameter(IBase parametersParameterComponent);
 
     /**
      * Creates an adapter that exposes common Endpoint operations across multiple versions of FHIR
@@ -113,7 +130,7 @@ public interface IAdapterFactory {
      * @param codeableConcept a FHIR CodeableConcept object
      * @return an adapter exposing common api calls
      */
-    ICodeableConceptAdapter createCodeableConcept(ICompositeType codeableConcept);
+    ICodeableConceptAdapter createCodeableConcept(IBase codeableConcept);
 
     /**
      * Creates an adapter that exposes common Coding operations across multiple versions of FHIR
@@ -121,7 +138,7 @@ public interface IAdapterFactory {
      * @param coding a FHIR Coding object
      * @return an adapter exposing common api calls
      */
-    ICodingAdapter createCoding(ICompositeType coding);
+    ICodingAdapter createCoding(IBase coding);
 
     /**
      * Creates an adapter that exposes common ElementDefinition operations across multiple versions of FHIR
@@ -129,7 +146,7 @@ public interface IAdapterFactory {
      * @param element a FHIR ElementDefinition object
      * @return an adapter exposing common api calls
      */
-    IElementDefinitionAdapter createElementDefinition(ICompositeType element);
+    IElementDefinitionAdapter createElementDefinition(IBase element);
 
     /**
      * Creates an adapter that exposes common RequestOrchestrationActionComponent operations across multiple versions of FHIR
@@ -137,7 +154,7 @@ public interface IAdapterFactory {
      * @param action a FHIR RequestOrchestrationActionComponent object
      * @return an adapter exposing common api calls
      */
-    IRequestActionAdapter createRequestAction(IBaseBackboneElement action);
+    IRequestActionAdapter createRequestAction(IBase action);
 
     /**
      * Creates an adapter that exposes common DataRequirement operations across multiple versions of FHIR
@@ -145,7 +162,7 @@ public interface IAdapterFactory {
      * @param dataRequirement a FHIR DataRequirement object
      * @return an adapter exposing common api calls
      */
-    IDataRequirementAdapter createDataRequirement(ICompositeType dataRequirement);
+    IDataRequirementAdapter createDataRequirement(IBase dataRequirement);
 
     /**
      * Creates an adapter that exposes common Questionnaire operations across multiple versions of FHIR
@@ -154,6 +171,39 @@ public interface IAdapterFactory {
      * @return an adapter exposing common api calls
      */
     IQuestionnaireAdapter createQuestionnaire(IBaseResource questionnaire);
+
+    /**
+     * Creates an adapter that exposes common Questionnaire item operations across multiple versions of FHIR
+     *
+     * @param questionnaireItem a FHIR QuestionnaireItemComponent object
+     * @return an adapter exposing common api calls
+     */
+    IQuestionnaireItemComponentAdapter createQuestionnaireItem(IBase questionnaireItem);
+
+    /**
+     * Creates an adapter that exposes common QuestionnaireResponse operations across multiple versions of FHIR
+     *
+     * @param questionnaireResponse a FHIR QuestionnaireResponse object
+     * @return an adapter exposing common api calls
+     */
+    IQuestionnaireResponseAdapter createQuestionnaireResponse(IBaseResource questionnaireResponse);
+
+    /**
+     * Creates an adapter that exposes common QuestionnaireResponse item operations across multiple versions of FHIR
+     *
+     * @param questionnaireResponseItem a FHIR QuestionnaireResponseItemComponent object
+     * @return an adapter exposing common api calls
+     */
+    IQuestionnaireResponseItemComponentAdapter createQuestionnaireResponseItem(IBase questionnaireResponseItem);
+
+    /**
+     * Creates an adapter that exposes common QuestionnaireResponse item answer operations across multiple versions of FHIR
+     *
+     * @param questionnaireResponseItemAnswer a FHIR QuestionnaireResponseItemAnswerComponent object
+     * @return an adapter exposing common api calls
+     */
+    IQuestionnaireResponseItemAnswerComponentAdapter createQuestionnaireResponseItemAnswer(
+            IBase questionnaireResponseItemAnswer);
 
     /**
      * Creates an adapter that exposes common ValueSet operations across multiple versions of FHIR

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IAttachmentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IAttachmentAdapter.java
@@ -1,11 +1,12 @@
 package org.opencds.cqf.fhir.utility.adapter;
 
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.ICompositeType;
 
 /**
  * This interface exposes common functionality across all FHIR Attachment versions.
  */
-public interface IAttachmentAdapter extends IAdapter<ICompositeType> {
+public interface IAttachmentAdapter extends IAdapter<IBase> {
 
     ICompositeType get();
 

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/ICodeableConceptAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/ICodeableConceptAdapter.java
@@ -1,9 +1,9 @@
 package org.opencds.cqf.fhir.utility.adapter;
 
 import java.util.List;
-import org.hl7.fhir.instance.model.api.ICompositeType;
+import org.hl7.fhir.instance.model.api.IBase;
 
-public interface ICodeableConceptAdapter extends IAdapter<ICompositeType> {
+public interface ICodeableConceptAdapter extends IAdapter<IBase> {
 
     boolean hasCoding();
 

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/ICodingAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/ICodingAdapter.java
@@ -1,8 +1,8 @@
 package org.opencds.cqf.fhir.utility.adapter;
 
-import org.hl7.fhir.instance.model.api.ICompositeType;
+import org.hl7.fhir.instance.model.api.IBase;
 
-public interface ICodingAdapter extends IAdapter<ICompositeType> {
+public interface ICodingAdapter extends IAdapter<IBase> {
     String getCode();
 
     boolean hasCode();

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IDataRequirementAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IDataRequirementAdapter.java
@@ -1,9 +1,9 @@
 package org.opencds.cqf.fhir.utility.adapter;
 
 import java.util.List;
-import org.hl7.fhir.instance.model.api.ICompositeType;
+import org.hl7.fhir.instance.model.api.IBase;
 
-public interface IDataRequirementAdapter extends IAdapter<ICompositeType> {
+public interface IDataRequirementAdapter extends IAdapter<IBase> {
 
     boolean hasId();
 

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IDataRequirementCodeFilterAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IDataRequirementCodeFilterAdapter.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.fhir.utility.adapter;
 
 import java.util.List;
-import org.hl7.fhir.instance.model.api.IBaseDatatypeElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 
-public interface IDataRequirementCodeFilterAdapter extends IAdapter<IBaseDatatypeElement> {
+public interface IDataRequirementCodeFilterAdapter extends IAdapter<IBase> {
     boolean hasCode();
 
     List<ICodingAdapter> getCode();

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IDependencyInfo.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IDependencyInfo.java
@@ -4,17 +4,17 @@ import java.util.List;
 import org.hl7.fhir.instance.model.api.IBaseExtension;
 
 public interface IDependencyInfo {
-    public String getReferenceSource();
+    String getReferenceSource();
 
-    public void setReferenceSource(String referenceSource);
+    void setReferenceSource(String referenceSource);
 
-    public String getReference();
+    String getReference();
 
-    public void setReference(String reference);
+    void setReference(String reference);
 
-    public String getReferencePackageId();
+    String getReferencePackageId();
 
-    public void setReferencePackageId(String referencePackageId);
+    void setReferencePackageId(String referencePackageId);
 
-    public <E extends IBaseExtension<?, ?>> List<E> getExtension();
+    <E extends IBaseExtension<?, ?>> List<E> getExtension();
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IElementDefinitionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IElementDefinitionAdapter.java
@@ -4,9 +4,8 @@ import java.util.List;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseDatatype;
 import org.hl7.fhir.instance.model.api.IBaseDatatypeElement;
-import org.hl7.fhir.instance.model.api.ICompositeType;
 
-public interface IElementDefinitionAdapter extends IAdapter<ICompositeType> {
+public interface IElementDefinitionAdapter extends IAdapter<IBase> {
     String getId();
 
     String getPath();

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IEndpointAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IEndpointAdapter.java
@@ -3,11 +3,11 @@ package org.opencds.cqf.fhir.utility.adapter;
 import static org.opencds.cqf.fhir.utility.adapter.IAdapter.newUrlType;
 
 public interface IEndpointAdapter extends IResourceAdapter {
-    public default String getAddress() {
+    default String getAddress() {
         return resolvePathString(get(), "address");
     }
 
-    public default void setAddress(String address) {
+    default void setAddress(String address) {
         getModelResolver()
                 .setValue(
                         get(), "address", newUrlType(fhirContext().getVersion().getVersion(), address));

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IItemComponentAdapter.java
@@ -1,0 +1,23 @@
+package org.opencds.cqf.fhir.utility.adapter;
+
+import java.util.List;
+import org.hl7.fhir.instance.model.api.IBase;
+
+public interface IItemComponentAdapter extends IAdapter<IBase> {
+
+    String getLinkId();
+
+    boolean hasDefinition();
+
+    String getDefinition();
+
+    boolean hasItem();
+
+    List<? extends IItemComponentAdapter> getItem();
+
+    void setItem(List<? extends IItemComponentAdapter> item);
+
+    void addItem(IItemComponentAdapter item);
+
+    void addItems(List<IItemComponentAdapter> items);
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IItemComponentAdapter.java
@@ -18,6 +18,4 @@ public interface IItemComponentAdapter extends IAdapter<IBase> {
     void setItem(List<? extends IItemComponentAdapter> item);
 
     void addItem(IItemComponentAdapter item);
-
-    void addItems(List<IItemComponentAdapter> items);
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IParametersAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IParametersAdapter.java
@@ -8,25 +8,25 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 
 public interface IParametersAdapter extends IResourceAdapter {
 
-    public boolean hasParameter();
+    boolean hasParameter();
 
-    public List<IParametersParameterComponentAdapter> getParameter();
+    List<IParametersParameterComponentAdapter> getParameter();
 
-    public boolean hasParameter(String name);
+    boolean hasParameter(String name);
 
-    public IParametersParameterComponentAdapter getParameter(String name);
+    IParametersParameterComponentAdapter getParameter(String name);
 
-    public <T extends IBaseDatatype> List<T> getParameterValues(String name);
+    <T extends IBaseDatatype> List<T> getParameterValues(String name);
 
-    public void setParameter(List<IBaseBackboneElement> parametersParameterComponents);
+    void setParameter(List<IBaseBackboneElement> parametersParameterComponents);
 
-    public void addParameter(IBase parameter);
+    void addParameter(IBase parameter);
 
-    public void addParameter(String name, String value);
+    void addParameter(String name, String value);
 
-    public void addParameter(String name, IBase value);
+    void addParameter(String name, IBase value);
 
-    public void addParameter(String name, IBaseResource resource);
+    void addParameter(String name, IBaseResource resource);
 
-    public IBaseBackboneElement addParameter();
+    IBaseBackboneElement addParameter();
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IParametersParameterComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IParametersParameterComponentAdapter.java
@@ -1,41 +1,42 @@
 package org.opencds.cqf.fhir.utility.adapter;
 
 import java.util.List;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IBaseDatatype;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
-public interface IParametersParameterComponentAdapter extends IAdapter<IBaseBackboneElement> {
+public interface IParametersParameterComponentAdapter extends IAdapter<IBase> {
 
-    public IBaseBackboneElement get();
+    IBaseBackboneElement get();
 
-    public String getName();
+    String getName();
 
-    public void setName(String name);
+    void setName(String name);
 
-    public List<IParametersParameterComponentAdapter> getPart();
+    List<IParametersParameterComponentAdapter> getPart();
 
-    public List<IBaseDatatype> getPartValues(String name);
+    List<IBaseDatatype> getPartValues(String name);
 
-    public void setPart(List<IBaseBackboneElement> parametersParameterComponents);
+    void setPart(List<IBaseBackboneElement> parametersParameterComponents);
 
-    public IBaseBackboneElement addPart();
+    IBaseBackboneElement addPart();
 
-    public boolean hasPart();
+    boolean hasPart();
 
-    public boolean hasResource();
+    boolean hasResource();
 
-    public IBaseResource getResource();
+    IBaseResource getResource();
 
-    public void setResource(IBaseResource resource);
+    void setResource(IBaseResource resource);
 
-    public boolean hasValue();
+    boolean hasValue();
 
-    public boolean hasPrimitiveValue();
+    boolean hasPrimitiveValue();
 
-    public String getPrimitiveValue();
+    String getPrimitiveValue();
 
-    public void setValue(IBaseDatatype value);
+    void setValue(IBaseDatatype value);
 
-    public IBaseDatatype getValue();
+    IBaseDatatype getValue();
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IPlanDefinitionActionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IPlanDefinitionActionAdapter.java
@@ -1,9 +1,9 @@
 package org.opencds.cqf.fhir.utility.adapter;
 
 import java.util.List;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 
-public interface IPlanDefinitionActionAdapter extends IAdapter<IBaseBackboneElement> {
+public interface IPlanDefinitionActionAdapter extends IAdapter<IBase> {
     boolean hasTrigger();
 
     List<ITriggerDefinitionAdapter> getTrigger();

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireAdapter.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.fhir.utility.adapter;
 
 import java.util.List;
+import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 
 /**
  * This interface exposes common functionality across all FHIR Questionnaire versions.
@@ -12,6 +13,8 @@ public interface IQuestionnaireAdapter extends IKnowledgeArtifactAdapter {
     List<IQuestionnaireItemComponentAdapter> getItem();
 
     void setItem(List<IQuestionnaireItemComponentAdapter> items);
+
+    void addItem(IBaseBackboneElement item);
 
     void addItem(IQuestionnaireItemComponentAdapter item);
 

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireAdapter.java
@@ -1,6 +1,19 @@
 package org.opencds.cqf.fhir.utility.adapter;
 
+import java.util.List;
+
 /**
  * This interface exposes common functionality across all FHIR Questionnaire versions.
  */
-public interface IQuestionnaireAdapter extends IKnowledgeArtifactAdapter {}
+public interface IQuestionnaireAdapter extends IKnowledgeArtifactAdapter {
+
+    boolean hasItem();
+
+    List<IQuestionnaireItemComponentAdapter> getItem();
+
+    void setItem(List<IQuestionnaireItemComponentAdapter> items);
+
+    void addItem(IQuestionnaireItemComponentAdapter item);
+
+    void addItems(List<IQuestionnaireItemComponentAdapter> items);
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireItemComponentAdapter.java
@@ -6,13 +6,35 @@ import org.hl7.fhir.instance.model.api.IBaseDatatype;
 
 public interface IQuestionnaireItemComponentAdapter extends IItemComponentAdapter {
 
+    IQuestionnaireItemComponentAdapter setLinkId(String linkId);
+
+    IQuestionnaireItemComponentAdapter setDefinition(String definition);
+
+    void addItems(List<IQuestionnaireItemComponentAdapter> items);
+
     List<IBaseCoding> getCode();
+
+    String getText();
+
+    IQuestionnaireItemComponentAdapter setText(String text);
 
     String getType();
 
+    IQuestionnaireItemComponentAdapter setType(String type);
+
     boolean isGroupItem();
 
+    boolean isChoiceItem();
+
+    boolean getRequired();
+
+    IQuestionnaireItemComponentAdapter setRequired(boolean required);
+
     boolean getRepeats();
+
+    IQuestionnaireItemComponentAdapter setRepeats(boolean repeats);
+
+    void addAnswerOption(ICodingAdapter option);
 
     boolean hasInitial();
 

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireItemComponentAdapter.java
@@ -1,0 +1,22 @@
+package org.opencds.cqf.fhir.utility.adapter;
+
+import java.util.List;
+import org.hl7.fhir.instance.model.api.IBaseCoding;
+import org.hl7.fhir.instance.model.api.IBaseDatatype;
+
+public interface IQuestionnaireItemComponentAdapter extends IItemComponentAdapter {
+
+    List<IBaseCoding> getCode();
+
+    String getType();
+
+    boolean isGroupItem();
+
+    boolean getRepeats();
+
+    boolean hasInitial();
+
+    List<? extends IBaseDatatype> getInitial();
+
+    IQuestionnaireResponseItemComponentAdapter newResponseItem();
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireItemComponentAdapter.java
@@ -3,6 +3,7 @@ package org.opencds.cqf.fhir.utility.adapter;
 import java.util.List;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
 import org.hl7.fhir.instance.model.api.IBaseDatatype;
+import org.hl7.fhir.instance.model.api.ICompositeType;
 
 public interface IQuestionnaireItemComponentAdapter extends IItemComponentAdapter {
 
@@ -41,4 +42,10 @@ public interface IQuestionnaireItemComponentAdapter extends IItemComponentAdapte
     List<? extends IBaseDatatype> getInitial();
 
     IQuestionnaireResponseItemComponentAdapter newResponseItem();
+
+    ICompositeType newExpression(String language, String expression);
+
+    default ICompositeType newExpression(String expression) {
+        return newExpression("text/cql-expression", expression);
+    }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireResponseAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireResponseAdapter.java
@@ -1,11 +1,23 @@
 package org.opencds.cqf.fhir.utility.adapter;
 
+import java.util.Date;
 import java.util.List;
+import org.hl7.fhir.instance.model.api.IIdType;
 
 /**
  * This interface exposes common functionality across all FHIR Questionnaire versions.
  */
 public interface IQuestionnaireResponseAdapter extends IResourceAdapter {
+
+    IQuestionnaireResponseAdapter setId(String id);
+
+    IQuestionnaireResponseAdapter setQuestionnaire(String canonical);
+
+    IQuestionnaireResponseAdapter setSubject(IIdType subject);
+
+    IQuestionnaireResponseAdapter setAuthored(Date date);
+
+    IQuestionnaireResponseAdapter setStatus(String status);
 
     boolean hasItem();
 

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireResponseAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireResponseAdapter.java
@@ -1,0 +1,19 @@
+package org.opencds.cqf.fhir.utility.adapter;
+
+import java.util.List;
+
+/**
+ * This interface exposes common functionality across all FHIR Questionnaire versions.
+ */
+public interface IQuestionnaireResponseAdapter extends IResourceAdapter {
+
+    boolean hasItem();
+
+    List<IQuestionnaireResponseItemComponentAdapter> getItem();
+
+    void setItem(List<IQuestionnaireResponseItemComponentAdapter> items);
+
+    void addItem(IQuestionnaireResponseItemComponentAdapter item);
+
+    void addItems(List<IQuestionnaireResponseItemComponentAdapter> items);
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireResponseItemAnswerComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireResponseItemAnswerComponentAdapter.java
@@ -1,0 +1,20 @@
+package org.opencds.cqf.fhir.utility.adapter;
+
+import java.util.List;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseDatatype;
+
+public interface IQuestionnaireResponseItemAnswerComponentAdapter extends IAdapter<IBase> {
+
+    boolean hasValue();
+
+    IBase getValue();
+
+    void setValue(IBaseDatatype value);
+
+    boolean hasItem();
+
+    List<IQuestionnaireResponseItemComponentAdapter> getItem();
+
+    void setItem(List<IQuestionnaireResponseItemComponentAdapter> items);
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireResponseItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireResponseItemComponentAdapter.java
@@ -5,6 +5,12 @@ import org.hl7.fhir.instance.model.api.IBaseDatatype;
 
 public interface IQuestionnaireResponseItemComponentAdapter extends IItemComponentAdapter {
 
+    IQuestionnaireResponseItemComponentAdapter setLinkId(String linkId);
+
+    IQuestionnaireResponseItemComponentAdapter setDefinition(String definition);
+
+    void addItems(List<IQuestionnaireResponseItemComponentAdapter> items);
+
     boolean hasAnswer();
 
     List<IQuestionnaireResponseItemAnswerComponentAdapter> getAnswer();

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireResponseItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireResponseItemComponentAdapter.java
@@ -17,5 +17,5 @@ public interface IQuestionnaireResponseItemComponentAdapter extends IItemCompone
 
     void setAnswer(List<IQuestionnaireResponseItemAnswerComponentAdapter> answers);
 
-    IQuestionnaireResponseItemAnswerComponentAdapter createAnswer(IBaseDatatype value);
+    IQuestionnaireResponseItemAnswerComponentAdapter newAnswer(IBaseDatatype value);
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireResponseItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IQuestionnaireResponseItemComponentAdapter.java
@@ -1,0 +1,15 @@
+package org.opencds.cqf.fhir.utility.adapter;
+
+import java.util.List;
+import org.hl7.fhir.instance.model.api.IBaseDatatype;
+
+public interface IQuestionnaireResponseItemComponentAdapter extends IItemComponentAdapter {
+
+    boolean hasAnswer();
+
+    List<IQuestionnaireResponseItemAnswerComponentAdapter> getAnswer();
+
+    void setAnswer(List<IQuestionnaireResponseItemAnswerComponentAdapter> answers);
+
+    IQuestionnaireResponseItemAnswerComponentAdapter createAnswer(IBaseDatatype value);
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IRequestActionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IRequestActionAdapter.java
@@ -1,12 +1,12 @@
 package org.opencds.cqf.fhir.utility.adapter;
 
 import java.util.List;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseHasExtensions;
 import org.hl7.fhir.instance.model.api.IBaseReference;
 import org.hl7.fhir.instance.model.api.ICompositeType;
 
-public interface IRequestActionAdapter extends IAdapter<IBaseBackboneElement> {
+public interface IRequestActionAdapter extends IAdapter<IBase> {
 
     String getId();
 

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IResourceAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IResourceAdapter.java
@@ -8,48 +8,46 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 
 public interface IResourceAdapter extends IAdapter<IBaseResource> {
 
-    public IBaseResource get();
+    IBaseResource get();
 
-    public IAdapterFactory getAdapterFactory();
+    IBase setProperty(String name, IBase value) throws FHIRException;
 
-    public IBase setProperty(String name, IBase value) throws FHIRException;
+    IBase addChild(String name) throws FHIRException;
 
-    public IBase addChild(String name) throws FHIRException;
+    IBase getSingleProperty(String name) throws FHIRException;
 
-    public IBase getSingleProperty(String name) throws FHIRException;
+    IBase[] getProperty(String name) throws FHIRException;
 
-    public IBase[] getProperty(String name) throws FHIRException;
+    IBase[] getProperty(String name, boolean checkValid) throws FHIRException;
 
-    public IBase[] getProperty(String name, boolean checkValid) throws FHIRException;
+    IBase makeProperty(String name) throws FHIRException;
 
-    public IBase makeProperty(String name) throws FHIRException;
+    String[] getTypesForProperty(String name) throws FHIRException;
 
-    public String[] getTypesForProperty(String name) throws FHIRException;
+    IBaseResource copy();
 
-    public IBaseResource copy();
+    void copyValues(IBaseResource destination);
 
-    public void copyValues(IBaseResource destination);
+    boolean equalsDeep(IBase other);
 
-    public boolean equalsDeep(IBase other);
+    boolean equalsShallow(IBase other);
 
-    public boolean equalsShallow(IBase other);
-
-    public default <R extends IBaseResource> List<R> getContained() {
+    default <R extends IBaseResource> List<R> getContained() {
         return getContained(get());
     }
 
-    public default boolean hasContained() {
+    default boolean hasContained() {
         return hasContained(get());
     }
 
     @SuppressWarnings("unchecked")
-    public default <R extends IBaseResource> List<R> getContained(IBaseResource base) {
+    default <R extends IBaseResource> List<R> getContained(IBaseResource base) {
         return resolvePathList(base, "contained", IBaseResource.class).stream()
                 .map(r -> (R) r)
                 .collect(Collectors.toList());
     }
 
-    public default Boolean hasContained(IBaseResource base) {
+    default Boolean hasContained(IBaseResource base) {
         return !getContained(base).isEmpty();
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IStructureDefinitionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IStructureDefinitionAdapter.java
@@ -2,11 +2,17 @@ package org.opencds.cqf.fhir.utility.adapter;
 
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
+import org.hl7.fhir.instance.model.api.IPrimitiveType;
 
 public interface IStructureDefinitionAdapter extends IKnowledgeArtifactAdapter {
+
     default String getType() {
         return resolvePathString(get(), "type");
     }
+
+    IPrimitiveType<String> getBaseDefinition();
+
+    boolean hasSnapshot();
 
     List<IElementDefinitionAdapter> getSnapshotElements();
 
@@ -25,7 +31,7 @@ public interface IStructureDefinitionAdapter extends IKnowledgeArtifactAdapter {
     /**
      * Returns the first element found with a matching path. Differential elements will be returned first. Elements with a slicing defined will be ignored.
      * @param path The path of the element without the preceding resource type. e.g. value[x] rather than Observation.value[x]
-     * @return
+     * @return IElementDefinitionAdapter
      */
     default IElementDefinitionAdapter getElementByPath(String path) {
         return getDifferentialElements().stream()

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/ITriggerDefinitionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/ITriggerDefinitionAdapter.java
@@ -1,8 +1,8 @@
 package org.opencds.cqf.fhir.utility.adapter;
 
-import org.hl7.fhir.instance.model.api.ICompositeType;
+import org.hl7.fhir.instance.model.api.IBase;
 
-public interface ITriggerDefinitionAdapter extends IAdapter<ICompositeType> {
+public interface ITriggerDefinitionAdapter extends IAdapter<IBase> {
 
     boolean hasName();
 

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IValueSetAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IValueSetAdapter.java
@@ -7,25 +7,25 @@ import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
  * This interface exposes common functionality across all FHIR ValueSet versions.
  */
 public interface IValueSetAdapter extends IKnowledgeArtifactAdapter {
-    public <T extends IBaseBackboneElement> void setExpansion(T expansion);
+    <T extends IBaseBackboneElement> void setExpansion(T expansion);
 
-    public <T extends IBaseBackboneElement> T getExpansion();
+    <T extends IBaseBackboneElement> T getExpansion();
 
-    public boolean hasExpansion();
+    boolean hasExpansion();
 
-    public boolean hasExpansionContains();
+    boolean hasExpansionContains();
 
-    public List<IValueSetExpansionContainsAdapter> getExpansionContains();
+    List<IValueSetExpansionContainsAdapter> getExpansionContains();
 
-    public <T extends IBaseBackboneElement> T newExpansion();
+    <T extends IBaseBackboneElement> T newExpansion();
 
-    public List<IValueSetConceptSetAdapter> getComposeInclude();
+    List<IValueSetConceptSetAdapter> getComposeInclude();
 
-    public List<String> getValueSetIncludes();
+    List<String> getValueSetIncludes();
 
-    public boolean hasCompose();
+    boolean hasCompose();
 
-    public boolean hasComposeInclude();
+    boolean hasComposeInclude();
 
     /**
      * A simple compose element of a ValueSet must have a compose without an exclude element. Each element of the
@@ -33,7 +33,7 @@ public interface IValueSetAdapter extends IKnowledgeArtifactAdapter {
      *
      * @return boolean
      */
-    public boolean hasSimpleCompose();
+    boolean hasSimpleCompose();
 
     /**
      * A grouping compose element of a ValueSet must have a compose without an exclude element and each element of the
@@ -41,14 +41,14 @@ public interface IValueSetAdapter extends IKnowledgeArtifactAdapter {
      *
      * @return boolean
      */
-    public boolean hasGroupingCompose();
+    boolean hasGroupingCompose();
 
     /**
      * Performs a naive expansion on the ValueSet by collecting all codes within the compose.  Can only be performed on a ValueSet with a simple compose.
      */
-    public void naiveExpand();
+    void naiveExpand();
 
-    public boolean hasNaiveParameter();
+    boolean hasNaiveParameter();
 
-    public <T extends IBaseBackboneElement> T createNaiveParameter();
+    <T extends IBaseBackboneElement> T createNaiveParameter();
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IValueSetConceptReferenceAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IValueSetConceptReferenceAdapter.java
@@ -1,8 +1,8 @@
 package org.opencds.cqf.fhir.utility.adapter;
 
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 
-public interface IValueSetConceptReferenceAdapter extends IAdapter<IBaseBackboneElement> {
+public interface IValueSetConceptReferenceAdapter extends IAdapter<IBase> {
 
     boolean hasCode();
 

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IValueSetConceptReferenceAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IValueSetConceptReferenceAdapter.java
@@ -7,4 +7,6 @@ public interface IValueSetConceptReferenceAdapter extends IAdapter<IBase> {
     boolean hasCode();
 
     String getCode();
+
+    String getDisplay();
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IValueSetConceptSetAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IValueSetConceptSetAdapter.java
@@ -1,9 +1,9 @@
 package org.opencds.cqf.fhir.utility.adapter;
 
 import java.util.List;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 
-public interface IValueSetConceptSetAdapter extends IAdapter<IBaseBackboneElement> {
+public interface IValueSetConceptSetAdapter extends IAdapter<IBase> {
     boolean hasConcept();
 
     List<IValueSetConceptReferenceAdapter> getConcept();

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IValueSetExpansionContainsAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/IValueSetExpansionContainsAdapter.java
@@ -1,8 +1,8 @@
 package org.opencds.cqf.fhir.utility.adapter;
 
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 
-public interface IValueSetExpansionContainsAdapter extends IAdapter<IBaseBackboneElement> {
+public interface IValueSetExpansionContainsAdapter extends IAdapter<IBase> {
 
     boolean hasCode();
 

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/AdapterFactory.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/AdapterFactory.java
@@ -59,7 +59,7 @@ public class AdapterFactory implements IAdapterFactory {
     }
 
     @Override
-    public IAdapter<? extends IBase> createBase(IBase element) {
+    public IAdapter<IBase> createBase(IBase element) {
         if (element instanceof QuestionnaireItemComponent) {
             return createQuestionnaireItem(element);
         } else if (element instanceof QuestionnaireResponseItemComponent) {

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/AdapterFactory.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/AdapterFactory.java
@@ -11,6 +11,7 @@ import org.hl7.fhir.dstu3.model.Parameters;
 import org.hl7.fhir.dstu3.model.PlanDefinition;
 import org.hl7.fhir.dstu3.model.Questionnaire;
 import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent;
 import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
 import org.hl7.fhir.dstu3.model.RequestGroup.RequestGroupActionComponent;
 import org.hl7.fhir.dstu3.model.StructureDefinition;
@@ -61,12 +62,14 @@ public class AdapterFactory implements IAdapterFactory {
 
     @Override
     public IAdapter<IBase> createBase(IBase element) {
-        if (element instanceof QuestionnaireItemComponent) {
-            return createQuestionnaireItem(element);
-        } else if (element instanceof QuestionnaireResponseItemComponent) {
-            return createQuestionnaireResponseItem(element);
-        } else if (element instanceof RequestGroupActionComponent) {
-            return createRequestAction(element);
+        if (element instanceof QuestionnaireItemComponent item) {
+            return createQuestionnaireItem(item);
+        } else if (element instanceof QuestionnaireResponseItemComponent responseItem) {
+            return createQuestionnaireResponseItem(responseItem);
+        } else if (element instanceof QuestionnaireResponseItemAnswerComponent answer) {
+            return createQuestionnaireResponseItemAnswer(answer);
+        } else if (element instanceof RequestGroupActionComponent requestAction) {
+            return createRequestAction(requestAction);
         } else {
             throw new UnprocessableEntityException(
                     String.format("Unable to create an adapter for type: %s", element.fhirType()));

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/AdapterFactory.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/AdapterFactory.java
@@ -41,6 +41,7 @@ import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemAnswerComp
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IRequestActionAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IResourceAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IStructureDefinitionAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetAdapter;
 
 public class AdapterFactory implements IAdapterFactory {
@@ -168,6 +169,11 @@ public class AdapterFactory implements IAdapterFactory {
     }
 
     @Override
+    public IQuestionnaireItemComponentAdapter createQuestionnaireItem() {
+        return new QuestionnaireItemComponentAdapter(new QuestionnaireItemComponent());
+    }
+
+    @Override
     public IQuestionnaireItemComponentAdapter createQuestionnaireItem(IBase item) {
         return new QuestionnaireItemComponentAdapter(item);
     }
@@ -195,5 +201,10 @@ public class AdapterFactory implements IAdapterFactory {
     @Override
     public IGraphDefinitionAdapter createGraphDefinition(IBaseResource graphDefinition) {
         return new GraphDefinitionAdapter((IDomainResource) graphDefinition);
+    }
+
+    @Override
+    public IStructureDefinitionAdapter createStructureDefinition(IBaseResource structureDefinition) {
+        return new StructureDefinitionAdapter((IDomainResource) structureDefinition);
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/AdapterFactory.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/AdapterFactory.java
@@ -10,14 +10,17 @@ import org.hl7.fhir.dstu3.model.MetadataResource;
 import org.hl7.fhir.dstu3.model.Parameters;
 import org.hl7.fhir.dstu3.model.PlanDefinition;
 import org.hl7.fhir.dstu3.model.Questionnaire;
+import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.dstu3.model.RequestGroup.RequestGroupActionComponent;
 import org.hl7.fhir.dstu3.model.StructureDefinition;
 import org.hl7.fhir.dstu3.model.ValueSet;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.instance.model.api.IDomainResource;
 import org.opencds.cqf.fhir.utility.adapter.IActivityDefinitionAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
 import org.opencds.cqf.fhir.utility.adapter.IAttachmentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodeableConceptAdapter;
@@ -32,6 +35,10 @@ import org.opencds.cqf.fhir.utility.adapter.IParametersAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IParametersParameterComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IPlanDefinitionAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemAnswerComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IRequestActionAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IResourceAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetAdapter;
@@ -48,6 +55,20 @@ public class AdapterFactory implements IAdapterFactory {
             return createParameters(parameters);
         } else {
             return new ResourceAdapter(resource);
+        }
+    }
+
+    @Override
+    public IAdapter<? extends IBase> createBase(IBase element) {
+        if (element instanceof QuestionnaireItemComponent) {
+            return createQuestionnaireItem(element);
+        } else if (element instanceof QuestionnaireResponseItemComponent) {
+            return createQuestionnaireResponseItem(element);
+        } else if (element instanceof RequestGroupActionComponent) {
+            return createRequestAction(element);
+        } else {
+            throw new UnprocessableEntityException(
+                    String.format("Unable to create an adapter for type: %s", element.fhirType()));
         }
     }
 
@@ -87,7 +108,7 @@ public class AdapterFactory implements IAdapterFactory {
     }
 
     @Override
-    public IAttachmentAdapter createAttachment(ICompositeType attachment) {
+    public IAttachmentAdapter createAttachment(IBase attachment) {
         return new AttachmentAdapter(attachment);
     }
 
@@ -97,8 +118,7 @@ public class AdapterFactory implements IAdapterFactory {
     }
 
     @Override
-    public IParametersParameterComponentAdapter createParametersParameter(
-            IBaseBackboneElement parametersParametersComponent) {
+    public IParametersParameterComponentAdapter createParametersParameter(IBase parametersParametersComponent) {
         return new ParametersParameterComponentAdapter(parametersParametersComponent);
     }
 
@@ -108,17 +128,17 @@ public class AdapterFactory implements IAdapterFactory {
     }
 
     @Override
-    public ICodeableConceptAdapter createCodeableConcept(ICompositeType codeableConcept) {
+    public ICodeableConceptAdapter createCodeableConcept(IBase codeableConcept) {
         return new CodeableConceptAdapter(codeableConcept);
     }
 
     @Override
-    public ICodingAdapter createCoding(ICompositeType coding) {
+    public ICodingAdapter createCoding(IBase coding) {
         return new CodingAdapter(coding);
     }
 
     @Override
-    public IElementDefinitionAdapter createElementDefinition(ICompositeType element) {
+    public IElementDefinitionAdapter createElementDefinition(IBase element) {
         return new ElementDefinitionAdapter(element);
     }
 
@@ -133,18 +153,38 @@ public class AdapterFactory implements IAdapterFactory {
     }
 
     @Override
-    public IRequestActionAdapter createRequestAction(IBaseBackboneElement action) {
+    public IRequestActionAdapter createRequestAction(IBase action) {
         return new RequestActionAdapter(action);
     }
 
     @Override
-    public IDataRequirementAdapter createDataRequirement(ICompositeType dataRequirement) {
+    public IDataRequirementAdapter createDataRequirement(IBase dataRequirement) {
         return new DataRequirementAdapter(dataRequirement);
     }
 
     @Override
     public IQuestionnaireAdapter createQuestionnaire(IBaseResource questionnaire) {
         return new QuestionnaireAdapter((IDomainResource) questionnaire);
+    }
+
+    @Override
+    public IQuestionnaireItemComponentAdapter createQuestionnaireItem(IBase item) {
+        return new QuestionnaireItemComponentAdapter(item);
+    }
+
+    @Override
+    public IQuestionnaireResponseAdapter createQuestionnaireResponse(IBaseResource questionnaireResponse) {
+        return new QuestionnaireResponseAdapter((IDomainResource) questionnaireResponse);
+    }
+
+    @Override
+    public IQuestionnaireResponseItemComponentAdapter createQuestionnaireResponseItem(IBase item) {
+        return new QuestionnaireResponseItemComponentAdapter(item);
+    }
+
+    @Override
+    public IQuestionnaireResponseItemAnswerComponentAdapter createQuestionnaireResponseItemAnswer(IBase answer) {
+        return new QuestionnaireResponseItemAnswerComponentAdapter(answer);
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/AttachmentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/AttachmentAdapter.java
@@ -1,23 +1,18 @@
 package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
-import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import org.hl7.fhir.dstu3.model.Attachment;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.ICompositeType;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IAttachmentAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-class AttachmentAdapter implements IAttachmentAdapter {
+class AttachmentAdapter extends BaseAdapter implements IAttachmentAdapter {
 
     private final Attachment attachment;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public AttachmentAdapter(ICompositeType attachment) {
-        if (attachment == null) {
-            throw new IllegalArgumentException("attachment can not be null");
-        }
-
+    public AttachmentAdapter(IBase attachment) {
+        super(FhirVersionEnum.DSTU3, attachment);
         if (!attachment.fhirType().equals("Attachment")) {
             throw new IllegalArgumentException("resource passed as attachment argument is not an Attachment resource");
         }
@@ -27,9 +22,6 @@ class AttachmentAdapter implements IAttachmentAdapter {
         }
 
         this.attachment = (Attachment) attachment;
-        fhirContext = FhirContext.forDstu3Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(
-                fhirContext.getVersion().getVersion());
     }
 
     protected Attachment getAttachment() {
@@ -59,15 +51,5 @@ class AttachmentAdapter implements IAttachmentAdapter {
     @Override
     public void setData(byte[] data) {
         this.getAttachment().setData(data);
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/CodeableConceptAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/CodeableConceptAdapter.java
@@ -1,46 +1,29 @@
 package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
-import org.hl7.fhir.instance.model.api.ICompositeType;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodeableConceptAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodingAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class CodeableConceptAdapter implements ICodeableConceptAdapter {
+public class CodeableConceptAdapter extends BaseAdapter implements ICodeableConceptAdapter {
 
     private final CodeableConcept codeableConcept;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
-    private final AdapterFactory adapterFactory;
 
-    public CodeableConceptAdapter(ICompositeType codeableConcept) {
+    public CodeableConceptAdapter(IBase codeableConcept) {
+        super(FhirVersionEnum.DSTU3, codeableConcept);
         if (!(codeableConcept instanceof CodeableConcept)) {
             throw new IllegalArgumentException(
                     "object passed as codeableConcept argument is not a CodeableConcept data type");
         }
         this.codeableConcept = (CodeableConcept) codeableConcept;
-        fhirContext = FhirContext.forDstu3Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.DSTU3);
-        adapterFactory = new AdapterFactory();
     }
 
     @Override
     public CodeableConcept get() {
         return codeableConcept;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/CodingAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/CodingAdapter.java
@@ -1,42 +1,27 @@
 package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import org.hl7.fhir.dstu3.model.Coding;
-import org.hl7.fhir.instance.model.api.ICompositeType;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodingAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class CodingAdapter implements ICodingAdapter {
+public class CodingAdapter extends BaseAdapter implements ICodingAdapter {
 
     private final Coding coding;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public CodingAdapter(ICompositeType coding) {
+    public CodingAdapter(IBase coding) {
+        super(FhirVersionEnum.DSTU3, coding);
         if (!(coding instanceof Coding)) {
             throw new IllegalArgumentException(
                     "object passed as codeableConcept argument is not a CodeableConcept data type");
         }
         this.coding = (Coding) coding;
-        fhirContext = FhirContext.forDstu3Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.DSTU3);
     }
 
     @Override
     public Coding get() {
         return coding;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/DataRequirementAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/DataRequirementAdapter.java
@@ -5,26 +5,23 @@ import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hl7.fhir.dstu3.model.DataRequirement;
-import org.hl7.fhir.instance.model.api.ICompositeType;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IDataRequirementAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IDataRequirementCodeFilterAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class DataRequirementAdapter implements IDataRequirementAdapter {
+public class DataRequirementAdapter extends BaseAdapter implements IDataRequirementAdapter {
 
     private final DataRequirement dataRequirement;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public DataRequirementAdapter(ICompositeType compositeType) {
+    public DataRequirementAdapter(IBase compositeType) {
+        super(FhirVersionEnum.DSTU3, compositeType);
         if (!(compositeType instanceof DataRequirement dataRequirementInner)) {
             throw new IllegalArgumentException(
                     "object passed as dataRequirement argument is not a DataRequirement data type");
         }
         this.dataRequirement = dataRequirementInner;
-        fhirContext = FhirContext.forDstu3Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R4);
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/DataRequirementCodeFilterAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/DataRequirementCodeFilterAdapter.java
@@ -1,46 +1,31 @@
 package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent;
-import org.hl7.fhir.instance.model.api.IBaseDatatypeElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodingAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IDataRequirementCodeFilterAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class DataRequirementCodeFilterAdapter implements IDataRequirementCodeFilterAdapter {
+public class DataRequirementCodeFilterAdapter extends BaseAdapter implements IDataRequirementCodeFilterAdapter {
 
     private final DataRequirementCodeFilterComponent codeFilter;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public DataRequirementCodeFilterAdapter(IBaseDatatypeElement codeFilter) {
+    public DataRequirementCodeFilterAdapter(IBase codeFilter) {
+        super(FhirVersionEnum.DSTU3, codeFilter);
         if (!(codeFilter instanceof DataRequirementCodeFilterComponent)) {
             throw new IllegalArgumentException(
                     "object passed as codeFilter argument is not a DataRequirementCodeFilterComponent data type");
         }
         this.codeFilter = (DataRequirementCodeFilterComponent) codeFilter;
-        fhirContext = FhirContext.forDstu3Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.DSTU3);
     }
 
     @Override
     public DataRequirementCodeFilterComponent get() {
         return codeFilter;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ElementDefinitionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ElementDefinitionAdapter.java
@@ -1,6 +1,5 @@
 package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import org.hl7.fhir.dstu3.model.ElementDefinition;
@@ -9,43 +8,26 @@ import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseDatatype;
 import org.hl7.fhir.instance.model.api.IBaseDatatypeElement;
-import org.hl7.fhir.instance.model.api.ICompositeType;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodingAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IElementDefinitionAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class ElementDefinitionAdapter implements IElementDefinitionAdapter {
+public class ElementDefinitionAdapter extends BaseAdapter implements IElementDefinitionAdapter {
 
     private final ElementDefinition elementDefinition;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
-    private final AdapterFactory adapterFactory;
 
-    public ElementDefinitionAdapter(ICompositeType elementDefinition) {
+    public ElementDefinitionAdapter(IBase elementDefinition) {
+        super(FhirVersionEnum.DSTU3, elementDefinition);
         if (!(elementDefinition instanceof ElementDefinition)) {
             throw new IllegalArgumentException(
                     "object passed as elementDefinition argument is not a ElementDefinition data type");
         }
         this.elementDefinition = (ElementDefinition) elementDefinition;
-        fhirContext = FhirContext.forDstu3Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.DSTU3);
-        adapterFactory = new AdapterFactory();
     }
 
     @Override
     public ElementDefinition get() {
         return elementDefinition;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ParametersParameterComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ParametersParameterComponentAdapter.java
@@ -1,46 +1,36 @@
 package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
-import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hl7.fhir.dstu3.model.Parameters;
 import org.hl7.fhir.dstu3.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.dstu3.model.Resource;
 import org.hl7.fhir.dstu3.model.Type;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IBaseDatatype;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
-import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IParametersParameterComponentAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-class ParametersParameterComponentAdapter implements IParametersParameterComponentAdapter {
+class ParametersParameterComponentAdapter extends BaseAdapter implements IParametersParameterComponentAdapter {
 
-    private final FhirContext fhirContext = FhirContext.forDstu3Cached();
     private final Parameters.ParametersParameterComponent parametersParameterComponent;
-    private final ModelResolver modelResolver;
-    private final IAdapterFactory adapterFactory;
 
     protected ParametersParameterComponent getParametersParameterComponent() {
         return parametersParameterComponent;
     }
 
-    public ParametersParameterComponentAdapter(IBaseBackboneElement parametersParameterComponent) {
-        if (parametersParameterComponent == null) {
-            throw new IllegalArgumentException("parametersParameterComponent can not be null");
-        }
-
+    public ParametersParameterComponentAdapter(IBase parametersParameterComponent) {
+        super(FhirVersionEnum.DSTU3, parametersParameterComponent);
         if (!parametersParameterComponent.fhirType().equals("Parameters.parameter")) {
             throw new IllegalArgumentException(
                     "element passed as parametersParameterComponent argument is not a ParametersParameterComponent Element");
         }
 
         this.parametersParameterComponent = (ParametersParameterComponent) parametersParameterComponent;
-        modelResolver = FhirModelResolverCache.resolverForVersion(
-                fhirContext.getVersion().getVersion());
-        adapterFactory = IAdapterFactory.forFhirContext(fhirContext);
     }
 
     @Override
@@ -133,15 +123,5 @@ class ParametersParameterComponentAdapter implements IParametersParameterCompone
         return hasPrimitiveValue()
                 ? this.parametersParameterComponent.getValue().primitiveValue()
                 : null;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/PlanDefinitionActionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/PlanDefinitionActionAdapter.java
@@ -1,45 +1,30 @@
 package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hl7.fhir.dstu3.model.PlanDefinition.PlanDefinitionActionComponent;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IPlanDefinitionActionAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ITriggerDefinitionAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class PlanDefinitionActionAdapter implements IPlanDefinitionActionAdapter {
+public class PlanDefinitionActionAdapter extends BaseAdapter implements IPlanDefinitionActionAdapter {
 
     private final PlanDefinitionActionComponent action;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public PlanDefinitionActionAdapter(IBaseBackboneElement action) {
+    public PlanDefinitionActionAdapter(IBase action) {
+        super(FhirVersionEnum.DSTU3, action);
         if (!(action instanceof PlanDefinitionActionComponent)) {
             throw new IllegalArgumentException(
                     "object passed as action argument is not a PlanDefinitionActionComponent data type");
         }
         this.action = (PlanDefinitionActionComponent) action;
-        fhirContext = FhirContext.forDstu3Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.DSTU3);
     }
 
     @Override
     public PlanDefinitionActionComponent get() {
         return action;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override
@@ -58,6 +43,6 @@ public class PlanDefinitionActionAdapter implements IPlanDefinitionActionAdapter
     public List<String> getTriggerType() {
         return get().getTriggerDefinition().stream()
                 .map(t -> t.getType().toCode())
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireAdapter.java
@@ -41,11 +41,6 @@ public class QuestionnaireAdapter extends KnowledgeArtifactAdapter implements IQ
     }
 
     @Override
-    public Questionnaire copy() {
-        return get().copy();
-    }
-
-    @Override
     public List<IDependencyInfo> getDependencies() {
         List<IDependencyInfo> references = new ArrayList<>();
         final String referenceSource = getReferenceSource();

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireAdapter.java
@@ -9,8 +9,10 @@ import org.hl7.fhir.dstu3.model.UriType;
 import org.hl7.fhir.instance.model.api.IDomainResource;
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.adapter.DependencyInfo;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IDependencyInfo;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
 
 public class QuestionnaireAdapter extends KnowledgeArtifactAdapter implements IQuestionnaireAdapter {
 
@@ -108,5 +110,39 @@ public class QuestionnaireAdapter extends KnowledgeArtifactAdapter implements IQ
                         referenceExt.getExtension(),
                         reference -> referenceExt.setValue(new UriType(reference)))));
         item.getItem().forEach(childItem -> getDependenciesOfItem(childItem, references, referenceSource));
+    }
+
+    @Override
+    public boolean hasItem() {
+        return getQuestionnaire().hasItem();
+    }
+
+    @Override
+    public List<IQuestionnaireItemComponentAdapter> getItem() {
+        return getQuestionnaire().getItem().stream()
+                .map(adapterFactory::createQuestionnaireItem)
+                .toList();
+    }
+
+    @Override
+    public void setItem(List<IQuestionnaireItemComponentAdapter> items) {
+        getQuestionnaire()
+                .setItem(items.stream()
+                        .map(IAdapter::get)
+                        .map(QuestionnaireItemComponent.class::cast)
+                        .toList());
+    }
+
+    @Override
+    public void addItem(IQuestionnaireItemComponentAdapter item) {
+        getQuestionnaire().addItem((QuestionnaireItemComponent) item.get());
+    }
+
+    @Override
+    public void addItems(List<IQuestionnaireItemComponentAdapter> items) {
+        items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireItemComponent.class::cast)
+                .forEach(item -> getQuestionnaire().addItem(item));
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireAdapter.java
@@ -2,10 +2,12 @@ package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.hl7.fhir.dstu3.model.Questionnaire;
 import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemComponent;
 import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.dstu3.model.UriType;
+import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IDomainResource;
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.adapter.DependencyInfo;
@@ -130,7 +132,14 @@ public class QuestionnaireAdapter extends KnowledgeArtifactAdapter implements IQ
                 .setItem(items.stream()
                         .map(IAdapter::get)
                         .map(QuestionnaireItemComponent.class::cast)
-                        .toList());
+                        .collect(Collectors.toList()));
+    }
+
+    @Override
+    public void addItem(IBaseBackboneElement item) {
+        if (item instanceof QuestionnaireItemComponent itemComponent) {
+            getQuestionnaire().addItem(itemComponent);
+        }
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireItemComponentAdapter.java
@@ -1,0 +1,120 @@
+package org.opencds.cqf.fhir.utility.adapter.dstu3;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.List;
+import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemType;
+import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.dstu3.model.Type;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseCoding;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
+
+public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQuestionnaireItemComponentAdapter {
+
+    private final QuestionnaireItemComponent item;
+
+    public QuestionnaireItemComponentAdapter(IBase item) {
+        super(FhirVersionEnum.DSTU3, item);
+        if (!(item instanceof QuestionnaireItemComponent)) {
+            throw new IllegalArgumentException(
+                    "object passed as item argument is not a QuestionnaireItemComponent data type");
+        }
+        this.item = (QuestionnaireItemComponent) item;
+    }
+
+    @Override
+    public QuestionnaireItemComponent get() {
+        return item;
+    }
+
+    @Override
+    public String getLinkId() {
+        return item.getLinkId();
+    }
+
+    @Override
+    public List<IBaseCoding> getCode() {
+        return item.getCode().stream().map(IBaseCoding.class::cast).toList();
+    }
+
+    @Override
+    public String getType() {
+        return item.getType().toCode();
+    }
+
+    @Override
+    public boolean isGroupItem() {
+        return item.getType().equals(QuestionnaireItemType.GROUP);
+    }
+
+    @Override
+    public boolean getRepeats() {
+        return item.getRepeats();
+    }
+
+    @Override
+    public boolean hasDefinition() {
+        return item.hasDefinition();
+    }
+
+    @Override
+    public String getDefinition() {
+        return item.getDefinition();
+    }
+
+    @Override
+    public boolean hasItem() {
+        return item.hasItem();
+    }
+
+    @Override
+    public List<IQuestionnaireItemComponentAdapter> getItem() {
+        return item.getItem().stream()
+                .map(adapterFactory::createQuestionnaireItem)
+                .toList();
+    }
+
+    @Override
+    public void setItem(List<? extends IItemComponentAdapter> items) {
+        item.setItem(items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireItemComponent.class::cast)
+                .toList());
+    }
+
+    @Override
+    public void addItem(IItemComponentAdapter item) {
+        this.item.addItem((QuestionnaireItemComponent) item.get());
+    }
+
+    @Override
+    public void addItems(List<IItemComponentAdapter> items) {
+        items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireItemComponent.class::cast)
+                .forEach(this.item::addItem);
+    }
+
+    @Override
+    public boolean hasInitial() {
+        return item.hasInitial();
+    }
+
+    @Override
+    public List<Type> getInitial() {
+        return List.of(item.getInitial());
+    }
+
+    @Override
+    public IQuestionnaireResponseItemComponentAdapter newResponseItem() {
+        return adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent()
+                .setLinkId(item.getLinkId())
+                .setDefinitionElement(item.getDefinitionElement())
+                .setTextElement(item.getTextElement()));
+    }
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireItemComponentAdapter.java
@@ -2,6 +2,9 @@ package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
+import java.util.stream.Collectors;
+import org.hl7.fhir.dstu3.model.Coding;
+import org.hl7.fhir.dstu3.model.Questionnaire;
 import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemComponent;
 import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemType;
 import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
@@ -10,6 +13,7 @@ import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
 import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IAdapter;
+import org.opencds.cqf.fhir.utility.adapter.ICodingAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IItemComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
@@ -38,23 +42,9 @@ public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQ
     }
 
     @Override
-    public List<IBaseCoding> getCode() {
-        return item.getCode().stream().map(IBaseCoding.class::cast).toList();
-    }
-
-    @Override
-    public String getType() {
-        return item.getType().toCode();
-    }
-
-    @Override
-    public boolean isGroupItem() {
-        return item.getType().equals(QuestionnaireItemType.GROUP);
-    }
-
-    @Override
-    public boolean getRepeats() {
-        return item.getRepeats();
+    public IQuestionnaireItemComponentAdapter setLinkId(String linkId) {
+        get().setLinkId(linkId);
+        return this;
     }
 
     @Override
@@ -65,6 +55,12 @@ public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQ
     @Override
     public String getDefinition() {
         return item.getDefinition();
+    }
+
+    @Override
+    public IQuestionnaireItemComponentAdapter setDefinition(String definition) {
+        get().setDefinition(definition);
+        return this;
     }
 
     @Override
@@ -84,7 +80,7 @@ public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQ
         item.setItem(items.stream()
                 .map(IAdapter::get)
                 .map(QuestionnaireItemComponent.class::cast)
-                .toList());
+                .collect(Collectors.toList()));
     }
 
     @Override
@@ -93,11 +89,75 @@ public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQ
     }
 
     @Override
-    public void addItems(List<IItemComponentAdapter> items) {
+    public void addItems(List<IQuestionnaireItemComponentAdapter> items) {
         items.stream()
                 .map(IAdapter::get)
                 .map(QuestionnaireItemComponent.class::cast)
                 .forEach(this.item::addItem);
+    }
+
+    @Override
+    public List<IBaseCoding> getCode() {
+        return item.getCode().stream().map(IBaseCoding.class::cast).toList();
+    }
+
+    @Override
+    public String getText() {
+        return item.getText();
+    }
+
+    @Override
+    public IQuestionnaireItemComponentAdapter setText(String text) {
+        item.setText(text);
+        return this;
+    }
+
+    @Override
+    public String getType() {
+        return item.getType().toCode();
+    }
+
+    @Override
+    public IQuestionnaireItemComponentAdapter setType(String type) {
+        item.setType(Questionnaire.QuestionnaireItemType.fromCode(type));
+        return this;
+    }
+
+    @Override
+    public boolean isGroupItem() {
+        return item.getType().equals(Questionnaire.QuestionnaireItemType.GROUP);
+    }
+
+    @Override
+    public boolean isChoiceItem() {
+        return item.getType().equals(QuestionnaireItemType.QUESTION);
+    }
+
+    @Override
+    public boolean getRequired() {
+        return item.getRequired();
+    }
+
+    @Override
+    public IQuestionnaireItemComponentAdapter setRequired(boolean required) {
+        get().setRequired(required);
+        return this;
+    }
+
+    @Override
+    public boolean getRepeats() {
+        return item.getRepeats();
+    }
+
+    @Override
+    public IQuestionnaireItemComponentAdapter setRepeats(boolean repeats) {
+        get().setRepeats(repeats);
+        return this;
+    }
+
+    @Override
+    public void addAnswerOption(ICodingAdapter option) {
+        get().addOption().setValue((Coding) option.get());
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireItemComponentAdapter.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hl7.fhir.dstu3.model.Coding;
@@ -126,12 +127,12 @@ public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQ
 
     @Override
     public boolean isGroupItem() {
-        return item.getType().equals(Questionnaire.QuestionnaireItemType.GROUP);
+        return item.getType().equals(QuestionnaireItemType.GROUP);
     }
 
     @Override
     public boolean isChoiceItem() {
-        return item.getType().equals(QuestionnaireItemType.QUESTION);
+        return item.getType().equals(QuestionnaireItemType.CHOICE);
     }
 
     @Override
@@ -168,7 +169,7 @@ public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQ
 
     @Override
     public List<Type> getInitial() {
-        return List.of(item.getInitial());
+        return item.hasInitial() ? List.of(item.getInitial()) : new ArrayList<>();
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireItemComponentAdapter.java
@@ -11,6 +11,7 @@ import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemC
 import org.hl7.fhir.dstu3.model.Type;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
+import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodingAdapter;
@@ -176,5 +177,10 @@ public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQ
                 .setLinkId(item.getLinkId())
                 .setDefinitionElement(item.getDefinitionElement())
                 .setTextElement(item.getTextElement()));
+    }
+
+    @Override
+    public ICompositeType newExpression(String language, String expression) {
+        return null;
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseAdapter.java
@@ -1,0 +1,72 @@
+package org.opencds.cqf.fhir.utility.adapter.dstu3;
+
+import java.util.List;
+import org.hl7.fhir.dstu3.model.QuestionnaireResponse;
+import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.instance.model.api.IDomainResource;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
+
+public class QuestionnaireResponseAdapter extends ResourceAdapter implements IQuestionnaireResponseAdapter {
+
+    public QuestionnaireResponseAdapter(IDomainResource questionnaireResponse) {
+        super(questionnaireResponse);
+        if (!(questionnaireResponse instanceof QuestionnaireResponse)) {
+            throw new IllegalArgumentException(
+                    "resource passed as questionnaire argument is not a QuestionnaireResponse resource");
+        }
+    }
+
+    public QuestionnaireResponseAdapter(QuestionnaireResponse questionnaireResponse) {
+        super(questionnaireResponse);
+    }
+
+    protected QuestionnaireResponse getQuestionnaireResponse() {
+        return (QuestionnaireResponse) resource;
+    }
+
+    @Override
+    public QuestionnaireResponse get() {
+        return getQuestionnaireResponse();
+    }
+
+    @Override
+    public QuestionnaireResponse copy() {
+        return get().copy();
+    }
+
+    @Override
+    public boolean hasItem() {
+        return getQuestionnaireResponse().hasItem();
+    }
+
+    @Override
+    public List<IQuestionnaireResponseItemComponentAdapter> getItem() {
+        return getQuestionnaireResponse().getItem().stream()
+                .map(adapterFactory::createQuestionnaireResponseItem)
+                .toList();
+    }
+
+    @Override
+    public void setItem(List<IQuestionnaireResponseItemComponentAdapter> items) {
+        getQuestionnaireResponse()
+                .setItem(items.stream()
+                        .map(IAdapter::get)
+                        .map(QuestionnaireResponseItemComponent.class::cast)
+                        .toList());
+    }
+
+    @Override
+    public void addItem(IQuestionnaireResponseItemComponentAdapter item) {
+        getQuestionnaireResponse().addItem((QuestionnaireResponseItemComponent) item.get());
+    }
+
+    @Override
+    public void addItems(List<IQuestionnaireResponseItemComponentAdapter> items) {
+        items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireResponseItemComponent.class::cast)
+                .forEach(item -> getQuestionnaireResponse().addItem(item));
+    }
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseAdapter.java
@@ -37,11 +37,6 @@ public class QuestionnaireResponseAdapter extends ResourceAdapter implements IQu
     }
 
     @Override
-    public QuestionnaireResponse copy() {
-        return get().copy();
-    }
-
-    @Override
     public IQuestionnaireResponseAdapter setId(String id) {
         get().setId(id);
         return this;

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseAdapter.java
@@ -1,9 +1,14 @@
 package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
+import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.hl7.fhir.dstu3.model.QuestionnaireResponse;
 import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseStatus;
+import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.instance.model.api.IDomainResource;
+import org.hl7.fhir.instance.model.api.IIdType;
 import org.opencds.cqf.fhir.utility.adapter.IAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
@@ -37,6 +42,36 @@ public class QuestionnaireResponseAdapter extends ResourceAdapter implements IQu
     }
 
     @Override
+    public IQuestionnaireResponseAdapter setId(String id) {
+        get().setId(id);
+        return this;
+    }
+
+    @Override
+    public IQuestionnaireResponseAdapter setQuestionnaire(String canonical) {
+        get().setQuestionnaire(new Reference(canonical));
+        return this;
+    }
+
+    @Override
+    public IQuestionnaireResponseAdapter setSubject(IIdType subject) {
+        get().setSubject(new Reference(subject));
+        return this;
+    }
+
+    @Override
+    public IQuestionnaireResponseAdapter setAuthored(Date date) {
+        get().setAuthored(date);
+        return this;
+    }
+
+    @Override
+    public IQuestionnaireResponseAdapter setStatus(String status) {
+        get().setStatus(QuestionnaireResponseStatus.fromCode(status));
+        return this;
+    }
+
+    @Override
     public boolean hasItem() {
         return getQuestionnaireResponse().hasItem();
     }
@@ -54,7 +89,7 @@ public class QuestionnaireResponseAdapter extends ResourceAdapter implements IQu
                 .setItem(items.stream()
                         .map(IAdapter::get)
                         .map(QuestionnaireResponseItemComponent.class::cast)
-                        .toList());
+                        .collect(Collectors.toList()));
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseItemAnswerComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseItemAnswerComponentAdapter.java
@@ -2,6 +2,7 @@ package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent;
 import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
 import org.hl7.fhir.dstu3.model.Type;
@@ -63,6 +64,6 @@ public class QuestionnaireResponseItemAnswerComponentAdapter extends BaseAdapter
         answer.setItem(items.stream()
                 .map(IAdapter::get)
                 .map(QuestionnaireResponseItemComponent.class::cast)
-                .toList());
+                .collect(Collectors.toList()));
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseItemAnswerComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseItemAnswerComponentAdapter.java
@@ -1,0 +1,68 @@
+package org.opencds.cqf.fhir.utility.adapter.dstu3;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.List;
+import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent;
+import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.dstu3.model.Type;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseDatatype;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemAnswerComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
+
+public class QuestionnaireResponseItemAnswerComponentAdapter extends BaseAdapter
+        implements IQuestionnaireResponseItemAnswerComponentAdapter {
+
+    private final QuestionnaireResponseItemAnswerComponent answer;
+
+    protected QuestionnaireResponseItemAnswerComponentAdapter(IBase answer) {
+        super(FhirVersionEnum.DSTU3, answer);
+        if (!(answer instanceof QuestionnaireResponseItemAnswerComponent)) {
+            throw new IllegalArgumentException(
+                    "object passed as answer argument is not a QuestionnaireResponseItemAnswerComponent data type");
+        }
+        this.answer = (QuestionnaireResponseItemAnswerComponent) answer;
+    }
+
+    @Override
+    public QuestionnaireResponseItemAnswerComponent get() {
+        return answer;
+    }
+
+    @Override
+    public boolean hasValue() {
+        return answer.hasValue();
+    }
+
+    @Override
+    public IBase getValue() {
+        return answer.getValue();
+    }
+
+    @Override
+    public void setValue(IBaseDatatype value) {
+        answer.setValue((Type) value);
+    }
+
+    @Override
+    public boolean hasItem() {
+        return answer.hasItem();
+    }
+
+    @Override
+    public List<IQuestionnaireResponseItemComponentAdapter> getItem() {
+        return answer.getItem().stream()
+                .map(adapterFactory::createQuestionnaireResponseItem)
+                .toList();
+    }
+
+    @Override
+    public void setItem(List<IQuestionnaireResponseItemComponentAdapter> items) {
+        answer.setItem(items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireResponseItemComponent.class::cast)
+                .toList());
+    }
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseItemComponentAdapter.java
@@ -39,6 +39,18 @@ public class QuestionnaireResponseItemComponentAdapter extends BaseAdapter
     }
 
     @Override
+    public IQuestionnaireResponseItemComponentAdapter setLinkId(String linkId) {
+        get().setLinkId(linkId);
+        return this;
+    }
+
+    @Override
+    public IQuestionnaireResponseItemComponentAdapter setDefinition(String definition) {
+        get().setDefinition(definition);
+        return this;
+    }
+
+    @Override
     public boolean hasDefinition() {
         return item.hasDefinition();
     }
@@ -65,7 +77,7 @@ public class QuestionnaireResponseItemComponentAdapter extends BaseAdapter
         item.setItem(items.stream()
                 .map(IAdapter::get)
                 .map(QuestionnaireResponseItemComponent.class::cast)
-                .toList());
+                .collect(Collectors.toList()));
     }
 
     @Override
@@ -74,7 +86,7 @@ public class QuestionnaireResponseItemComponentAdapter extends BaseAdapter
     }
 
     @Override
-    public void addItems(List<IItemComponentAdapter> items) {
+    public void addItems(List<IQuestionnaireResponseItemComponentAdapter> items) {
         items.stream()
                 .map(IAdapter::get)
                 .map(QuestionnaireResponseItemComponent.class::cast)

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseItemComponentAdapter.java
@@ -115,7 +115,7 @@ public class QuestionnaireResponseItemComponentAdapter extends BaseAdapter
     }
 
     @Override
-    public IQuestionnaireResponseItemAnswerComponentAdapter createAnswer(IBaseDatatype value) {
+    public IQuestionnaireResponseItemAnswerComponentAdapter newAnswer(IBaseDatatype value) {
         return adapterFactory.createQuestionnaireResponseItemAnswer(
                 new QuestionnaireResponseItemAnswerComponent().setValue((Type) value));
     }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseItemComponentAdapter.java
@@ -1,0 +1,110 @@
+package org.opencds.cqf.fhir.utility.adapter.dstu3;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent;
+import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.dstu3.model.Type;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseDatatype;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemAnswerComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
+
+public class QuestionnaireResponseItemComponentAdapter extends BaseAdapter
+        implements IQuestionnaireResponseItemComponentAdapter {
+
+    private final QuestionnaireResponseItemComponent item;
+
+    public QuestionnaireResponseItemComponentAdapter(IBase item) {
+        super(FhirVersionEnum.DSTU3, item);
+        if (!(item instanceof QuestionnaireResponseItemComponent)) {
+            throw new IllegalArgumentException(
+                    "object passed as item argument is not a QuestionnaireResponseItemComponent data type");
+        }
+        this.item = (QuestionnaireResponseItemComponent) item;
+    }
+
+    @Override
+    public QuestionnaireResponseItemComponent get() {
+        return item;
+    }
+
+    @Override
+    public String getLinkId() {
+        return item.getLinkId();
+    }
+
+    @Override
+    public boolean hasDefinition() {
+        return item.hasDefinition();
+    }
+
+    @Override
+    public String getDefinition() {
+        return item.getDefinition();
+    }
+
+    @Override
+    public boolean hasItem() {
+        return item.hasItem();
+    }
+
+    @Override
+    public List<IQuestionnaireResponseItemComponentAdapter> getItem() {
+        return item.getItem().stream()
+                .map(adapterFactory::createQuestionnaireResponseItem)
+                .toList();
+    }
+
+    @Override
+    public void setItem(List<? extends IItemComponentAdapter> items) {
+        item.setItem(items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireResponseItemComponent.class::cast)
+                .toList());
+    }
+
+    @Override
+    public void addItem(IItemComponentAdapter item) {
+        this.item.addItem((QuestionnaireResponseItemComponent) item.get());
+    }
+
+    @Override
+    public void addItems(List<IItemComponentAdapter> items) {
+        items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireResponseItemComponent.class::cast)
+                .forEach(this.item::addItem);
+    }
+
+    @Override
+    public boolean hasAnswer() {
+        return item.hasAnswer();
+    }
+
+    @Override
+    public List<IQuestionnaireResponseItemAnswerComponentAdapter> getAnswer() {
+        return item.getAnswer().stream()
+                .map(adapterFactory::createQuestionnaireResponseItemAnswer)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void setAnswer(List<IQuestionnaireResponseItemAnswerComponentAdapter> answers) {
+        item.setAnswer(answers.stream()
+                .map(IAdapter::get)
+                .filter(QuestionnaireResponseItemAnswerComponent.class::isInstance)
+                .map(QuestionnaireResponseItemAnswerComponent.class::cast)
+                .toList());
+    }
+
+    @Override
+    public IQuestionnaireResponseItemAnswerComponentAdapter createAnswer(IBaseDatatype value) {
+        return adapterFactory.createQuestionnaireResponseItemAnswer(
+                new QuestionnaireResponseItemAnswerComponent().setValue((Type) value));
+    }
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/RequestActionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/RequestActionAdapter.java
@@ -1,47 +1,33 @@
 package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
-import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.dstu3.model.RelatedArtifact;
 import org.hl7.fhir.dstu3.model.RequestGroup.RequestGroupActionComponent;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodeableConceptAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IRequestActionAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class RequestActionAdapter implements IRequestActionAdapter {
+public class RequestActionAdapter extends BaseAdapter implements IRequestActionAdapter {
 
     private final RequestGroupActionComponent action;
-    private final FhirContext fhirContext = FhirContext.forDstu3Cached();
-    private final ModelResolver modelResolver;
 
-    public RequestActionAdapter(IBaseBackboneElement action) {
+    public RequestActionAdapter(IBase action) {
+        super(FhirVersionEnum.DSTU3, action);
         if (!(action instanceof RequestGroupActionComponent)) {
             throw new IllegalArgumentException(
                     "element passed as action argument is not a RequestGroupActionComponent Element");
         }
         this.action = (RequestGroupActionComponent) action;
-        modelResolver = FhirModelResolverCache.resolverForVersion(
-                fhirContext.getVersion().getVersion());
     }
 
     @Override
     public RequestGroupActionComponent get() {
         return action;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/StructureDefinitionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/StructureDefinitionAdapter.java
@@ -6,6 +6,7 @@ import org.hl7.fhir.dstu3.model.ElementDefinition;
 import org.hl7.fhir.dstu3.model.StructureDefinition;
 import org.hl7.fhir.dstu3.model.UriType;
 import org.hl7.fhir.instance.model.api.IDomainResource;
+import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.opencds.cqf.fhir.utility.adapter.DependencyInfo;
 import org.opencds.cqf.fhir.utility.adapter.IDependencyInfo;
 import org.opencds.cqf.fhir.utility.adapter.IElementDefinitionAdapter;
@@ -103,8 +104,20 @@ public class StructureDefinitionAdapter extends KnowledgeArtifactAdapter impleme
     }
 
     @Override
+    public IPrimitiveType<String> getBaseDefinition() {
+        return get().getBaseDefinitionElement();
+    }
+
+    @Override
+    public boolean hasSnapshot() {
+        return get().hasSnapshot();
+    }
+
+    @Override
     public List<IElementDefinitionAdapter> getSnapshotElements() {
         return get().getSnapshot().getElement().stream()
+                .filter(ElementDefinition::hasPath)
+                .filter(e -> e.getPath().split("\\.").length > 1)
                 .map(adapterFactory::createElementDefinition)
                 .toList();
     }
@@ -112,6 +125,8 @@ public class StructureDefinitionAdapter extends KnowledgeArtifactAdapter impleme
     @Override
     public List<IElementDefinitionAdapter> getDifferentialElements() {
         return get().getDifferential().getElement().stream()
+                .filter(ElementDefinition::hasPath)
+                .filter(e -> e.getPath().split("\\.").length > 1)
                 .map(adapterFactory::createElementDefinition)
                 .toList();
     }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/TriggerDefinitionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/TriggerDefinitionAdapter.java
@@ -1,42 +1,27 @@
 package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import org.hl7.fhir.dstu3.model.TriggerDefinition;
-import org.hl7.fhir.instance.model.api.ICompositeType;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ITriggerDefinitionAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class TriggerDefinitionAdapter implements ITriggerDefinitionAdapter {
+public class TriggerDefinitionAdapter extends BaseAdapter implements ITriggerDefinitionAdapter {
 
     private final TriggerDefinition triggerDefinition;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public TriggerDefinitionAdapter(ICompositeType triggerDefinition) {
+    public TriggerDefinitionAdapter(IBase triggerDefinition) {
+        super(FhirVersionEnum.DSTU3, triggerDefinition);
         if (!(triggerDefinition instanceof TriggerDefinition)) {
             throw new IllegalArgumentException(
                     "object passed as triggerDefinition argument is not a TriggerDefinition data type");
         }
         this.triggerDefinition = (TriggerDefinition) triggerDefinition;
-        fhirContext = FhirContext.forDstu3Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.DSTU3);
     }
 
     @Override
     public TriggerDefinition get() {
         return triggerDefinition;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ValueSetConceptReferenceAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ValueSetConceptReferenceAdapter.java
@@ -33,4 +33,9 @@ public class ValueSetConceptReferenceAdapter extends BaseAdapter implements IVal
     public String getCode() {
         return get().getCode();
     }
+
+    @Override
+    public String getDisplay() {
+        return get().getDisplay();
+    }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ValueSetConceptReferenceAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ValueSetConceptReferenceAdapter.java
@@ -1,42 +1,27 @@
 package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import org.hl7.fhir.dstu3.model.ValueSet.ConceptReferenceComponent;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetConceptReferenceAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class ValueSetConceptReferenceAdapter implements IValueSetConceptReferenceAdapter {
+public class ValueSetConceptReferenceAdapter extends BaseAdapter implements IValueSetConceptReferenceAdapter {
 
     private final ConceptReferenceComponent conceptReference;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public ValueSetConceptReferenceAdapter(IBaseBackboneElement conceptReference) {
+    public ValueSetConceptReferenceAdapter(IBase conceptReference) {
+        super(FhirVersionEnum.DSTU3, conceptReference);
         if (!(conceptReference instanceof ConceptReferenceComponent)) {
             throw new IllegalArgumentException(
                     "element passed as conceptReference argument is not a ConceptReferenceComponent element");
         }
         this.conceptReference = (ConceptReferenceComponent) conceptReference;
-        fhirContext = FhirContext.forDstu3Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.DSTU3);
     }
 
     @Override
     public ConceptReferenceComponent get() {
         return conceptReference;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ValueSetConceptSetAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ValueSetConceptSetAdapter.java
@@ -1,45 +1,30 @@
 package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hl7.fhir.dstu3.model.ValueSet.ConceptSetComponent;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetConceptReferenceAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetConceptSetAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class ValueSetConceptSetAdapter implements IValueSetConceptSetAdapter {
+public class ValueSetConceptSetAdapter extends BaseAdapter implements IValueSetConceptSetAdapter {
 
     private final ConceptSetComponent conceptSet;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public ValueSetConceptSetAdapter(IBaseBackboneElement conceptSet) {
+    public ValueSetConceptSetAdapter(IBase conceptSet) {
+        super(FhirVersionEnum.DSTU3, conceptSet);
         if (!(conceptSet instanceof ConceptSetComponent)) {
             throw new IllegalArgumentException(
                     "element passed as conceptSet argument is not a ConceptSetComponent element");
         }
         this.conceptSet = (ConceptSetComponent) conceptSet;
-        fhirContext = FhirContext.forDstu3Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.DSTU3);
     }
 
     @Override
     public ConceptSetComponent get() {
         return conceptSet;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ValueSetExpansionContainsAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ValueSetExpansionContainsAdapter.java
@@ -1,42 +1,27 @@
 package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import org.hl7.fhir.dstu3.model.ValueSet.ValueSetExpansionContainsComponent;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetExpansionContainsAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class ValueSetExpansionContainsAdapter implements IValueSetExpansionContainsAdapter {
+public class ValueSetExpansionContainsAdapter extends BaseAdapter implements IValueSetExpansionContainsAdapter {
 
     private final ValueSetExpansionContainsComponent contains;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public ValueSetExpansionContainsAdapter(IBaseBackboneElement contains) {
+    public ValueSetExpansionContainsAdapter(IBase contains) {
+        super(FhirVersionEnum.DSTU3, contains);
         if (!(contains instanceof ValueSetExpansionContainsComponent)) {
             throw new IllegalArgumentException(
                     "element passed as contains argument is not a ValueSetExpansionContainsComponent element");
         }
         this.contains = (ValueSetExpansionContainsComponent) contains;
-        fhirContext = FhirContext.forDstu3Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.DSTU3);
     }
 
     @Override
     public ValueSetExpansionContainsComponent get() {
         return contains;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/AdapterFactory.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/AdapterFactory.java
@@ -59,7 +59,7 @@ public class AdapterFactory implements IAdapterFactory {
     }
 
     @Override
-    public IAdapter<? extends IBase> createBase(IBase element) {
+    public IAdapter<IBase> createBase(IBase element) {
         if (element instanceof QuestionnaireItemComponent) {
             return createQuestionnaireItem(element);
         } else if (element instanceof QuestionnaireResponseItemComponent) {

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/AdapterFactory.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/AdapterFactory.java
@@ -15,6 +15,7 @@ import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.PlanDefinition;
 import org.hl7.fhir.r4.model.Questionnaire;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent;
 import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
 import org.hl7.fhir.r4.model.RequestGroup.RequestGroupActionComponent;
 import org.hl7.fhir.r4.model.StructureDefinition;
@@ -61,12 +62,14 @@ public class AdapterFactory implements IAdapterFactory {
 
     @Override
     public IAdapter<IBase> createBase(IBase element) {
-        if (element instanceof QuestionnaireItemComponent) {
-            return createQuestionnaireItem(element);
-        } else if (element instanceof QuestionnaireResponseItemComponent) {
-            return createQuestionnaireResponseItem(element);
-        } else if (element instanceof RequestGroupActionComponent) {
-            return createRequestAction(element);
+        if (element instanceof QuestionnaireItemComponent item) {
+            return createQuestionnaireItem(item);
+        } else if (element instanceof QuestionnaireResponseItemComponent responseItem) {
+            return createQuestionnaireResponseItem(responseItem);
+        } else if (element instanceof QuestionnaireResponseItemAnswerComponent answer) {
+            return createQuestionnaireResponseItemAnswer(answer);
+        } else if (element instanceof RequestGroupActionComponent requestAction) {
+            return createRequestAction(requestAction);
         } else {
             throw new UnprocessableEntityException(
                     String.format("Unable to create an adapter for type: %s", element.fhirType()));

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/AdapterFactory.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/AdapterFactory.java
@@ -41,6 +41,7 @@ import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemAnswerComp
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IRequestActionAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IResourceAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IStructureDefinitionAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetAdapter;
 
 public class AdapterFactory implements IAdapterFactory {
@@ -168,6 +169,11 @@ public class AdapterFactory implements IAdapterFactory {
     }
 
     @Override
+    public IQuestionnaireItemComponentAdapter createQuestionnaireItem() {
+        return new QuestionnaireItemComponentAdapter(new QuestionnaireItemComponent());
+    }
+
+    @Override
     public IQuestionnaireItemComponentAdapter createQuestionnaireItem(IBase item) {
         return new QuestionnaireItemComponentAdapter(item);
     }
@@ -195,5 +201,10 @@ public class AdapterFactory implements IAdapterFactory {
     @Override
     public IGraphDefinitionAdapter createGraphDefinition(IBaseResource graphDefinition) {
         return new GraphDefinitionAdapter((IDomainResource) graphDefinition);
+    }
+
+    @Override
+    public IStructureDefinitionAdapter createStructureDefinition(IBaseResource structureDefinition) {
+        return new StructureDefinitionAdapter((IDomainResource) structureDefinition);
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/AdapterFactory.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/AdapterFactory.java
@@ -1,10 +1,9 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.instance.model.api.IDomainResource;
 import org.hl7.fhir.r4.model.ActivityDefinition;
 import org.hl7.fhir.r4.model.Endpoint;
@@ -15,9 +14,13 @@ import org.hl7.fhir.r4.model.MetadataResource;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.PlanDefinition;
 import org.hl7.fhir.r4.model.Questionnaire;
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.r4.model.RequestGroup.RequestGroupActionComponent;
 import org.hl7.fhir.r4.model.StructureDefinition;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.opencds.cqf.fhir.utility.adapter.IActivityDefinitionAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
 import org.opencds.cqf.fhir.utility.adapter.IAttachmentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodeableConceptAdapter;
@@ -32,6 +35,10 @@ import org.opencds.cqf.fhir.utility.adapter.IParametersAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IParametersParameterComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IPlanDefinitionAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemAnswerComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IRequestActionAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IResourceAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetAdapter;
@@ -48,6 +55,20 @@ public class AdapterFactory implements IAdapterFactory {
             return createParameters(parameters);
         } else {
             return new ResourceAdapter(resource);
+        }
+    }
+
+    @Override
+    public IAdapter<? extends IBase> createBase(IBase element) {
+        if (element instanceof QuestionnaireItemComponent) {
+            return createQuestionnaireItem(element);
+        } else if (element instanceof QuestionnaireResponseItemComponent) {
+            return createQuestionnaireResponseItem(element);
+        } else if (element instanceof RequestGroupActionComponent) {
+            return createRequestAction(element);
+        } else {
+            throw new UnprocessableEntityException(
+                    String.format("Unable to create an adapter for type: %s", element.fhirType()));
         }
     }
 
@@ -87,7 +108,7 @@ public class AdapterFactory implements IAdapterFactory {
     }
 
     @Override
-    public IAttachmentAdapter createAttachment(ICompositeType attachment) {
+    public IAttachmentAdapter createAttachment(IBase attachment) {
         return new AttachmentAdapter(attachment);
     }
 
@@ -97,8 +118,7 @@ public class AdapterFactory implements IAdapterFactory {
     }
 
     @Override
-    public IParametersParameterComponentAdapter createParametersParameter(
-            IBaseBackboneElement parametersParametersComponent) {
+    public IParametersParameterComponentAdapter createParametersParameter(IBase parametersParametersComponent) {
         return new ParametersParameterComponentAdapter(parametersParametersComponent);
     }
 
@@ -108,17 +128,17 @@ public class AdapterFactory implements IAdapterFactory {
     }
 
     @Override
-    public ICodeableConceptAdapter createCodeableConcept(ICompositeType codeableConcept) {
+    public ICodeableConceptAdapter createCodeableConcept(IBase codeableConcept) {
         return new CodeableConceptAdapter(codeableConcept);
     }
 
     @Override
-    public ICodingAdapter createCoding(ICompositeType coding) {
+    public ICodingAdapter createCoding(IBase coding) {
         return new CodingAdapter(coding);
     }
 
     @Override
-    public IElementDefinitionAdapter createElementDefinition(ICompositeType element) {
+    public IElementDefinitionAdapter createElementDefinition(IBase element) {
         return new ElementDefinitionAdapter(element);
     }
 
@@ -133,18 +153,38 @@ public class AdapterFactory implements IAdapterFactory {
     }
 
     @Override
-    public IRequestActionAdapter createRequestAction(IBaseBackboneElement action) {
+    public IRequestActionAdapter createRequestAction(IBase action) {
         return new RequestActionAdapter(action);
     }
 
     @Override
-    public IDataRequirementAdapter createDataRequirement(ICompositeType dataRequirement) {
+    public IDataRequirementAdapter createDataRequirement(IBase dataRequirement) {
         return new DataRequirementAdapter(dataRequirement);
     }
 
     @Override
     public IQuestionnaireAdapter createQuestionnaire(IBaseResource questionnaire) {
         return new QuestionnaireAdapter((IDomainResource) questionnaire);
+    }
+
+    @Override
+    public IQuestionnaireItemComponentAdapter createQuestionnaireItem(IBase item) {
+        return new QuestionnaireItemComponentAdapter(item);
+    }
+
+    @Override
+    public IQuestionnaireResponseAdapter createQuestionnaireResponse(IBaseResource questionnaireResponse) {
+        return new QuestionnaireResponseAdapter((IDomainResource) questionnaireResponse);
+    }
+
+    @Override
+    public IQuestionnaireResponseItemComponentAdapter createQuestionnaireResponseItem(IBase item) {
+        return new QuestionnaireResponseItemComponentAdapter(item);
+    }
+
+    @Override
+    public IQuestionnaireResponseItemAnswerComponentAdapter createQuestionnaireResponseItemAnswer(IBase answer) {
+        return new QuestionnaireResponseItemAnswerComponentAdapter(answer);
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/AttachmentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/AttachmentAdapter.java
@@ -1,23 +1,18 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
-import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.r4.model.Attachment;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IAttachmentAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-class AttachmentAdapter implements IAttachmentAdapter {
+class AttachmentAdapter extends BaseAdapter implements IAttachmentAdapter {
 
     private final Attachment attachment;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public AttachmentAdapter(ICompositeType attachment) {
-        if (attachment == null) {
-            throw new IllegalArgumentException("attachment can not be null");
-        }
-
+    public AttachmentAdapter(IBase attachment) {
+        super(FhirVersionEnum.R4, attachment);
         if (!attachment.fhirType().equals("Attachment")) {
             throw new IllegalArgumentException("resource passed as attachment argument is not an Attachment resource");
         }
@@ -27,9 +22,6 @@ class AttachmentAdapter implements IAttachmentAdapter {
         }
 
         this.attachment = (Attachment) attachment;
-        fhirContext = FhirContext.forR4Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(
-                fhirContext.getVersion().getVersion());
     }
 
     protected Attachment getAttachment() {
@@ -59,15 +51,5 @@ class AttachmentAdapter implements IAttachmentAdapter {
     @Override
     public void setData(byte[] data) {
         this.getAttachment().setData(data);
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/CodeableConceptAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/CodeableConceptAdapter.java
@@ -1,46 +1,29 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
-import org.hl7.fhir.instance.model.api.ICompositeType;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r4.model.CodeableConcept;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodeableConceptAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodingAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class CodeableConceptAdapter implements ICodeableConceptAdapter {
+public class CodeableConceptAdapter extends BaseAdapter implements ICodeableConceptAdapter {
 
     private final CodeableConcept codeableConcept;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
-    private final AdapterFactory adapterFactory;
 
-    public CodeableConceptAdapter(ICompositeType codeableConcept) {
+    public CodeableConceptAdapter(IBase codeableConcept) {
+        super(FhirVersionEnum.R4, codeableConcept);
         if (!(codeableConcept instanceof CodeableConcept)) {
             throw new IllegalArgumentException(
                     "object passed as codeableConcept argument is not a CodeableConcept data type");
         }
         this.codeableConcept = (CodeableConcept) codeableConcept;
-        fhirContext = FhirContext.forR4Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R4);
-        adapterFactory = new AdapterFactory();
     }
 
     @Override
     public CodeableConcept get() {
         return codeableConcept;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/CodingAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/CodingAdapter.java
@@ -1,42 +1,27 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
-import org.hl7.fhir.instance.model.api.ICompositeType;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r4.model.Coding;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodingAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class CodingAdapter implements ICodingAdapter {
+public class CodingAdapter extends BaseAdapter implements ICodingAdapter {
 
     private final Coding coding;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public CodingAdapter(ICompositeType coding) {
+    public CodingAdapter(IBase coding) {
+        super(FhirVersionEnum.R4, coding);
         if (!(coding instanceof Coding)) {
             throw new IllegalArgumentException(
                     "object passed as codeableConcept argument is not a CodeableConcept data type");
         }
         this.coding = (Coding) coding;
-        fhirContext = FhirContext.forR4Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R4);
     }
 
     @Override
     public Coding get() {
         return coding;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/CodingAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/CodingAdapter.java
@@ -13,8 +13,7 @@ public class CodingAdapter extends BaseAdapter implements ICodingAdapter {
     public CodingAdapter(IBase coding) {
         super(FhirVersionEnum.R4, coding);
         if (!(coding instanceof Coding)) {
-            throw new IllegalArgumentException(
-                    "object passed as codeableConcept argument is not a CodeableConcept data type");
+            throw new IllegalArgumentException("object passed as coding argument is not a Coding data type");
         }
         this.coding = (Coding) coding;
     }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/DataRequirementAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/DataRequirementAdapter.java
@@ -1,45 +1,30 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.hl7.fhir.instance.model.api.ICompositeType;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r4.model.DataRequirement;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IDataRequirementAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IDataRequirementCodeFilterAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class DataRequirementAdapter implements IDataRequirementAdapter {
+public class DataRequirementAdapter extends BaseAdapter implements IDataRequirementAdapter {
 
     private final DataRequirement dataRequirement;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public DataRequirementAdapter(ICompositeType compositeType) {
+    public DataRequirementAdapter(IBase compositeType) {
+        super(FhirVersionEnum.R4, compositeType);
         if (!(compositeType instanceof DataRequirement dataRequirementInner)) {
             throw new IllegalArgumentException(
                     "object passed as dataRequirement argument is not a DataRequirement data type");
         }
         this.dataRequirement = dataRequirementInner;
-        fhirContext = FhirContext.forR4Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R4);
     }
 
     @Override
     public DataRequirement get() {
         return dataRequirement;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/DataRequirementCodeFilterAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/DataRequirementCodeFilterAdapter.java
@@ -1,46 +1,31 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.hl7.fhir.instance.model.api.IBaseDatatypeElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodingAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IDataRequirementCodeFilterAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class DataRequirementCodeFilterAdapter implements IDataRequirementCodeFilterAdapter {
+public class DataRequirementCodeFilterAdapter extends BaseAdapter implements IDataRequirementCodeFilterAdapter {
 
     private final DataRequirementCodeFilterComponent codeFilter;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public DataRequirementCodeFilterAdapter(IBaseDatatypeElement codeFilter) {
+    public DataRequirementCodeFilterAdapter(IBase codeFilter) {
+        super(FhirVersionEnum.R4, codeFilter);
         if (!(codeFilter instanceof DataRequirementCodeFilterComponent)) {
             throw new IllegalArgumentException(
                     "object passed as codeFilter argument is not a DataRequirementCodeFilterComponent data type");
         }
         this.codeFilter = (DataRequirementCodeFilterComponent) codeFilter;
-        fhirContext = FhirContext.forR4Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R4);
     }
 
     @Override
     public DataRequirementCodeFilterComponent get() {
         return codeFilter;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/ElementDefinitionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/ElementDefinitionAdapter.java
@@ -1,52 +1,34 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseDatatype;
 import org.hl7.fhir.instance.model.api.IBaseDatatypeElement;
-import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.ElementDefinition;
 import org.hl7.fhir.r4.model.PrimitiveType;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.fhir.utility.Constants;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodingAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IElementDefinitionAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class ElementDefinitionAdapter implements IElementDefinitionAdapter {
+public class ElementDefinitionAdapter extends BaseAdapter implements IElementDefinitionAdapter {
 
     private final ElementDefinition elementDefinition;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
-    private final AdapterFactory adapterFactory;
 
-    public ElementDefinitionAdapter(ICompositeType elementDefinition) {
+    public ElementDefinitionAdapter(IBase elementDefinition) {
+        super(FhirVersionEnum.R4, elementDefinition);
         if (!(elementDefinition instanceof ElementDefinition)) {
             throw new IllegalArgumentException(
                     "object passed as elementDefinition argument is not a ElementDefinition data type");
         }
         this.elementDefinition = (ElementDefinition) elementDefinition;
-        fhirContext = FhirContext.forR4Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R5);
-        adapterFactory = new AdapterFactory();
     }
 
     @Override
     public ElementDefinition get() {
         return elementDefinition;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/ParametersParameterComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/ParametersParameterComponentAdapter.java
@@ -1,8 +1,9 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
-import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IBaseDatatype;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -11,36 +12,25 @@ import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.Type;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
-import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IParametersParameterComponentAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-class ParametersParameterComponentAdapter implements IParametersParameterComponentAdapter {
+class ParametersParameterComponentAdapter extends BaseAdapter implements IParametersParameterComponentAdapter {
 
-    private final FhirContext fhirContext = FhirContext.forR4Cached();
     private final Parameters.ParametersParameterComponent parametersParameterComponent;
-    private final ModelResolver modelResolver;
-    private final IAdapterFactory adapterFactory;
 
     protected Parameters.ParametersParameterComponent getParametersParameterComponent() {
         return this.parametersParameterComponent;
     }
 
-    public ParametersParameterComponentAdapter(IBaseBackboneElement parametersParameterComponent) {
-        if (parametersParameterComponent == null) {
-            throw new IllegalArgumentException("parametersParameterComponent can not be null");
-        }
-
+    public ParametersParameterComponentAdapter(IBase parametersParameterComponent) {
+        super(FhirVersionEnum.R4, parametersParameterComponent);
         if (!parametersParameterComponent.fhirType().equals("Parameters.parameter")) {
             throw new IllegalArgumentException(
                     "element passed as parametersParameterComponent argument is not a ParametersParameterComponent Element");
         }
 
         this.parametersParameterComponent = (ParametersParameterComponent) parametersParameterComponent;
-        modelResolver = FhirModelResolverCache.resolverForVersion(
-                fhirContext.getVersion().getVersion());
-        adapterFactory = IAdapterFactory.forFhirContext(fhirContext);
     }
 
     @Override
@@ -134,15 +124,5 @@ class ParametersParameterComponentAdapter implements IParametersParameterCompone
         return hasPrimitiveValue()
                 ? this.getParametersParameterComponent().getValue().primitiveValue()
                 : null;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/PlanDefinitionActionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/PlanDefinitionActionAdapter.java
@@ -1,45 +1,30 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r4.model.PlanDefinition.PlanDefinitionActionComponent;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IPlanDefinitionActionAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ITriggerDefinitionAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class PlanDefinitionActionAdapter implements IPlanDefinitionActionAdapter {
+public class PlanDefinitionActionAdapter extends BaseAdapter implements IPlanDefinitionActionAdapter {
 
     private final PlanDefinitionActionComponent action;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public PlanDefinitionActionAdapter(IBaseBackboneElement action) {
+    public PlanDefinitionActionAdapter(IBase action) {
+        super(FhirVersionEnum.R4, action);
         if (!(action instanceof PlanDefinitionActionComponent)) {
             throw new IllegalArgumentException(
                     "object passed as action argument is not a PlanDefinitionActionComponent data type");
         }
         this.action = (PlanDefinitionActionComponent) action;
-        fhirContext = FhirContext.forR4Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R4);
     }
 
     @Override
     public PlanDefinitionActionComponent get() {
         return action;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override
@@ -54,6 +39,6 @@ public class PlanDefinitionActionAdapter implements IPlanDefinitionActionAdapter
 
     @Override
     public List<String> getTriggerType() {
-        return get().getTrigger().stream().map(t -> t.getType().toCode()).collect(Collectors.toUnmodifiableList());
+        return get().getTrigger().stream().map(t -> t.getType().toCode()).toList();
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireAdapter.java
@@ -2,6 +2,8 @@ package org.opencds.cqf.fhir.utility.adapter.r4;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IDomainResource;
 import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.Expression;
@@ -147,7 +149,14 @@ public class QuestionnaireAdapter extends KnowledgeArtifactAdapter implements IQ
                 .setItem(items.stream()
                         .map(IAdapter::get)
                         .map(QuestionnaireItemComponent.class::cast)
-                        .toList());
+                        .collect(Collectors.toList()));
+    }
+
+    @Override
+    public void addItem(IBaseBackboneElement item) {
+        if (item instanceof QuestionnaireItemComponent itemComponent) {
+            getQuestionnaire().addItem(itemComponent);
+        }
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireAdapter.java
@@ -40,11 +40,6 @@ public class QuestionnaireAdapter extends KnowledgeArtifactAdapter implements IQ
     }
 
     @Override
-    public Questionnaire copy() {
-        return get().copy();
-    }
-
-    @Override
     public List<IDependencyInfo> getDependencies() {
         List<IDependencyInfo> references = new ArrayList<>();
         final String referenceSource = getReferenceSource();

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireAdapter.java
@@ -9,8 +9,10 @@ import org.hl7.fhir.r4.model.Questionnaire;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.adapter.DependencyInfo;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IDependencyInfo;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
 
 public class QuestionnaireAdapter extends KnowledgeArtifactAdapter implements IQuestionnaireAdapter {
 
@@ -125,5 +127,39 @@ public class QuestionnaireAdapter extends KnowledgeArtifactAdapter implements IQ
                         expression.getExtension(),
                         expression::setReference)));
         item.getItem().forEach(childItem -> getDependenciesOfItem(childItem, references, referenceSource));
+    }
+
+    @Override
+    public boolean hasItem() {
+        return getQuestionnaire().hasItem();
+    }
+
+    @Override
+    public List<IQuestionnaireItemComponentAdapter> getItem() {
+        return getQuestionnaire().getItem().stream()
+                .map(adapterFactory::createQuestionnaireItem)
+                .toList();
+    }
+
+    @Override
+    public void setItem(List<IQuestionnaireItemComponentAdapter> items) {
+        getQuestionnaire()
+                .setItem(items.stream()
+                        .map(IAdapter::get)
+                        .map(QuestionnaireItemComponent.class::cast)
+                        .toList());
+    }
+
+    @Override
+    public void addItem(IQuestionnaireItemComponentAdapter item) {
+        getQuestionnaire().addItem((QuestionnaireItemComponent) item.get());
+    }
+
+    @Override
+    public void addItems(List<IQuestionnaireItemComponentAdapter> items) {
+        items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireItemComponent.class::cast)
+                .forEach(item -> getQuestionnaire().addItem(item));
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireItemComponentAdapter.java
@@ -6,7 +6,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
+import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Expression;
 import org.hl7.fhir.r4.model.Questionnaire;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemInitialComponent;
@@ -190,5 +192,10 @@ public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQ
                 .setLinkId(item.getLinkId())
                 .setDefinitionElement(item.getDefinitionElement())
                 .setTextElement(item.getTextElement()));
+    }
+
+    @Override
+    public ICompositeType newExpression(String language, String expression) {
+        return new Expression().setLanguage(language).setExpression(expression);
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireItemComponentAdapter.java
@@ -3,16 +3,19 @@ package org.opencds.cqf.fhir.utility.adapter.r4;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Questionnaire;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemInitialComponent;
-import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType;
 import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
 import org.hl7.fhir.r4.model.Type;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IAdapter;
+import org.opencds.cqf.fhir.utility.adapter.ICodingAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IItemComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
@@ -51,23 +54,9 @@ public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQ
     }
 
     @Override
-    public List<IBaseCoding> getCode() {
-        return item.getCode().stream().map(IBaseCoding.class::cast).toList();
-    }
-
-    @Override
-    public String getType() {
-        return item.getType().toCode();
-    }
-
-    @Override
-    public boolean isGroupItem() {
-        return item.getType().equals(QuestionnaireItemType.GROUP);
-    }
-
-    @Override
-    public boolean getRepeats() {
-        return item.getRepeats();
+    public IQuestionnaireItemComponentAdapter setLinkId(String linkId) {
+        get().setLinkId(linkId);
+        return this;
     }
 
     @Override
@@ -78,6 +67,12 @@ public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQ
     @Override
     public String getDefinition() {
         return item.getDefinition();
+    }
+
+    @Override
+    public IQuestionnaireItemComponentAdapter setDefinition(String definition) {
+        item.setDefinition(definition);
+        return this;
     }
 
     @Override
@@ -97,7 +92,7 @@ public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQ
         item.setItem(items.stream()
                 .map(IAdapter::get)
                 .map(QuestionnaireItemComponent.class::cast)
-                .toList());
+                .collect(Collectors.toList()));
     }
 
     @Override
@@ -106,11 +101,75 @@ public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQ
     }
 
     @Override
-    public void addItems(List<IItemComponentAdapter> items) {
+    public void addItems(List<IQuestionnaireItemComponentAdapter> items) {
         items.stream()
                 .map(IAdapter::get)
                 .map(QuestionnaireItemComponent.class::cast)
                 .forEach(this.item::addItem);
+    }
+
+    @Override
+    public List<IBaseCoding> getCode() {
+        return item.getCode().stream().map(IBaseCoding.class::cast).toList();
+    }
+
+    @Override
+    public String getText() {
+        return item.getText();
+    }
+
+    @Override
+    public IQuestionnaireItemComponentAdapter setText(String text) {
+        item.setText(text);
+        return this;
+    }
+
+    @Override
+    public String getType() {
+        return item.getType().toCode();
+    }
+
+    @Override
+    public IQuestionnaireItemComponentAdapter setType(String type) {
+        item.setType(Questionnaire.QuestionnaireItemType.fromCode(type));
+        return this;
+    }
+
+    @Override
+    public boolean isGroupItem() {
+        return item.getType().equals(Questionnaire.QuestionnaireItemType.GROUP);
+    }
+
+    @Override
+    public boolean isChoiceItem() {
+        return item.getType().equals(Questionnaire.QuestionnaireItemType.QUESTION);
+    }
+
+    @Override
+    public boolean getRequired() {
+        return item.getRequired();
+    }
+
+    @Override
+    public IQuestionnaireItemComponentAdapter setRequired(boolean required) {
+        get().setRequired(required);
+        return this;
+    }
+
+    @Override
+    public boolean getRepeats() {
+        return item.getRepeats();
+    }
+
+    @Override
+    public IQuestionnaireItemComponentAdapter setRepeats(boolean repeats) {
+        get().setRepeats(repeats);
+        return this;
+    }
+
+    @Override
+    public void addAnswerOption(ICodingAdapter option) {
+        get().addAnswerOption().setValue((Coding) option.get());
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireItemComponentAdapter.java
@@ -9,9 +9,9 @@ import org.hl7.fhir.instance.model.api.IBaseCoding;
 import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Expression;
-import org.hl7.fhir.r4.model.Questionnaire;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemInitialComponent;
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType;
 import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
 import org.hl7.fhir.r4.model.Type;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
@@ -133,18 +133,18 @@ public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQ
 
     @Override
     public IQuestionnaireItemComponentAdapter setType(String type) {
-        item.setType(Questionnaire.QuestionnaireItemType.fromCode(type));
+        item.setType(QuestionnaireItemType.fromCode(type));
         return this;
     }
 
     @Override
     public boolean isGroupItem() {
-        return item.getType().equals(Questionnaire.QuestionnaireItemType.GROUP);
+        return item.getType().equals(QuestionnaireItemType.GROUP);
     }
 
     @Override
     public boolean isChoiceItem() {
-        return item.getType().equals(Questionnaire.QuestionnaireItemType.QUESTION);
+        return item.getType().equals(QuestionnaireItemType.CHOICE);
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireItemComponentAdapter.java
@@ -1,0 +1,135 @@
+package org.opencds.cqf.fhir.utility.adapter.r4;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.List;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseCoding;
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemInitialComponent;
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType;
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.r4.model.Type;
+import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
+
+public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQuestionnaireItemComponentAdapter {
+
+    private final QuestionnaireItemComponent item;
+
+    public QuestionnaireItemComponentAdapter(IBase item) {
+        super(FhirVersionEnum.R4, item);
+        if (!(item instanceof QuestionnaireItemComponent)) {
+            throw new IllegalArgumentException(
+                    "object passed as item argument is not a QuestionnaireItemComponent data type");
+        }
+        this.item = (QuestionnaireItemComponent) item;
+    }
+
+    @Override
+    public QuestionnaireItemComponent get() {
+        return item;
+    }
+
+    @Override
+    public FhirContext fhirContext() {
+        return fhirContext;
+    }
+
+    @Override
+    public ModelResolver getModelResolver() {
+        return modelResolver;
+    }
+
+    @Override
+    public String getLinkId() {
+        return item.getLinkId();
+    }
+
+    @Override
+    public List<IBaseCoding> getCode() {
+        return item.getCode().stream().map(IBaseCoding.class::cast).toList();
+    }
+
+    @Override
+    public String getType() {
+        return item.getType().toCode();
+    }
+
+    @Override
+    public boolean isGroupItem() {
+        return item.getType().equals(QuestionnaireItemType.GROUP);
+    }
+
+    @Override
+    public boolean getRepeats() {
+        return item.getRepeats();
+    }
+
+    @Override
+    public boolean hasDefinition() {
+        return item.hasDefinition();
+    }
+
+    @Override
+    public String getDefinition() {
+        return item.getDefinition();
+    }
+
+    @Override
+    public boolean hasItem() {
+        return item.hasItem();
+    }
+
+    @Override
+    public List<IQuestionnaireItemComponentAdapter> getItem() {
+        return item.getItem().stream()
+                .map(adapterFactory::createQuestionnaireItem)
+                .toList();
+    }
+
+    @Override
+    public void setItem(List<? extends IItemComponentAdapter> items) {
+        item.setItem(items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireItemComponent.class::cast)
+                .toList());
+    }
+
+    @Override
+    public void addItem(IItemComponentAdapter item) {
+        this.item.addItem((QuestionnaireItemComponent) item.get());
+    }
+
+    @Override
+    public void addItems(List<IItemComponentAdapter> items) {
+        items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireItemComponent.class::cast)
+                .forEach(this.item::addItem);
+    }
+
+    @Override
+    public boolean hasInitial() {
+        return item.hasInitial();
+    }
+
+    @Override
+    public List<Type> getInitial() {
+        return item.getInitial().stream()
+                .map(QuestionnaireItemInitialComponent::getValue)
+                .toList();
+    }
+
+    @Override
+    public IQuestionnaireResponseItemComponentAdapter newResponseItem() {
+        return adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent()
+                .setLinkId(item.getLinkId())
+                .setDefinitionElement(item.getDefinitionElement())
+                .setTextElement(item.getTextElement()));
+    }
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseAdapter.java
@@ -1,0 +1,72 @@
+package org.opencds.cqf.fhir.utility.adapter.r4;
+
+import java.util.List;
+import org.hl7.fhir.instance.model.api.IDomainResource;
+import org.hl7.fhir.r4.model.QuestionnaireResponse;
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
+
+public class QuestionnaireResponseAdapter extends ResourceAdapter implements IQuestionnaireResponseAdapter {
+
+    public QuestionnaireResponseAdapter(IDomainResource questionnaireResponse) {
+        super(questionnaireResponse);
+        if (!(questionnaireResponse instanceof QuestionnaireResponse)) {
+            throw new IllegalArgumentException(
+                    "resource passed as questionnaire argument is not a QuestionnaireResponse resource");
+        }
+    }
+
+    public QuestionnaireResponseAdapter(QuestionnaireResponse questionnaireResponse) {
+        super(questionnaireResponse);
+    }
+
+    protected QuestionnaireResponse getQuestionnaireResponse() {
+        return (QuestionnaireResponse) resource;
+    }
+
+    @Override
+    public QuestionnaireResponse get() {
+        return getQuestionnaireResponse();
+    }
+
+    @Override
+    public QuestionnaireResponse copy() {
+        return get().copy();
+    }
+
+    @Override
+    public boolean hasItem() {
+        return getQuestionnaireResponse().hasItem();
+    }
+
+    @Override
+    public List<IQuestionnaireResponseItemComponentAdapter> getItem() {
+        return getQuestionnaireResponse().getItem().stream()
+                .map(adapterFactory::createQuestionnaireResponseItem)
+                .toList();
+    }
+
+    @Override
+    public void setItem(List<IQuestionnaireResponseItemComponentAdapter> items) {
+        getQuestionnaireResponse()
+                .setItem(items.stream()
+                        .map(IAdapter::get)
+                        .map(QuestionnaireResponseItemComponent.class::cast)
+                        .toList());
+    }
+
+    @Override
+    public void addItem(IQuestionnaireResponseItemComponentAdapter item) {
+        getQuestionnaireResponse().addItem((QuestionnaireResponseItemComponent) item.get());
+    }
+
+    @Override
+    public void addItems(List<IQuestionnaireResponseItemComponentAdapter> items) {
+        items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireResponseItemComponent.class::cast)
+                .forEach(item -> getQuestionnaireResponse().addItem(item));
+    }
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseAdapter.java
@@ -37,11 +37,6 @@ public class QuestionnaireResponseAdapter extends ResourceAdapter implements IQu
     }
 
     @Override
-    public QuestionnaireResponse copy() {
-        return get().copy();
-    }
-
-    @Override
     public IQuestionnaireResponseAdapter setId(String id) {
         get().setId(id);
         return this;

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseAdapter.java
@@ -1,9 +1,14 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
+import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.hl7.fhir.instance.model.api.IDomainResource;
+import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.QuestionnaireResponse;
 import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseStatus;
+import org.hl7.fhir.r4.model.Reference;
 import org.opencds.cqf.fhir.utility.adapter.IAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
@@ -37,6 +42,36 @@ public class QuestionnaireResponseAdapter extends ResourceAdapter implements IQu
     }
 
     @Override
+    public IQuestionnaireResponseAdapter setId(String id) {
+        get().setId(id);
+        return this;
+    }
+
+    @Override
+    public IQuestionnaireResponseAdapter setQuestionnaire(String canonical) {
+        get().setQuestionnaire(canonical);
+        return this;
+    }
+
+    @Override
+    public IQuestionnaireResponseAdapter setSubject(IIdType subject) {
+        get().setSubject(new Reference(subject));
+        return this;
+    }
+
+    @Override
+    public IQuestionnaireResponseAdapter setAuthored(Date date) {
+        get().setAuthored(date);
+        return this;
+    }
+
+    @Override
+    public IQuestionnaireResponseAdapter setStatus(String status) {
+        get().setStatus(QuestionnaireResponseStatus.fromCode(status));
+        return this;
+    }
+
+    @Override
     public boolean hasItem() {
         return getQuestionnaireResponse().hasItem();
     }
@@ -54,7 +89,7 @@ public class QuestionnaireResponseAdapter extends ResourceAdapter implements IQu
                 .setItem(items.stream()
                         .map(IAdapter::get)
                         .map(QuestionnaireResponseItemComponent.class::cast)
-                        .toList());
+                        .collect(Collectors.toList()));
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseItemAnswerComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseItemAnswerComponentAdapter.java
@@ -1,0 +1,68 @@
+package org.opencds.cqf.fhir.utility.adapter.r4;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.List;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseDatatype;
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent;
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.r4.model.Type;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemAnswerComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
+
+public class QuestionnaireResponseItemAnswerComponentAdapter extends BaseAdapter
+        implements IQuestionnaireResponseItemAnswerComponentAdapter {
+
+    private final QuestionnaireResponseItemAnswerComponent answer;
+
+    protected QuestionnaireResponseItemAnswerComponentAdapter(IBase answer) {
+        super(FhirVersionEnum.R4, answer);
+        if (!(answer instanceof QuestionnaireResponseItemAnswerComponent)) {
+            throw new IllegalArgumentException(
+                    "object passed as answer argument is not a QuestionnaireResponseItemAnswerComponent data type");
+        }
+        this.answer = (QuestionnaireResponseItemAnswerComponent) answer;
+    }
+
+    @Override
+    public QuestionnaireResponseItemAnswerComponent get() {
+        return answer;
+    }
+
+    @Override
+    public boolean hasValue() {
+        return answer.hasValue();
+    }
+
+    @Override
+    public IBase getValue() {
+        return answer.getValue();
+    }
+
+    @Override
+    public void setValue(IBaseDatatype value) {
+        answer.setValue((Type) value);
+    }
+
+    @Override
+    public boolean hasItem() {
+        return answer.hasItem();
+    }
+
+    @Override
+    public List<IQuestionnaireResponseItemComponentAdapter> getItem() {
+        return answer.getItem().stream()
+                .map(adapterFactory::createQuestionnaireResponseItem)
+                .toList();
+    }
+
+    @Override
+    public void setItem(List<IQuestionnaireResponseItemComponentAdapter> items) {
+        answer.setItem(items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireResponseItemComponent.class::cast)
+                .toList());
+    }
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseItemAnswerComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseItemAnswerComponentAdapter.java
@@ -2,6 +2,7 @@ package org.opencds.cqf.fhir.utility.adapter.r4;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseDatatype;
 import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent;
@@ -63,6 +64,6 @@ public class QuestionnaireResponseItemAnswerComponentAdapter extends BaseAdapter
         answer.setItem(items.stream()
                 .map(IAdapter::get)
                 .map(QuestionnaireResponseItemComponent.class::cast)
-                .toList());
+                .collect(Collectors.toList()));
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseItemComponentAdapter.java
@@ -39,6 +39,18 @@ public class QuestionnaireResponseItemComponentAdapter extends BaseAdapter
     }
 
     @Override
+    public IQuestionnaireResponseItemComponentAdapter setLinkId(String linkId) {
+        get().setLinkId(linkId);
+        return this;
+    }
+
+    @Override
+    public IQuestionnaireResponseItemComponentAdapter setDefinition(String definition) {
+        get().setDefinition(definition);
+        return this;
+    }
+
+    @Override
     public boolean hasDefinition() {
         return item.hasDefinition();
     }
@@ -65,7 +77,7 @@ public class QuestionnaireResponseItemComponentAdapter extends BaseAdapter
         item.setItem(items.stream()
                 .map(IAdapter::get)
                 .map(QuestionnaireResponseItemComponent.class::cast)
-                .toList());
+                .collect(Collectors.toList()));
     }
 
     @Override
@@ -74,7 +86,7 @@ public class QuestionnaireResponseItemComponentAdapter extends BaseAdapter
     }
 
     @Override
-    public void addItems(List<IItemComponentAdapter> items) {
+    public void addItems(List<IQuestionnaireResponseItemComponentAdapter> items) {
         items.stream()
                 .map(IAdapter::get)
                 .map(QuestionnaireResponseItemComponent.class::cast)

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseItemComponentAdapter.java
@@ -115,7 +115,7 @@ public class QuestionnaireResponseItemComponentAdapter extends BaseAdapter
     }
 
     @Override
-    public IQuestionnaireResponseItemAnswerComponentAdapter createAnswer(IBaseDatatype value) {
+    public IQuestionnaireResponseItemAnswerComponentAdapter newAnswer(IBaseDatatype value) {
         return adapterFactory.createQuestionnaireResponseItemAnswer(
                 new QuestionnaireResponseItemAnswerComponent().setValue((Type) value));
     }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseItemComponentAdapter.java
@@ -1,0 +1,110 @@
+package org.opencds.cqf.fhir.utility.adapter.r4;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseDatatype;
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent;
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.r4.model.Type;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemAnswerComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
+
+public class QuestionnaireResponseItemComponentAdapter extends BaseAdapter
+        implements IQuestionnaireResponseItemComponentAdapter {
+
+    private final QuestionnaireResponseItemComponent item;
+
+    public QuestionnaireResponseItemComponentAdapter(IBase item) {
+        super(FhirVersionEnum.R4, item);
+        if (!(item instanceof QuestionnaireResponseItemComponent)) {
+            throw new IllegalArgumentException(
+                    "object passed as item argument is not a QuestionnaireResponseItemComponent data type");
+        }
+        this.item = (QuestionnaireResponseItemComponent) item;
+    }
+
+    @Override
+    public QuestionnaireResponseItemComponent get() {
+        return item;
+    }
+
+    @Override
+    public String getLinkId() {
+        return item.getLinkId();
+    }
+
+    @Override
+    public boolean hasDefinition() {
+        return item.hasDefinition();
+    }
+
+    @Override
+    public String getDefinition() {
+        return item.getDefinition();
+    }
+
+    @Override
+    public boolean hasItem() {
+        return item.hasItem();
+    }
+
+    @Override
+    public List<IQuestionnaireResponseItemComponentAdapter> getItem() {
+        return item.getItem().stream()
+                .map(adapterFactory::createQuestionnaireResponseItem)
+                .toList();
+    }
+
+    @Override
+    public void setItem(List<? extends IItemComponentAdapter> items) {
+        item.setItem(items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireResponseItemComponent.class::cast)
+                .toList());
+    }
+
+    @Override
+    public void addItem(IItemComponentAdapter item) {
+        this.item.addItem((QuestionnaireResponseItemComponent) item.get());
+    }
+
+    @Override
+    public void addItems(List<IItemComponentAdapter> items) {
+        items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireResponseItemComponent.class::cast)
+                .forEach(this.item::addItem);
+    }
+
+    @Override
+    public boolean hasAnswer() {
+        return item.hasAnswer();
+    }
+
+    @Override
+    public List<IQuestionnaireResponseItemAnswerComponentAdapter> getAnswer() {
+        return item.getAnswer().stream()
+                .map(adapterFactory::createQuestionnaireResponseItemAnswer)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void setAnswer(List<IQuestionnaireResponseItemAnswerComponentAdapter> answers) {
+        item.setAnswer(answers.stream()
+                .map(IAdapter::get)
+                .filter(QuestionnaireResponseItemAnswerComponent.class::isInstance)
+                .map(QuestionnaireResponseItemAnswerComponent.class::cast)
+                .toList());
+    }
+
+    @Override
+    public IQuestionnaireResponseItemAnswerComponentAdapter createAnswer(IBaseDatatype value) {
+        return adapterFactory.createQuestionnaireResponseItemAnswer(
+                new QuestionnaireResponseItemAnswerComponent().setValue((Type) value));
+    }
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/RequestActionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/RequestActionAdapter.java
@@ -1,46 +1,32 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
-import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.RelatedArtifact;
 import org.hl7.fhir.r4.model.RequestGroup.RequestGroupActionComponent;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodeableConceptAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IRequestActionAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class RequestActionAdapter implements IRequestActionAdapter {
+public class RequestActionAdapter extends BaseAdapter implements IRequestActionAdapter {
 
     private final RequestGroupActionComponent action;
-    private final FhirContext fhirContext = FhirContext.forR4Cached();
-    private final ModelResolver modelResolver;
 
-    public RequestActionAdapter(IBaseBackboneElement action) {
+    public RequestActionAdapter(IBase action) {
+        super(FhirVersionEnum.R4, action);
         if (!(action instanceof RequestGroupActionComponent)) {
             throw new IllegalArgumentException(
                     "element passed as action argument is not a RequestGroupActionComponent Element");
         }
         this.action = (RequestGroupActionComponent) action;
-        modelResolver = FhirModelResolverCache.resolverForVersion(
-                fhirContext.getVersion().getVersion());
     }
 
     @Override
     public RequestGroupActionComponent get() {
         return action;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/StructureDefinitionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/StructureDefinitionAdapter.java
@@ -3,6 +3,7 @@ package org.opencds.cqf.fhir.utility.adapter.r4;
 import java.util.ArrayList;
 import java.util.List;
 import org.hl7.fhir.instance.model.api.IDomainResource;
+import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.hl7.fhir.r4.model.ElementDefinition;
 import org.hl7.fhir.r4.model.Expression;
 import org.hl7.fhir.r4.model.StructureDefinition;
@@ -61,7 +62,7 @@ public class StructureDefinitionAdapter extends KnowledgeArtifactAdapter impleme
         get().getExtensionsByUrl(Constants.CPG_ASSERTION_EXPRESSION).stream()
                 .filter(e -> e.getValue() instanceof Expression)
                 .map(e -> (Expression) e.getValue())
-                .filter(e -> e.hasReference())
+                .filter(Expression::hasReference)
                 .forEach(expression -> references.add(new DependencyInfo(
                         referenceSource,
                         expression.getReference(),
@@ -70,7 +71,7 @@ public class StructureDefinitionAdapter extends KnowledgeArtifactAdapter impleme
         get().getExtensionsByUrl(Constants.CPG_FEATURE_EXPRESSION).stream()
                 .filter(e -> e.getValue() instanceof Expression)
                 .map(e -> (Expression) e.getValue())
-                .filter(e -> e.hasReference())
+                .filter(Expression::hasReference)
                 .forEach(expression -> references.add(new DependencyInfo(
                         referenceSource,
                         expression.getReference(),
@@ -79,7 +80,7 @@ public class StructureDefinitionAdapter extends KnowledgeArtifactAdapter impleme
         get().getExtensionsByUrl(Constants.CPG_INFERENCE_EXPRESSION).stream()
                 .filter(e -> e.getValue() instanceof Expression)
                 .map(e -> (Expression) e.getValue())
-                .filter(e -> e.hasReference())
+                .filter(Expression::hasReference)
                 .forEach(expression -> references.add(new DependencyInfo(
                         referenceSource,
                         expression.getReference(),
@@ -122,8 +123,20 @@ public class StructureDefinitionAdapter extends KnowledgeArtifactAdapter impleme
     }
 
     @Override
+    public IPrimitiveType<String> getBaseDefinition() {
+        return get().getBaseDefinitionElement();
+    }
+
+    @Override
+    public boolean hasSnapshot() {
+        return get().hasSnapshot();
+    }
+
+    @Override
     public List<IElementDefinitionAdapter> getSnapshotElements() {
         return get().getSnapshot().getElement().stream()
+                .filter(ElementDefinition::hasPath)
+                .filter(e -> e.getPath().split("\\.").length > 1)
                 .map(adapterFactory::createElementDefinition)
                 .toList();
     }
@@ -131,6 +144,8 @@ public class StructureDefinitionAdapter extends KnowledgeArtifactAdapter impleme
     @Override
     public List<IElementDefinitionAdapter> getDifferentialElements() {
         return get().getDifferential().getElement().stream()
+                .filter(ElementDefinition::hasPath)
+                .filter(e -> e.getPath().split("\\.").length > 1)
                 .map(adapterFactory::createElementDefinition)
                 .toList();
     }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/TriggerDefinitionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/TriggerDefinitionAdapter.java
@@ -1,42 +1,27 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
-import org.hl7.fhir.instance.model.api.ICompositeType;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r4.model.TriggerDefinition;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ITriggerDefinitionAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class TriggerDefinitionAdapter implements ITriggerDefinitionAdapter {
+public class TriggerDefinitionAdapter extends BaseAdapter implements ITriggerDefinitionAdapter {
 
     private final TriggerDefinition triggerDefinition;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public TriggerDefinitionAdapter(ICompositeType triggerDefinition) {
+    public TriggerDefinitionAdapter(IBase triggerDefinition) {
+        super(FhirVersionEnum.R4, triggerDefinition);
         if (!(triggerDefinition instanceof TriggerDefinition)) {
             throw new IllegalArgumentException(
                     "object passed as triggerDefinition argument is not a TriggerDefinition data type");
         }
         this.triggerDefinition = (TriggerDefinition) triggerDefinition;
-        fhirContext = FhirContext.forR4Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R4);
     }
 
     @Override
     public TriggerDefinition get() {
         return triggerDefinition;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/ValueSetConceptReferenceAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/ValueSetConceptReferenceAdapter.java
@@ -33,4 +33,9 @@ public class ValueSetConceptReferenceAdapter extends BaseAdapter implements IVal
     public String getCode() {
         return get().getCode();
     }
+
+    @Override
+    public String getDisplay() {
+        return get().getDisplay();
+    }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/ValueSetConceptReferenceAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/ValueSetConceptReferenceAdapter.java
@@ -1,42 +1,27 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r4.model.ValueSet.ConceptReferenceComponent;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetConceptReferenceAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class ValueSetConceptReferenceAdapter implements IValueSetConceptReferenceAdapter {
+public class ValueSetConceptReferenceAdapter extends BaseAdapter implements IValueSetConceptReferenceAdapter {
 
     private final ConceptReferenceComponent conceptReference;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public ValueSetConceptReferenceAdapter(IBaseBackboneElement conceptReference) {
+    public ValueSetConceptReferenceAdapter(IBase conceptReference) {
+        super(FhirVersionEnum.R4, conceptReference);
         if (!(conceptReference instanceof ConceptReferenceComponent)) {
             throw new IllegalArgumentException(
                     "element passed as conceptReference argument is not a ConceptReferenceComponent element");
         }
         this.conceptReference = (ConceptReferenceComponent) conceptReference;
-        fhirContext = FhirContext.forR4Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R4);
     }
 
     @Override
     public ConceptReferenceComponent get() {
         return conceptReference;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/ValueSetConceptSetAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/ValueSetConceptSetAdapter.java
@@ -1,45 +1,30 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r4.model.ValueSet.ConceptSetComponent;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetConceptReferenceAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetConceptSetAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class ValueSetConceptSetAdapter implements IValueSetConceptSetAdapter {
+public class ValueSetConceptSetAdapter extends BaseAdapter implements IValueSetConceptSetAdapter {
 
     private final ConceptSetComponent conceptSet;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public ValueSetConceptSetAdapter(IBaseBackboneElement conceptSet) {
+    public ValueSetConceptSetAdapter(IBase conceptSet) {
+        super(FhirVersionEnum.R4, conceptSet);
         if (!(conceptSet instanceof ConceptSetComponent)) {
             throw new IllegalArgumentException(
                     "element passed as conceptSet argument is not a ConceptSetComponent element");
         }
         this.conceptSet = (ConceptSetComponent) conceptSet;
-        fhirContext = FhirContext.forR4Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R4);
     }
 
     @Override
     public ConceptSetComponent get() {
         return conceptSet;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/ValueSetExpansionContainsAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r4/ValueSetExpansionContainsAdapter.java
@@ -1,42 +1,27 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r4.model.ValueSet.ValueSetExpansionContainsComponent;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetExpansionContainsAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class ValueSetExpansionContainsAdapter implements IValueSetExpansionContainsAdapter {
+public class ValueSetExpansionContainsAdapter extends BaseAdapter implements IValueSetExpansionContainsAdapter {
 
     private final ValueSetExpansionContainsComponent contains;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public ValueSetExpansionContainsAdapter(IBaseBackboneElement contains) {
+    public ValueSetExpansionContainsAdapter(IBase contains) {
+        super(FhirVersionEnum.R4, contains);
         if (!(contains instanceof ValueSetExpansionContainsComponent)) {
             throw new IllegalArgumentException(
                     "element passed as contains argument is not a ValueSetExpansionContainsComponent element");
         }
         this.contains = (ValueSetExpansionContainsComponent) contains;
-        fhirContext = FhirContext.forR4Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R4);
     }
 
     @Override
     public ValueSetExpansionContainsComponent get() {
         return contains;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/AdapterFactory.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/AdapterFactory.java
@@ -59,7 +59,7 @@ public class AdapterFactory implements IAdapterFactory {
     }
 
     @Override
-    public IAdapter<? extends IBase> createBase(IBase element) {
+    public IAdapter<IBase> createBase(IBase element) {
         if (element instanceof QuestionnaireItemComponent) {
             return createQuestionnaireItem(element);
         } else if (element instanceof QuestionnaireResponseItemComponent) {

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/AdapterFactory.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/AdapterFactory.java
@@ -41,6 +41,7 @@ import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemAnswerComp
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IRequestActionAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IResourceAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IStructureDefinitionAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetAdapter;
 
 public class AdapterFactory implements IAdapterFactory {
@@ -168,6 +169,11 @@ public class AdapterFactory implements IAdapterFactory {
     }
 
     @Override
+    public IQuestionnaireItemComponentAdapter createQuestionnaireItem() {
+        return new QuestionnaireItemComponentAdapter(new QuestionnaireItemComponent());
+    }
+
+    @Override
     public IQuestionnaireItemComponentAdapter createQuestionnaireItem(IBase item) {
         return new QuestionnaireItemComponentAdapter(item);
     }
@@ -195,5 +201,10 @@ public class AdapterFactory implements IAdapterFactory {
     @Override
     public IGraphDefinitionAdapter createGraphDefinition(IBaseResource graphDefinition) {
         return new GraphDefinitionAdapter((IDomainResource) graphDefinition);
+    }
+
+    @Override
+    public IStructureDefinitionAdapter createStructureDefinition(IBaseResource structureDefinition) {
+        return new StructureDefinitionAdapter((IDomainResource) structureDefinition);
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/AdapterFactory.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/AdapterFactory.java
@@ -1,10 +1,9 @@
 package org.opencds.cqf.fhir.utility.adapter.r5;
 
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.instance.model.api.IDomainResource;
 import org.hl7.fhir.r5.model.ActivityDefinition;
 import org.hl7.fhir.r5.model.Endpoint;
@@ -15,9 +14,13 @@ import org.hl7.fhir.r5.model.MetadataResource;
 import org.hl7.fhir.r5.model.Parameters;
 import org.hl7.fhir.r5.model.PlanDefinition;
 import org.hl7.fhir.r5.model.Questionnaire;
+import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.r5.model.RequestOrchestration.RequestOrchestrationActionComponent;
 import org.hl7.fhir.r5.model.StructureDefinition;
 import org.hl7.fhir.r5.model.ValueSet;
 import org.opencds.cqf.fhir.utility.adapter.IActivityDefinitionAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
 import org.opencds.cqf.fhir.utility.adapter.IAttachmentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodeableConceptAdapter;
@@ -32,6 +35,10 @@ import org.opencds.cqf.fhir.utility.adapter.IParametersAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IParametersParameterComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IPlanDefinitionAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemAnswerComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IRequestActionAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IResourceAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetAdapter;
@@ -48,6 +55,20 @@ public class AdapterFactory implements IAdapterFactory {
             return createParameters(parameters);
         } else {
             return new ResourceAdapter(resource);
+        }
+    }
+
+    @Override
+    public IAdapter<? extends IBase> createBase(IBase element) {
+        if (element instanceof QuestionnaireItemComponent) {
+            return createQuestionnaireItem(element);
+        } else if (element instanceof QuestionnaireResponseItemComponent) {
+            return createQuestionnaireResponseItem(element);
+        } else if (element instanceof RequestOrchestrationActionComponent) {
+            return createRequestAction(element);
+        } else {
+            throw new UnprocessableEntityException(
+                    String.format("Unable to create an adapter for type: %s", element.fhirType()));
         }
     }
 
@@ -87,7 +108,7 @@ public class AdapterFactory implements IAdapterFactory {
     }
 
     @Override
-    public IAttachmentAdapter createAttachment(ICompositeType attachment) {
+    public IAttachmentAdapter createAttachment(IBase attachment) {
         return new AttachmentAdapter(attachment);
     }
 
@@ -97,8 +118,7 @@ public class AdapterFactory implements IAdapterFactory {
     }
 
     @Override
-    public IParametersParameterComponentAdapter createParametersParameter(
-            IBaseBackboneElement parametersParametersComponent) {
+    public IParametersParameterComponentAdapter createParametersParameter(IBase parametersParametersComponent) {
         return new ParametersParameterComponentAdapter(parametersParametersComponent);
     }
 
@@ -108,17 +128,17 @@ public class AdapterFactory implements IAdapterFactory {
     }
 
     @Override
-    public ICodeableConceptAdapter createCodeableConcept(ICompositeType codeableConcept) {
+    public ICodeableConceptAdapter createCodeableConcept(IBase codeableConcept) {
         return new CodeableConceptAdapter(codeableConcept);
     }
 
     @Override
-    public ICodingAdapter createCoding(ICompositeType coding) {
+    public ICodingAdapter createCoding(IBase coding) {
         return new CodingAdapter(coding);
     }
 
     @Override
-    public IElementDefinitionAdapter createElementDefinition(ICompositeType element) {
+    public IElementDefinitionAdapter createElementDefinition(IBase element) {
         return new ElementDefinitionAdapter(element);
     }
 
@@ -133,18 +153,38 @@ public class AdapterFactory implements IAdapterFactory {
     }
 
     @Override
-    public IRequestActionAdapter createRequestAction(IBaseBackboneElement action) {
+    public IRequestActionAdapter createRequestAction(IBase action) {
         return new RequestActionAdapter(action);
     }
 
     @Override
-    public IDataRequirementAdapter createDataRequirement(ICompositeType dataRequirement) {
+    public IDataRequirementAdapter createDataRequirement(IBase dataRequirement) {
         return new DataRequirementAdapter(dataRequirement);
     }
 
     @Override
     public IQuestionnaireAdapter createQuestionnaire(IBaseResource questionnaire) {
         return new QuestionnaireAdapter((IDomainResource) questionnaire);
+    }
+
+    @Override
+    public IQuestionnaireItemComponentAdapter createQuestionnaireItem(IBase item) {
+        return new QuestionnaireItemComponentAdapter(item);
+    }
+
+    @Override
+    public IQuestionnaireResponseAdapter createQuestionnaireResponse(IBaseResource questionnaireResponse) {
+        return new QuestionnaireResponseAdapter((IDomainResource) questionnaireResponse);
+    }
+
+    @Override
+    public IQuestionnaireResponseItemComponentAdapter createQuestionnaireResponseItem(IBase item) {
+        return new QuestionnaireResponseItemComponentAdapter(item);
+    }
+
+    @Override
+    public IQuestionnaireResponseItemAnswerComponentAdapter createQuestionnaireResponseItemAnswer(IBase answer) {
+        return new QuestionnaireResponseItemAnswerComponentAdapter(answer);
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/AdapterFactory.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/AdapterFactory.java
@@ -15,6 +15,7 @@ import org.hl7.fhir.r5.model.Parameters;
 import org.hl7.fhir.r5.model.PlanDefinition;
 import org.hl7.fhir.r5.model.Questionnaire;
 import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent;
 import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
 import org.hl7.fhir.r5.model.RequestOrchestration.RequestOrchestrationActionComponent;
 import org.hl7.fhir.r5.model.StructureDefinition;
@@ -61,12 +62,14 @@ public class AdapterFactory implements IAdapterFactory {
 
     @Override
     public IAdapter<IBase> createBase(IBase element) {
-        if (element instanceof QuestionnaireItemComponent) {
-            return createQuestionnaireItem(element);
-        } else if (element instanceof QuestionnaireResponseItemComponent) {
-            return createQuestionnaireResponseItem(element);
-        } else if (element instanceof RequestOrchestrationActionComponent) {
-            return createRequestAction(element);
+        if (element instanceof QuestionnaireItemComponent item) {
+            return createQuestionnaireItem(item);
+        } else if (element instanceof QuestionnaireResponseItemComponent responseItem) {
+            return createQuestionnaireResponseItem(responseItem);
+        } else if (element instanceof QuestionnaireResponseItemAnswerComponent answer) {
+            return createQuestionnaireResponseItemAnswer(answer);
+        } else if (element instanceof RequestOrchestrationActionComponent requestAction) {
+            return createRequestAction(requestAction);
         } else {
             throw new UnprocessableEntityException(
                     String.format("Unable to create an adapter for type: %s", element.fhirType()));

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/AttachmentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/AttachmentAdapter.java
@@ -1,23 +1,18 @@
 package org.opencds.cqf.fhir.utility.adapter.r5;
 
-import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.r5.model.Attachment;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IAttachmentAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-class AttachmentAdapter implements IAttachmentAdapter {
+class AttachmentAdapter extends BaseAdapter implements IAttachmentAdapter {
 
     private final Attachment attachment;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public AttachmentAdapter(ICompositeType attachment) {
-        if (attachment == null) {
-            throw new IllegalArgumentException("attachment can not be null");
-        }
-
+    public AttachmentAdapter(IBase attachment) {
+        super(FhirVersionEnum.R5, attachment);
         if (!attachment.fhirType().equals("Attachment")) {
             throw new IllegalArgumentException("resource passed as attachment argument is not an Attachment resource");
         }
@@ -27,9 +22,6 @@ class AttachmentAdapter implements IAttachmentAdapter {
         }
 
         this.attachment = (Attachment) attachment;
-        fhirContext = FhirContext.forR5Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(
-                fhirContext.getVersion().getVersion());
     }
 
     protected Attachment getAttachment() {
@@ -59,15 +51,5 @@ class AttachmentAdapter implements IAttachmentAdapter {
     @Override
     public void setData(byte[] data) {
         this.getAttachment().setData(data);
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/CodeableConceptAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/CodeableConceptAdapter.java
@@ -3,29 +3,24 @@ package org.opencds.cqf.fhir.utility.adapter.r5;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
-import org.hl7.fhir.instance.model.api.ICompositeType;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r5.model.CodeableConcept;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodeableConceptAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodingAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class CodeableConceptAdapter implements ICodeableConceptAdapter {
+public class CodeableConceptAdapter extends BaseAdapter implements ICodeableConceptAdapter {
 
     private final CodeableConcept codeableConcept;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
-    private final AdapterFactory adapterFactory;
 
-    public CodeableConceptAdapter(ICompositeType codeableConcept) {
+    public CodeableConceptAdapter(IBase codeableConcept) {
+        super(FhirVersionEnum.R5, codeableConcept);
         if (!(codeableConcept instanceof CodeableConcept)) {
             throw new IllegalArgumentException(
                     "object passed as codeableConcept argument is not a CodeableConcept data type");
         }
         this.codeableConcept = (CodeableConcept) codeableConcept;
-        fhirContext = FhirContext.forR5Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R5);
-        adapterFactory = new AdapterFactory();
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/CodingAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/CodingAdapter.java
@@ -1,41 +1,26 @@
 package org.opencds.cqf.fhir.utility.adapter.r5;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
-import org.hl7.fhir.instance.model.api.ICompositeType;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r5.model.Coding;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodingAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class CodingAdapter implements ICodingAdapter {
+public class CodingAdapter extends BaseAdapter implements ICodingAdapter {
 
     private final Coding coding;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public CodingAdapter(ICompositeType coding) {
+    public CodingAdapter(IBase coding) {
+        super(FhirVersionEnum.R5, coding);
         if (!(coding instanceof Coding)) {
             throw new IllegalArgumentException("object passed as coding argument is not a Coding data type");
         }
         this.coding = (Coding) coding;
-        fhirContext = FhirContext.forR5Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R5);
     }
 
     @Override
     public Coding get() {
         return coding;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/DataRequirementAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/DataRequirementAdapter.java
@@ -1,45 +1,30 @@
 package org.opencds.cqf.fhir.utility.adapter.r5;
 
-import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.hl7.fhir.instance.model.api.ICompositeType;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r5.model.DataRequirement;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IDataRequirementAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IDataRequirementCodeFilterAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class DataRequirementAdapter implements IDataRequirementAdapter {
+public class DataRequirementAdapter extends BaseAdapter implements IDataRequirementAdapter {
 
     private final DataRequirement dataRequirement;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public DataRequirementAdapter(ICompositeType compositeType) {
+    public DataRequirementAdapter(IBase compositeType) {
+        super(FhirVersionEnum.R5, compositeType);
         if (!(compositeType instanceof DataRequirement dataRequirementInner)) {
             throw new IllegalArgumentException(
                     "object passed as dataRequirement argument is not a DataRequirement data type");
         }
         this.dataRequirement = dataRequirementInner;
-        fhirContext = FhirContext.forR5Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(
-                fhirContext.getVersion().getVersion());
     }
 
     @Override
     public DataRequirement get() {
         return dataRequirement;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/DataRequirementCodeFilterAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/DataRequirementCodeFilterAdapter.java
@@ -1,46 +1,31 @@
 package org.opencds.cqf.fhir.utility.adapter.r5;
 
-import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.hl7.fhir.instance.model.api.IBaseDatatypeElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodingAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IDataRequirementCodeFilterAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class DataRequirementCodeFilterAdapter implements IDataRequirementCodeFilterAdapter {
+public class DataRequirementCodeFilterAdapter extends BaseAdapter implements IDataRequirementCodeFilterAdapter {
 
     private final DataRequirementCodeFilterComponent codeFilter;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public DataRequirementCodeFilterAdapter(IBaseDatatypeElement codeFilter) {
+    public DataRequirementCodeFilterAdapter(IBase codeFilter) {
+        super(FhirVersionEnum.R5, codeFilter);
         if (!(codeFilter instanceof DataRequirementCodeFilterComponent)) {
             throw new IllegalArgumentException(
                     "object passed as codeFilter argument is not a DataRequirementCodeFilterComponent data type");
         }
         this.codeFilter = (DataRequirementCodeFilterComponent) codeFilter;
-        fhirContext = FhirContext.forR5Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(
-                fhirContext.getVersion().getVersion());
     }
 
     @Override
     public DataRequirementCodeFilterComponent get() {
         return codeFilter;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/ElementDefinitionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/ElementDefinitionAdapter.java
@@ -1,51 +1,33 @@
 package org.opencds.cqf.fhir.utility.adapter.r5;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseDatatype;
 import org.hl7.fhir.instance.model.api.IBaseDatatypeElement;
-import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.r5.model.CanonicalType;
 import org.hl7.fhir.r5.model.ElementDefinition;
 import org.hl7.fhir.r5.model.PrimitiveType;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodingAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IElementDefinitionAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class ElementDefinitionAdapter implements IElementDefinitionAdapter {
+public class ElementDefinitionAdapter extends BaseAdapter implements IElementDefinitionAdapter {
 
     private final ElementDefinition elementDefinition;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
-    private final AdapterFactory adapterFactory;
 
-    public ElementDefinitionAdapter(ICompositeType elementDefinition) {
+    public ElementDefinitionAdapter(IBase elementDefinition) {
+        super(FhirVersionEnum.R5, elementDefinition);
         if (!(elementDefinition instanceof ElementDefinition)) {
             throw new IllegalArgumentException(
                     "object passed as elementDefinition argument is not a ElementDefinition data type");
         }
         this.elementDefinition = (ElementDefinition) elementDefinition;
-        fhirContext = FhirContext.forR5Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R5);
-        adapterFactory = new AdapterFactory();
     }
 
     @Override
     public ElementDefinition get() {
         return elementDefinition;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/ParametersParameterComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/ParametersParameterComponentAdapter.java
@@ -1,8 +1,9 @@
 package org.opencds.cqf.fhir.utility.adapter.r5;
 
-import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IBaseDatatype;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -11,36 +12,25 @@ import org.hl7.fhir.r5.model.DataType;
 import org.hl7.fhir.r5.model.Parameters;
 import org.hl7.fhir.r5.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.r5.model.Resource;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
-import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IParametersParameterComponentAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-class ParametersParameterComponentAdapter implements IParametersParameterComponentAdapter {
+class ParametersParameterComponentAdapter extends BaseAdapter implements IParametersParameterComponentAdapter {
 
-    private final FhirContext fhirContext = FhirContext.forR5Cached();
     private final Parameters.ParametersParameterComponent parametersParameterComponent;
-    private final ModelResolver modelResolver;
-    private final IAdapterFactory adapterFactory;
 
     protected Parameters.ParametersParameterComponent getParametersParameterComponent() {
         return this.parametersParameterComponent;
     }
 
-    public ParametersParameterComponentAdapter(IBaseBackboneElement parametersParameterComponent) {
-        if (parametersParameterComponent == null) {
-            throw new IllegalArgumentException("parametersParameterComponent can not be null");
-        }
-
+    public ParametersParameterComponentAdapter(IBase parametersParameterComponent) {
+        super(FhirVersionEnum.R5, parametersParameterComponent);
         if (!parametersParameterComponent.fhirType().equals("Parameters.parameter")) {
             throw new IllegalArgumentException(
                     "element passed as parametersParameterComponent argument is not a ParametersParameterComponent Element");
         }
 
         this.parametersParameterComponent = (ParametersParameterComponent) parametersParameterComponent;
-        modelResolver = FhirModelResolverCache.resolverForVersion(
-                fhirContext.getVersion().getVersion());
-        adapterFactory = IAdapterFactory.forFhirContext(fhirContext);
     }
 
     @Override
@@ -134,15 +124,5 @@ class ParametersParameterComponentAdapter implements IParametersParameterCompone
         return hasPrimitiveValue()
                 ? this.getParametersParameterComponent().getValue().primitiveValue()
                 : null;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/PlanDefinitionActionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/PlanDefinitionActionAdapter.java
@@ -1,45 +1,30 @@
 package org.opencds.cqf.fhir.utility.adapter.r5;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r5.model.PlanDefinition.PlanDefinitionActionComponent;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IPlanDefinitionActionAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ITriggerDefinitionAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class PlanDefinitionActionAdapter implements IPlanDefinitionActionAdapter {
+public class PlanDefinitionActionAdapter extends BaseAdapter implements IPlanDefinitionActionAdapter {
 
     private final PlanDefinitionActionComponent action;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public PlanDefinitionActionAdapter(IBaseBackboneElement action) {
+    public PlanDefinitionActionAdapter(IBase action) {
+        super(FhirVersionEnum.R5, action);
         if (!(action instanceof PlanDefinitionActionComponent)) {
             throw new IllegalArgumentException(
                     "object passed as action argument is not a PlanDefinitionActionComponent data type");
         }
         this.action = (PlanDefinitionActionComponent) action;
-        fhirContext = FhirContext.forR5Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R5);
     }
 
     @Override
     public PlanDefinitionActionComponent get() {
         return action;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override
@@ -54,6 +39,6 @@ public class PlanDefinitionActionAdapter implements IPlanDefinitionActionAdapter
 
     @Override
     public List<String> getTriggerType() {
-        return get().getTrigger().stream().map(t -> t.getType().toCode()).collect(Collectors.toUnmodifiableList());
+        return get().getTrigger().stream().map(t -> t.getType().toCode()).toList();
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireAdapter.java
@@ -9,8 +9,10 @@ import org.hl7.fhir.r5.model.Questionnaire;
 import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemComponent;
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.adapter.DependencyInfo;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IDependencyInfo;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
 
 public class QuestionnaireAdapter extends KnowledgeArtifactAdapter implements IQuestionnaireAdapter {
 
@@ -125,5 +127,39 @@ public class QuestionnaireAdapter extends KnowledgeArtifactAdapter implements IQ
                         expression.getExtension(),
                         expression::setReference)));
         item.getItem().forEach(childItem -> getDependenciesOfItem(childItem, references, referenceSource));
+    }
+
+    @Override
+    public boolean hasItem() {
+        return getQuestionnaire().hasItem();
+    }
+
+    @Override
+    public List<IQuestionnaireItemComponentAdapter> getItem() {
+        return getQuestionnaire().getItem().stream()
+                .map(adapterFactory::createQuestionnaireItem)
+                .toList();
+    }
+
+    @Override
+    public void setItem(List<IQuestionnaireItemComponentAdapter> items) {
+        getQuestionnaire()
+                .setItem(items.stream()
+                        .map(IAdapter::get)
+                        .map(QuestionnaireItemComponent.class::cast)
+                        .toList());
+    }
+
+    @Override
+    public void addItem(IQuestionnaireItemComponentAdapter item) {
+        getQuestionnaire().addItem((QuestionnaireItemComponent) item.get());
+    }
+
+    @Override
+    public void addItems(List<IQuestionnaireItemComponentAdapter> items) {
+        items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireItemComponent.class::cast)
+                .forEach(item -> getQuestionnaire().addItem(item));
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireAdapter.java
@@ -2,6 +2,8 @@ package org.opencds.cqf.fhir.utility.adapter.r5;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IDomainResource;
 import org.hl7.fhir.r5.model.CanonicalType;
 import org.hl7.fhir.r5.model.Expression;
@@ -147,7 +149,14 @@ public class QuestionnaireAdapter extends KnowledgeArtifactAdapter implements IQ
                 .setItem(items.stream()
                         .map(IAdapter::get)
                         .map(QuestionnaireItemComponent.class::cast)
-                        .toList());
+                        .collect(Collectors.toList()));
+    }
+
+    @Override
+    public void addItem(IBaseBackboneElement item) {
+        if (item instanceof QuestionnaireItemComponent itemComponent) {
+            getQuestionnaire().addItem(itemComponent);
+        }
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireItemComponentAdapter.java
@@ -3,8 +3,10 @@ package org.opencds.cqf.fhir.utility.adapter.r5;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
+import org.hl7.fhir.r5.model.Coding;
 import org.hl7.fhir.r5.model.DataType;
 import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemComponent;
 import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemInitialComponent;
@@ -13,6 +15,7 @@ import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemComp
 import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IAdapter;
+import org.opencds.cqf.fhir.utility.adapter.ICodingAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IItemComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
@@ -51,28 +54,20 @@ public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQ
     }
 
     @Override
-    public List<IBaseCoding> getCode() {
-        return item.getCode().stream().map(IBaseCoding.class::cast).toList();
-    }
-
-    @Override
-    public String getType() {
-        return item.getType().toCode();
-    }
-
-    @Override
-    public boolean isGroupItem() {
-        return item.getType().equals(QuestionnaireItemType.GROUP);
-    }
-
-    @Override
-    public boolean getRepeats() {
-        return item.getRepeats();
+    public IQuestionnaireItemComponentAdapter setLinkId(String linkId) {
+        get().setLinkId(linkId);
+        return this;
     }
 
     @Override
     public boolean hasDefinition() {
         return item.hasDefinition();
+    }
+
+    @Override
+    public IQuestionnaireItemComponentAdapter setDefinition(String definition) {
+        item.setDefinition(definition);
+        return this;
     }
 
     @Override
@@ -97,7 +92,7 @@ public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQ
         item.setItem(items.stream()
                 .map(IAdapter::get)
                 .map(QuestionnaireItemComponent.class::cast)
-                .toList());
+                .collect(Collectors.toList()));
     }
 
     @Override
@@ -106,11 +101,75 @@ public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQ
     }
 
     @Override
-    public void addItems(List<IItemComponentAdapter> items) {
+    public void addItems(List<IQuestionnaireItemComponentAdapter> items) {
         items.stream()
                 .map(IAdapter::get)
                 .map(QuestionnaireItemComponent.class::cast)
                 .forEach(this.item::addItem);
+    }
+
+    @Override
+    public List<IBaseCoding> getCode() {
+        return item.getCode().stream().map(IBaseCoding.class::cast).toList();
+    }
+
+    @Override
+    public String getText() {
+        return item.getText();
+    }
+
+    @Override
+    public IQuestionnaireItemComponentAdapter setText(String text) {
+        item.setText(text);
+        return this;
+    }
+
+    @Override
+    public String getType() {
+        return item.getType().toCode();
+    }
+
+    @Override
+    public IQuestionnaireItemComponentAdapter setType(String type) {
+        item.setType(QuestionnaireItemType.fromCode(type));
+        return this;
+    }
+
+    @Override
+    public boolean isGroupItem() {
+        return item.getType().equals(QuestionnaireItemType.GROUP);
+    }
+
+    @Override
+    public boolean isChoiceItem() {
+        return item.getType().equals(QuestionnaireItemType.QUESTION);
+    }
+
+    @Override
+    public boolean getRequired() {
+        return item.getRequired();
+    }
+
+    @Override
+    public IQuestionnaireItemComponentAdapter setRequired(boolean required) {
+        get().setRequired(required);
+        return this;
+    }
+
+    @Override
+    public boolean getRepeats() {
+        return item.getRepeats();
+    }
+
+    @Override
+    public IQuestionnaireItemComponentAdapter setRepeats(boolean repeats) {
+        get().setRepeats(repeats);
+        return this;
+    }
+
+    @Override
+    public void addAnswerOption(ICodingAdapter option) {
+        get().addAnswerOption().setValue((Coding) option.get());
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireItemComponentAdapter.java
@@ -6,8 +6,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
+import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.r5.model.Coding;
 import org.hl7.fhir.r5.model.DataType;
+import org.hl7.fhir.r5.model.Expression;
 import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemComponent;
 import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemInitialComponent;
 import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType;
@@ -189,5 +191,10 @@ public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQ
         return adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent(item.getLinkId())
                 .setDefinitionElement(item.getDefinitionElement())
                 .setTextElement(item.getTextElement()));
+    }
+
+    @Override
+    public ICompositeType newExpression(String language, String expression) {
+        return new Expression().setLanguage(language).setExpression(expression);
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireItemComponentAdapter.java
@@ -1,0 +1,134 @@
+package org.opencds.cqf.fhir.utility.adapter.r5;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.List;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseCoding;
+import org.hl7.fhir.r5.model.DataType;
+import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemInitialComponent;
+import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType;
+import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
+
+public class QuestionnaireItemComponentAdapter extends BaseAdapter implements IQuestionnaireItemComponentAdapter {
+
+    private final QuestionnaireItemComponent item;
+
+    public QuestionnaireItemComponentAdapter(IBase item) {
+        super(FhirVersionEnum.R5, item);
+        if (!(item instanceof QuestionnaireItemComponent)) {
+            throw new IllegalArgumentException(
+                    "object passed as item argument is not a QuestionnaireItemComponent data type");
+        }
+        this.item = (QuestionnaireItemComponent) item;
+    }
+
+    @Override
+    public QuestionnaireItemComponent get() {
+        return item;
+    }
+
+    @Override
+    public FhirContext fhirContext() {
+        return fhirContext;
+    }
+
+    @Override
+    public ModelResolver getModelResolver() {
+        return modelResolver;
+    }
+
+    @Override
+    public String getLinkId() {
+        return item.getLinkId();
+    }
+
+    @Override
+    public List<IBaseCoding> getCode() {
+        return item.getCode().stream().map(IBaseCoding.class::cast).toList();
+    }
+
+    @Override
+    public String getType() {
+        return item.getType().toCode();
+    }
+
+    @Override
+    public boolean isGroupItem() {
+        return item.getType().equals(QuestionnaireItemType.GROUP);
+    }
+
+    @Override
+    public boolean getRepeats() {
+        return item.getRepeats();
+    }
+
+    @Override
+    public boolean hasDefinition() {
+        return item.hasDefinition();
+    }
+
+    @Override
+    public String getDefinition() {
+        return item.getDefinition();
+    }
+
+    @Override
+    public boolean hasItem() {
+        return item.hasItem();
+    }
+
+    @Override
+    public List<IQuestionnaireItemComponentAdapter> getItem() {
+        return item.getItem().stream()
+                .map(adapterFactory::createQuestionnaireItem)
+                .toList();
+    }
+
+    @Override
+    public void setItem(List<? extends IItemComponentAdapter> items) {
+        item.setItem(items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireItemComponent.class::cast)
+                .toList());
+    }
+
+    @Override
+    public void addItem(IItemComponentAdapter item) {
+        this.item.addItem((QuestionnaireItemComponent) item.get());
+    }
+
+    @Override
+    public void addItems(List<IItemComponentAdapter> items) {
+        items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireItemComponent.class::cast)
+                .forEach(this.item::addItem);
+    }
+
+    @Override
+    public boolean hasInitial() {
+        return item.hasInitial();
+    }
+
+    @Override
+    public List<DataType> getInitial() {
+        return item.getInitial().stream()
+                .map(QuestionnaireItemInitialComponent::getValue)
+                .toList();
+    }
+
+    @Override
+    public IQuestionnaireResponseItemComponentAdapter newResponseItem() {
+        return adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent(item.getLinkId())
+                .setDefinitionElement(item.getDefinitionElement())
+                .setTextElement(item.getTextElement()));
+    }
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseAdapter.java
@@ -1,0 +1,72 @@
+package org.opencds.cqf.fhir.utility.adapter.r5;
+
+import java.util.List;
+import org.hl7.fhir.instance.model.api.IDomainResource;
+import org.hl7.fhir.r5.model.QuestionnaireResponse;
+import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
+
+public class QuestionnaireResponseAdapter extends ResourceAdapter implements IQuestionnaireResponseAdapter {
+
+    public QuestionnaireResponseAdapter(IDomainResource questionnaireResponse) {
+        super(questionnaireResponse);
+        if (!(questionnaireResponse instanceof QuestionnaireResponse)) {
+            throw new IllegalArgumentException(
+                    "resource passed as questionnaire argument is not a QuestionnaireResponse resource");
+        }
+    }
+
+    public QuestionnaireResponseAdapter(QuestionnaireResponse questionnaireResponse) {
+        super(questionnaireResponse);
+    }
+
+    protected QuestionnaireResponse getQuestionnaireResponse() {
+        return (QuestionnaireResponse) resource;
+    }
+
+    @Override
+    public QuestionnaireResponse get() {
+        return getQuestionnaireResponse();
+    }
+
+    @Override
+    public QuestionnaireResponse copy() {
+        return get().copy();
+    }
+
+    @Override
+    public boolean hasItem() {
+        return getQuestionnaireResponse().hasItem();
+    }
+
+    @Override
+    public List<IQuestionnaireResponseItemComponentAdapter> getItem() {
+        return getQuestionnaireResponse().getItem().stream()
+                .map(adapterFactory::createQuestionnaireResponseItem)
+                .toList();
+    }
+
+    @Override
+    public void setItem(List<IQuestionnaireResponseItemComponentAdapter> items) {
+        getQuestionnaireResponse()
+                .setItem(items.stream()
+                        .map(IAdapter::get)
+                        .map(QuestionnaireResponseItemComponent.class::cast)
+                        .toList());
+    }
+
+    @Override
+    public void addItem(IQuestionnaireResponseItemComponentAdapter item) {
+        getQuestionnaireResponse().addItem((QuestionnaireResponseItemComponent) item.get());
+    }
+
+    @Override
+    public void addItems(List<IQuestionnaireResponseItemComponentAdapter> items) {
+        items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireResponseItemComponent.class::cast)
+                .forEach(item -> getQuestionnaireResponse().addItem(item));
+    }
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseAdapter.java
@@ -1,9 +1,14 @@
 package org.opencds.cqf.fhir.utility.adapter.r5;
 
+import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.hl7.fhir.instance.model.api.IDomainResource;
+import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r5.model.QuestionnaireResponse;
 import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseStatus;
+import org.hl7.fhir.r5.model.Reference;
 import org.opencds.cqf.fhir.utility.adapter.IAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
@@ -37,6 +42,36 @@ public class QuestionnaireResponseAdapter extends ResourceAdapter implements IQu
     }
 
     @Override
+    public IQuestionnaireResponseAdapter setId(String id) {
+        get().setId(id);
+        return this;
+    }
+
+    @Override
+    public IQuestionnaireResponseAdapter setQuestionnaire(String canonical) {
+        get().setQuestionnaire(canonical);
+        return this;
+    }
+
+    @Override
+    public IQuestionnaireResponseAdapter setSubject(IIdType subject) {
+        get().setSubject(new Reference(subject));
+        return this;
+    }
+
+    @Override
+    public IQuestionnaireResponseAdapter setAuthored(Date date) {
+        get().setAuthored(date);
+        return this;
+    }
+
+    @Override
+    public IQuestionnaireResponseAdapter setStatus(String status) {
+        get().setStatus(QuestionnaireResponseStatus.fromCode(status));
+        return this;
+    }
+
+    @Override
     public boolean hasItem() {
         return getQuestionnaireResponse().hasItem();
     }
@@ -54,7 +89,7 @@ public class QuestionnaireResponseAdapter extends ResourceAdapter implements IQu
                 .setItem(items.stream()
                         .map(IAdapter::get)
                         .map(QuestionnaireResponseItemComponent.class::cast)
-                        .toList());
+                        .collect(Collectors.toList()));
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseItemAnswerComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseItemAnswerComponentAdapter.java
@@ -1,0 +1,68 @@
+package org.opencds.cqf.fhir.utility.adapter.r5;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.List;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseDatatype;
+import org.hl7.fhir.r5.model.DataType;
+import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent;
+import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemAnswerComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
+
+public class QuestionnaireResponseItemAnswerComponentAdapter extends BaseAdapter
+        implements IQuestionnaireResponseItemAnswerComponentAdapter {
+
+    private final QuestionnaireResponseItemAnswerComponent answer;
+
+    protected QuestionnaireResponseItemAnswerComponentAdapter(IBase answer) {
+        super(FhirVersionEnum.R5, answer);
+        if (!(answer instanceof QuestionnaireResponseItemAnswerComponent)) {
+            throw new IllegalArgumentException(
+                    "object passed as answer argument is not a QuestionnaireResponseItemAnswerComponent data type");
+        }
+        this.answer = (QuestionnaireResponseItemAnswerComponent) answer;
+    }
+
+    @Override
+    public QuestionnaireResponseItemAnswerComponent get() {
+        return answer;
+    }
+
+    @Override
+    public boolean hasValue() {
+        return answer.hasValue();
+    }
+
+    @Override
+    public IBase getValue() {
+        return answer.getValue();
+    }
+
+    @Override
+    public void setValue(IBaseDatatype value) {
+        answer.setValue((DataType) value);
+    }
+
+    @Override
+    public boolean hasItem() {
+        return answer.hasItem();
+    }
+
+    @Override
+    public List<IQuestionnaireResponseItemComponentAdapter> getItem() {
+        return answer.getItem().stream()
+                .map(adapterFactory::createQuestionnaireResponseItem)
+                .toList();
+    }
+
+    @Override
+    public void setItem(List<IQuestionnaireResponseItemComponentAdapter> items) {
+        answer.setItem(items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireResponseItemComponent.class::cast)
+                .toList());
+    }
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseItemAnswerComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseItemAnswerComponentAdapter.java
@@ -2,6 +2,7 @@ package org.opencds.cqf.fhir.utility.adapter.r5;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseDatatype;
 import org.hl7.fhir.r5.model.DataType;
@@ -63,6 +64,6 @@ public class QuestionnaireResponseItemAnswerComponentAdapter extends BaseAdapter
         answer.setItem(items.stream()
                 .map(IAdapter::get)
                 .map(QuestionnaireResponseItemComponent.class::cast)
-                .toList());
+                .collect(Collectors.toList()));
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseItemComponentAdapter.java
@@ -39,6 +39,18 @@ public class QuestionnaireResponseItemComponentAdapter extends BaseAdapter
     }
 
     @Override
+    public IQuestionnaireResponseItemComponentAdapter setLinkId(String linkId) {
+        get().setLinkId(linkId);
+        return this;
+    }
+
+    @Override
+    public IQuestionnaireResponseItemComponentAdapter setDefinition(String definition) {
+        get().setDefinition(definition);
+        return this;
+    }
+
+    @Override
     public boolean hasDefinition() {
         return item.hasDefinition();
     }
@@ -65,7 +77,7 @@ public class QuestionnaireResponseItemComponentAdapter extends BaseAdapter
         item.setItem(items.stream()
                 .map(IAdapter::get)
                 .map(QuestionnaireResponseItemComponent.class::cast)
-                .toList());
+                .collect(Collectors.toList()));
     }
 
     @Override
@@ -74,7 +86,7 @@ public class QuestionnaireResponseItemComponentAdapter extends BaseAdapter
     }
 
     @Override
-    public void addItems(List<IItemComponentAdapter> items) {
+    public void addItems(List<IQuestionnaireResponseItemComponentAdapter> items) {
         items.stream()
                 .map(IAdapter::get)
                 .map(QuestionnaireResponseItemComponent.class::cast)

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseItemComponentAdapter.java
@@ -115,7 +115,7 @@ public class QuestionnaireResponseItemComponentAdapter extends BaseAdapter
     }
 
     @Override
-    public IQuestionnaireResponseItemAnswerComponentAdapter createAnswer(IBaseDatatype value) {
+    public IQuestionnaireResponseItemAnswerComponentAdapter newAnswer(IBaseDatatype value) {
         return adapterFactory.createQuestionnaireResponseItemAnswer(
                 new QuestionnaireResponseItemAnswerComponent().setValue((DataType) value));
     }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseItemComponentAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseItemComponentAdapter.java
@@ -1,0 +1,110 @@
+package org.opencds.cqf.fhir.utility.adapter.r5;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseDatatype;
+import org.hl7.fhir.r5.model.DataType;
+import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent;
+import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IItemComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemAnswerComponentAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IQuestionnaireResponseItemComponentAdapter;
+
+public class QuestionnaireResponseItemComponentAdapter extends BaseAdapter
+        implements IQuestionnaireResponseItemComponentAdapter {
+
+    private final QuestionnaireResponseItemComponent item;
+
+    public QuestionnaireResponseItemComponentAdapter(IBase item) {
+        super(FhirVersionEnum.R5, item);
+        if (!(item instanceof QuestionnaireResponseItemComponent)) {
+            throw new IllegalArgumentException(
+                    "object passed as item argument is not a QuestionnaireResponseItemComponent data type");
+        }
+        this.item = (QuestionnaireResponseItemComponent) item;
+    }
+
+    @Override
+    public QuestionnaireResponseItemComponent get() {
+        return item;
+    }
+
+    @Override
+    public String getLinkId() {
+        return item.getLinkId();
+    }
+
+    @Override
+    public boolean hasDefinition() {
+        return item.hasDefinition();
+    }
+
+    @Override
+    public String getDefinition() {
+        return item.getDefinition();
+    }
+
+    @Override
+    public boolean hasItem() {
+        return item.hasItem();
+    }
+
+    @Override
+    public List<IQuestionnaireResponseItemComponentAdapter> getItem() {
+        return item.getItem().stream()
+                .map(adapterFactory::createQuestionnaireResponseItem)
+                .toList();
+    }
+
+    @Override
+    public void setItem(List<? extends IItemComponentAdapter> items) {
+        item.setItem(items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireResponseItemComponent.class::cast)
+                .toList());
+    }
+
+    @Override
+    public void addItem(IItemComponentAdapter item) {
+        this.item.addItem((QuestionnaireResponseItemComponent) item.get());
+    }
+
+    @Override
+    public void addItems(List<IItemComponentAdapter> items) {
+        items.stream()
+                .map(IAdapter::get)
+                .map(QuestionnaireResponseItemComponent.class::cast)
+                .forEach(this.item::addItem);
+    }
+
+    @Override
+    public boolean hasAnswer() {
+        return item.hasAnswer();
+    }
+
+    @Override
+    public List<IQuestionnaireResponseItemAnswerComponentAdapter> getAnswer() {
+        return item.getAnswer().stream()
+                .map(adapterFactory::createQuestionnaireResponseItemAnswer)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void setAnswer(List<IQuestionnaireResponseItemAnswerComponentAdapter> answers) {
+        item.setAnswer(answers.stream()
+                .map(IAdapter::get)
+                .filter(QuestionnaireResponseItemAnswerComponent.class::isInstance)
+                .map(QuestionnaireResponseItemAnswerComponent.class::cast)
+                .toList());
+    }
+
+    @Override
+    public IQuestionnaireResponseItemAnswerComponentAdapter createAnswer(IBaseDatatype value) {
+        return adapterFactory.createQuestionnaireResponseItemAnswer(
+                new QuestionnaireResponseItemAnswerComponent().setValue((DataType) value));
+    }
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/RequestActionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/RequestActionAdapter.java
@@ -1,46 +1,32 @@
 package org.opencds.cqf.fhir.utility.adapter.r5;
 
-import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r5.model.Reference;
 import org.hl7.fhir.r5.model.RelatedArtifact;
 import org.hl7.fhir.r5.model.RequestOrchestration.RequestOrchestrationActionComponent;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ICodeableConceptAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IRequestActionAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class RequestActionAdapter implements IRequestActionAdapter {
+public class RequestActionAdapter extends BaseAdapter implements IRequestActionAdapter {
 
     private final RequestOrchestrationActionComponent action;
-    private final FhirContext fhirContext = FhirContext.forR5Cached();
-    private final ModelResolver modelResolver;
 
-    public RequestActionAdapter(IBaseBackboneElement action) {
+    public RequestActionAdapter(IBase action) {
+        super(FhirVersionEnum.R5, action);
         if (!(action instanceof RequestOrchestrationActionComponent)) {
             throw new IllegalArgumentException(
                     "element passed as action argument is not a RequestOrchestrationActionComponent Element");
         }
         this.action = (RequestOrchestrationActionComponent) action;
-        modelResolver = FhirModelResolverCache.resolverForVersion(
-                fhirContext.getVersion().getVersion());
     }
 
     @Override
     public RequestOrchestrationActionComponent get() {
         return action;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/StructureDefinitionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/StructureDefinitionAdapter.java
@@ -78,7 +78,7 @@ public class StructureDefinitionAdapter extends ResourceAdapter implements IStru
         get().getExtensionsByUrl(Constants.CPG_ASSERTION_EXPRESSION).stream()
                 .filter(e -> e.getValue() instanceof Expression)
                 .map(e -> (Expression) e.getValue())
-                .filter(e -> e.hasReference())
+                .filter(Expression::hasReference)
                 .forEach(expression -> references.add(new DependencyInfo(
                         referenceSource,
                         expression.getReference(),
@@ -87,7 +87,7 @@ public class StructureDefinitionAdapter extends ResourceAdapter implements IStru
         get().getExtensionsByUrl(Constants.CPG_FEATURE_EXPRESSION).stream()
                 .filter(e -> e.getValue() instanceof Expression)
                 .map(e -> (Expression) e.getValue())
-                .filter(e -> e.hasReference())
+                .filter(Expression::hasReference)
                 .forEach(expression -> references.add(new DependencyInfo(
                         referenceSource,
                         expression.getReference(),
@@ -96,7 +96,7 @@ public class StructureDefinitionAdapter extends ResourceAdapter implements IStru
         get().getExtensionsByUrl(Constants.CPG_INFERENCE_EXPRESSION).stream()
                 .filter(e -> e.getValue() instanceof Expression)
                 .map(e -> (Expression) e.getValue())
-                .filter(e -> e.hasReference())
+                .filter(Expression::hasReference)
                 .forEach(expression -> references.add(new DependencyInfo(
                         referenceSource,
                         expression.getReference(),
@@ -266,8 +266,20 @@ public class StructureDefinitionAdapter extends ResourceAdapter implements IStru
     }
 
     @Override
+    public IPrimitiveType<String> getBaseDefinition() {
+        return get().getBaseDefinitionElement();
+    }
+
+    @Override
+    public boolean hasSnapshot() {
+        return get().hasSnapshot();
+    }
+
+    @Override
     public List<IElementDefinitionAdapter> getSnapshotElements() {
         return get().getSnapshot().getElement().stream()
+                .filter(ElementDefinition::hasPath)
+                .filter(e -> e.getPath().split("\\.").length > 1)
                 .map(adapterFactory::createElementDefinition)
                 .toList();
     }
@@ -275,6 +287,8 @@ public class StructureDefinitionAdapter extends ResourceAdapter implements IStru
     @Override
     public List<IElementDefinitionAdapter> getDifferentialElements() {
         return get().getDifferential().getElement().stream()
+                .filter(ElementDefinition::hasPath)
+                .filter(e -> e.getPath().split("\\.").length > 1)
                 .map(adapterFactory::createElementDefinition)
                 .toList();
     }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/TriggerDefinitionAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/TriggerDefinitionAdapter.java
@@ -1,42 +1,27 @@
 package org.opencds.cqf.fhir.utility.adapter.r5;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
-import org.hl7.fhir.instance.model.api.ICompositeType;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r5.model.TriggerDefinition;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.ITriggerDefinitionAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class TriggerDefinitionAdapter implements ITriggerDefinitionAdapter {
+public class TriggerDefinitionAdapter extends BaseAdapter implements ITriggerDefinitionAdapter {
 
     private final TriggerDefinition triggerDefinition;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public TriggerDefinitionAdapter(ICompositeType triggerDefinition) {
+    public TriggerDefinitionAdapter(IBase triggerDefinition) {
+        super(FhirVersionEnum.R5, triggerDefinition);
         if (!(triggerDefinition instanceof TriggerDefinition)) {
             throw new IllegalArgumentException(
                     "object passed as triggerDefinition argument is not a TriggerDefinition data type");
         }
         this.triggerDefinition = (TriggerDefinition) triggerDefinition;
-        fhirContext = FhirContext.forR5Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R5);
     }
 
     @Override
     public TriggerDefinition get() {
         return triggerDefinition;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/ValueSetConceptReferenceAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/ValueSetConceptReferenceAdapter.java
@@ -1,42 +1,27 @@
 package org.opencds.cqf.fhir.utility.adapter.r5;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r5.model.ValueSet.ConceptReferenceComponent;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetConceptReferenceAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class ValueSetConceptReferenceAdapter implements IValueSetConceptReferenceAdapter {
+public class ValueSetConceptReferenceAdapter extends BaseAdapter implements IValueSetConceptReferenceAdapter {
 
     private final ConceptReferenceComponent conceptReference;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public ValueSetConceptReferenceAdapter(IBaseBackboneElement conceptReference) {
+    public ValueSetConceptReferenceAdapter(IBase conceptReference) {
+        super(FhirVersionEnum.R5, conceptReference);
         if (!(conceptReference instanceof ConceptReferenceComponent)) {
             throw new IllegalArgumentException(
                     "element passed as conceptReference argument is not a ConceptReferenceComponent element");
         }
         this.conceptReference = (ConceptReferenceComponent) conceptReference;
-        fhirContext = FhirContext.forR5Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R5);
     }
 
     @Override
     public ConceptReferenceComponent get() {
         return conceptReference;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/ValueSetConceptReferenceAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/ValueSetConceptReferenceAdapter.java
@@ -33,4 +33,9 @@ public class ValueSetConceptReferenceAdapter extends BaseAdapter implements IVal
     public String getCode() {
         return get().getCode();
     }
+
+    @Override
+    public String getDisplay() {
+        return get().getDisplay();
+    }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/ValueSetConceptSetAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/ValueSetConceptSetAdapter.java
@@ -1,45 +1,30 @@
 package org.opencds.cqf.fhir.utility.adapter.r5;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r5.model.ValueSet.ConceptSetComponent;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetConceptReferenceAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetConceptSetAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class ValueSetConceptSetAdapter implements IValueSetConceptSetAdapter {
+public class ValueSetConceptSetAdapter extends BaseAdapter implements IValueSetConceptSetAdapter {
 
     private final ConceptSetComponent conceptSet;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public ValueSetConceptSetAdapter(IBaseBackboneElement conceptSet) {
+    public ValueSetConceptSetAdapter(IBase conceptSet) {
+        super(FhirVersionEnum.R5, conceptSet);
         if (!(conceptSet instanceof ConceptSetComponent)) {
             throw new IllegalArgumentException(
                     "element passed as conceptSet argument is not a ConceptSetComponent element");
         }
         this.conceptSet = (ConceptSetComponent) conceptSet;
-        fhirContext = FhirContext.forR5Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R5);
     }
 
     @Override
     public ConceptSetComponent get() {
         return conceptSet;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/ValueSetExpansionContainsAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/r5/ValueSetExpansionContainsAdapter.java
@@ -1,42 +1,27 @@
 package org.opencds.cqf.fhir.utility.adapter.r5;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
-import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r5.model.ValueSet.ValueSetExpansionContainsComponent;
-import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.utility.adapter.BaseAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetExpansionContainsAdapter;
-import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
-public class ValueSetExpansionContainsAdapter implements IValueSetExpansionContainsAdapter {
+public class ValueSetExpansionContainsAdapter extends BaseAdapter implements IValueSetExpansionContainsAdapter {
 
     private final ValueSetExpansionContainsComponent contains;
-    private final FhirContext fhirContext;
-    private final ModelResolver modelResolver;
 
-    public ValueSetExpansionContainsAdapter(IBaseBackboneElement contains) {
+    public ValueSetExpansionContainsAdapter(IBase contains) {
+        super(FhirVersionEnum.R5, contains);
         if (!(contains instanceof ValueSetExpansionContainsComponent)) {
             throw new IllegalArgumentException(
                     "element passed as contains argument is not a ValueSetExpansionContainsComponent element");
         }
         this.contains = (ValueSetExpansionContainsComponent) contains;
-        fhirContext = FhirContext.forR5Cached();
-        modelResolver = FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R5);
     }
 
     @Override
     public ValueSetExpansionContainsComponent get() {
         return contains;
-    }
-
-    @Override
-    public FhirContext fhirContext() {
-        return fhirContext;
-    }
-
-    @Override
-    public ModelResolver getModelResolver() {
-        return modelResolver;
     }
 
     @Override

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/BundleHelperTests.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/BundleHelperTests.java
@@ -2,6 +2,7 @@ package org.opencds.cqf.fhir.utility;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opencds.cqf.fhir.utility.BundleHelper.addEntry;
@@ -10,9 +11,21 @@ import static org.opencds.cqf.fhir.utility.BundleHelper.getEntryFirstRep;
 import static org.opencds.cqf.fhir.utility.BundleHelper.getEntryResource;
 import static org.opencds.cqf.fhir.utility.BundleHelper.getEntryResourceFirstRep;
 import static org.opencds.cqf.fhir.utility.BundleHelper.getEntryResources;
+import static org.opencds.cqf.fhir.utility.BundleHelper.isEntryRequestPost;
+import static org.opencds.cqf.fhir.utility.BundleHelper.isEntryRequestPut;
 import static org.opencds.cqf.fhir.utility.BundleHelper.newBundle;
 import static org.opencds.cqf.fhir.utility.BundleHelper.newEntry;
 import static org.opencds.cqf.fhir.utility.BundleHelper.newEntryWithResource;
+import static org.opencds.cqf.fhir.utility.BundleHelper.newEntryWithResponse;
+import static org.opencds.cqf.fhir.utility.BundleHelper.newRequest;
+import static org.opencds.cqf.fhir.utility.BundleHelper.newResponseWithLocation;
+import static org.opencds.cqf.fhir.utility.BundleHelper.resourceToRuntimeSearchParam;
+import static org.opencds.cqf.fhir.utility.BundleHelper.setBundleTotal;
+import static org.opencds.cqf.fhir.utility.BundleHelper.setBundleType;
+import static org.opencds.cqf.fhir.utility.BundleHelper.setEntryFullUrl;
+import static org.opencds.cqf.fhir.utility.BundleHelper.setEntryRequest;
+import static org.opencds.cqf.fhir.utility.BundleHelper.setRequestIfNoneExist;
+import static org.opencds.cqf.fhir.utility.BundleHelper.setRequestUrl;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.Collections;
@@ -29,6 +42,7 @@ class BundleHelperTests {
         var fhirVersion = FhirVersionEnum.DSTU2;
         var entry = new org.hl7.fhir.dstu2.model.Bundle.BundleEntryComponent();
         var bundle = new org.hl7.fhir.dstu2.model.Bundle().addEntry(entry);
+        var resource = new org.hl7.fhir.dstu2.model.Patient();
         assertThrows(IllegalArgumentException.class, () -> {
             getEntryFirstRep(bundle);
         });
@@ -42,6 +56,12 @@ class BundleHelperTests {
             getEntryResource(fhirVersion, entry);
         });
         assertThrows(IllegalArgumentException.class, () -> {
+            isEntryRequestPut(fhirVersion, entry);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            isEntryRequestPost(fhirVersion, entry);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
             getEntry(bundle);
         });
         assertThrows(IllegalArgumentException.class, () -> {
@@ -51,7 +71,43 @@ class BundleHelperTests {
             newBundle(fhirVersion);
         });
         assertThrows(IllegalArgumentException.class, () -> {
+            setBundleType(bundle, "transaction");
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            setBundleTotal(bundle, 10);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
             newEntry(fhirVersion);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            newEntryWithResource(resource);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            newEntryWithResponse(fhirVersion, null);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            newResponseWithLocation(fhirVersion, null);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            newRequest(fhirVersion, null, null);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            newRequest(fhirVersion, null);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            setRequestUrl(fhirVersion, null, null);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            setRequestIfNoneExist(fhirVersion, null, null);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            setEntryFullUrl(fhirVersion, null, null);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            setEntryRequest(fhirVersion, null, null);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            resourceToRuntimeSearchParam(resource);
         });
     }
 
@@ -59,14 +115,14 @@ class BundleHelperTests {
     void dstu3() {
         var fhirVersion = FhirVersionEnum.DSTU3;
         var bundle = newBundle(fhirVersion);
-        assertTrue(bundle instanceof org.hl7.fhir.dstu3.model.Bundle);
+        assertInstanceOf(org.hl7.fhir.dstu3.model.Bundle.class, bundle);
         assertTrue(getEntry(bundle).isEmpty());
         var resource = new org.hl7.fhir.dstu3.model.Patient()
                 .setName(Collections.singletonList(new org.hl7.fhir.dstu3.model.HumanName()
                         .setFamily("Test")
                         .addGiven("Test")));
         var entry = newEntryWithResource(resource);
-        assertTrue(entry instanceof org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent);
+        assertInstanceOf(org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent.class, entry);
         addEntry(bundle, entry);
         assertFalse(getEntry(bundle).isEmpty());
         assertEquals(entry, getEntryFirstRep(bundle));
@@ -79,13 +135,13 @@ class BundleHelperTests {
     void r4() {
         var fhirVersion = FhirVersionEnum.R4;
         var bundle = newBundle(fhirVersion);
-        assertTrue(bundle instanceof org.hl7.fhir.r4.model.Bundle);
+        assertInstanceOf(Bundle.class, bundle);
         assertTrue(getEntry(bundle).isEmpty());
         var resource = new org.hl7.fhir.r4.model.Patient()
                 .setName(Collections.singletonList(
                         new org.hl7.fhir.r4.model.HumanName().setFamily("Test").addGiven("Test")));
         var entry = newEntryWithResource(resource);
-        assertTrue(entry instanceof org.hl7.fhir.r4.model.Bundle.BundleEntryComponent);
+        assertInstanceOf(BundleEntryComponent.class, entry);
         addEntry(bundle, entry);
         assertFalse(getEntry(bundle).isEmpty());
         assertEquals(entry, getEntryFirstRep(bundle));
@@ -98,13 +154,13 @@ class BundleHelperTests {
     void r5() {
         var fhirVersion = FhirVersionEnum.R5;
         var bundle = newBundle(fhirVersion);
-        assertTrue(bundle instanceof org.hl7.fhir.r5.model.Bundle);
+        assertInstanceOf(org.hl7.fhir.r5.model.Bundle.class, bundle);
         assertTrue(getEntry(bundle).isEmpty());
         var resource = new org.hl7.fhir.r5.model.Patient()
                 .setName(Collections.singletonList(
                         new org.hl7.fhir.r5.model.HumanName().setFamily("Test").addGiven("Test")));
         var entry = newEntryWithResource(resource);
-        assertTrue(entry instanceof org.hl7.fhir.r5.model.Bundle.BundleEntryComponent);
+        assertInstanceOf(org.hl7.fhir.r5.model.Bundle.BundleEntryComponent.class, entry);
         addEntry(bundle, entry);
         assertFalse(getEntry(bundle).isEmpty());
         assertEquals(entry, getEntryFirstRep(bundle));
@@ -169,6 +225,7 @@ class BundleHelperTests {
 
         var res = BundleHelper.getEntryRequestId(FhirVersionEnum.DSTU3, bundle);
 
+        assertTrue(res.isPresent());
         assertEquals(new org.hl7.fhir.dstu3.model.IdType("123"), res.get());
     }
 
@@ -181,6 +238,7 @@ class BundleHelperTests {
 
         var res = BundleHelper.getEntryRequestId(FhirVersionEnum.R4, bundle);
 
+        assertTrue(res.isPresent());
         assertEquals(new IdType("123"), res.get());
     }
 
@@ -195,6 +253,7 @@ class BundleHelperTests {
 
         var res = BundleHelper.getEntryRequestId(FhirVersionEnum.R5, bundle);
 
+        assertTrue(res.isPresent());
         assertEquals(new org.hl7.fhir.r5.model.IdType("123"), res.get());
     }
 

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/AdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/AdapterTest.java
@@ -39,8 +39,9 @@ class AdapterTest {
         var factory = IAdapterFactory.forFhirVersion(fhirVersion);
         assertThrows(IllegalArgumentException.class, () -> factory.createCoding(null));
         var adapter = factory.createCoding(coding);
-        assertEquals(fhirVersion, adapter.fhirVersion());
         assertEquals(coding, adapter.get());
+        assertEquals(fhirVersion, adapter.fhirVersion());
         assertNotNull(adapter.getAdapterFactory());
+        assertNotNull(adapter.getModelResolver());
     }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/AdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/AdapterTest.java
@@ -2,13 +2,17 @@ package org.opencds.cqf.fhir.utility.adapter;
 
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import java.util.Date;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.Test;
 
 class AdapterTest {
@@ -43,5 +47,19 @@ class AdapterTest {
         assertEquals(fhirVersion, adapter.fhirVersion());
         assertNotNull(adapter.getAdapterFactory());
         assertNotNull(adapter.getModelResolver());
+    }
+
+    @Test
+    void testBaseResourceAdapter() {
+        var extUrl = "test.com";
+        var extValue = new StringType("test");
+        var resource = new Observation();
+        var adapter = IAdapterFactory.createAdapterForResource(resource);
+        assertFalse(adapter.hasExtension());
+        var newExtension = adapter.addExtension();
+        newExtension.setUrl(extUrl);
+        newExtension.setValue(extValue);
+        assertTrue(adapter.hasExtension());
+        assertEquals(extValue, adapter.getExtensionByUrl(extUrl).getValue());
     }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/AdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/AdapterTest.java
@@ -1,10 +1,13 @@
 package org.opencds.cqf.fhir.utility.adapter;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import java.util.Date;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Library;
 import org.junit.jupiter.api.Test;
 
@@ -22,10 +25,22 @@ class AdapterTest {
     }
 
     @Test
-    void testResolvPath() {
+    void testResolvePath() {
         var library = new Library();
         library.setDate(new Date());
         var adapter = IAdapterFactory.createAdapterForResource(library);
         assertThrows(UnprocessableEntityException.class, () -> adapter.resolvePathString(library, "date"));
+    }
+
+    @Test
+    void testBaseAdapter() {
+        var fhirVersion = FhirVersionEnum.R4;
+        var coding = new Coding();
+        var factory = IAdapterFactory.forFhirVersion(fhirVersion);
+        assertThrows(IllegalArgumentException.class, () -> factory.createCoding(null));
+        var adapter = factory.createCoding(coding);
+        assertEquals(fhirVersion, adapter.fhirVersion());
+        assertEquals(coding, adapter.get());
+        assertNotNull(adapter.getAdapterFactory());
     }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireAdapterTest.java
@@ -18,9 +18,12 @@ import org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus;
 import org.hl7.fhir.dstu3.model.Library;
 import org.hl7.fhir.dstu3.model.Period;
 import org.hl7.fhir.dstu3.model.Questionnaire;
+import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemType;
 import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.dstu3.model.RelatedArtifact;
 import org.hl7.fhir.dstu3.model.UriType;
+import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.junit.jupiter.api.Test;
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.adapter.TestVisitor;
@@ -184,7 +187,33 @@ class QuestionnaireAdapterTest {
         var extractedDependencies = adapter.getDependencies();
         assertEquals(dependencies.size(), extractedDependencies.size());
         extractedDependencies.forEach(dep -> {
-            assertTrue(dependencies.indexOf(dep.getReference()) >= 0);
+            assertTrue(dependencies.contains(dep.getReference()));
         });
+    }
+
+    @Test
+    void testItem() {
+        var questionnaire = new Questionnaire();
+        var item1 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent().setLinkId("1").setType(QuestionnaireItemType.BOOLEAN));
+        var item2 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent().setLinkId("2").setType(QuestionnaireItemType.BOOLEAN));
+        var item3 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent().setLinkId("3").setType(QuestionnaireItemType.BOOLEAN));
+        var item4 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent().setLinkId("4").setType(QuestionnaireItemType.BOOLEAN));
+        questionnaire.addItem((QuestionnaireItemComponent) item1.get());
+        questionnaire.addItem((QuestionnaireItemComponent) item2.get());
+        var adapter = adapterFactory.createQuestionnaire(questionnaire);
+        assertTrue(adapter.hasItem());
+        assertEquals(2, adapter.getItem().size());
+        adapter.addItem(item3);
+        assertEquals(3, adapter.getItem().size());
+        adapter.addItem((IBaseBackboneElement) item4.get());
+        assertEquals(4, adapter.getItem().size());
+        adapter.setItem(List.of(item1));
+        assertEquals(1, adapter.getItem().size());
+        adapter.addItems(List.of(item2, item3, item4));
+        assertEquals(4, adapter.getItem().size());
     }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireItemComponentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireItemComponentAdapterTest.java
@@ -1,0 +1,59 @@
+package org.opencds.cqf.fhir.utility.adapter.dstu3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.List;
+import org.hl7.fhir.dstu3.model.Library;
+import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemType;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
+
+class QuestionnaireItemComponentAdapterTest {
+    private final IAdapterFactory adapterFactory = new AdapterFactory();
+
+    @Test
+    void invalid_object_fails() {
+        var library = new Library();
+        assertThrows(IllegalArgumentException.class, () -> adapterFactory.createQuestionnaireItem(library));
+    }
+
+    @Test
+    void test() {
+        var item = new QuestionnaireItemComponent();
+        var adapter = new QuestionnaireItemComponentAdapter(item);
+        assertNotNull(adapter);
+        assertEquals(item, adapter.get());
+        assertEquals(FhirVersionEnum.DSTU3, adapter.fhirVersion());
+        assertNotNull(adapter.getModelResolver());
+        assertNotNull(adapter.getAdapterFactory());
+    }
+
+    @Test
+    void testItem() {
+        var item = new QuestionnaireItemComponent();
+        var item1 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent().setLinkId("1").setType(QuestionnaireItemType.BOOLEAN));
+        var item2 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent().setLinkId("2").setType(QuestionnaireItemType.BOOLEAN));
+        var item3 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent().setLinkId("3").setType(QuestionnaireItemType.BOOLEAN));
+        var item4 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent().setLinkId("4").setType(QuestionnaireItemType.BOOLEAN));
+        item.addItem((QuestionnaireItemComponent) item1.get());
+        item.addItem((QuestionnaireItemComponent) item2.get());
+        var adapter = adapterFactory.createQuestionnaireItem(item);
+        assertTrue(adapter.hasItem());
+        assertEquals(2, adapter.getItem().size());
+        adapter.addItem(item3);
+        assertEquals(3, adapter.getItem().size());
+        adapter.setItem(List.of(item1));
+        assertEquals(1, adapter.getItem().size());
+        adapter.addItems(List.of(item2, item3, item4));
+        assertEquals(4, adapter.getItem().size());
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireItemComponentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireItemComponentAdapterTest.java
@@ -1,12 +1,15 @@
 package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
+import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.Library;
 import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemComponent;
 import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemType;
@@ -24,13 +27,44 @@ class QuestionnaireItemComponentAdapterTest {
 
     @Test
     void test() {
-        var item = new QuestionnaireItemComponent();
-        var adapter = new QuestionnaireItemComponentAdapter(item);
-        assertNotNull(adapter);
+        var text = "test";
+        var item = new QuestionnaireItemComponent().addCode(new Coding().setCode(text));
+        var adapter = adapterFactory.createQuestionnaireItem(item);
+        assertNotNull(adapterFactory.createBase(item));
         assertEquals(item, adapter.get());
         assertEquals(FhirVersionEnum.DSTU3, adapter.fhirVersion());
         assertNotNull(adapter.getModelResolver());
         assertNotNull(adapter.getAdapterFactory());
+        var linkId = "1";
+        adapter.setLinkId(linkId);
+        assertEquals(linkId, adapter.getLinkId());
+        assertEquals(text, adapter.getCode().get(0).getCode());
+        adapter.setText(text);
+        assertEquals(text, adapter.getText());
+        assertFalse(adapter.hasDefinition());
+        var definition = "Observation.valueBoolean";
+        adapter.setDefinition(definition);
+        assertEquals(definition, adapter.getDefinition());
+        adapter.setType("choice");
+        assertFalse(adapter.isGroupItem());
+        assertTrue(adapter.isChoiceItem());
+        adapter.setRequired(true);
+        assertTrue(adapter.getRequired());
+        adapter.setRepeats(false);
+        assertFalse(adapter.getRepeats());
+        var optionValue = "option";
+        adapter.addAnswerOption(new CodingAdapter(new Coding().setCode(optionValue)));
+        assertEquals(
+                optionValue,
+                ((Coding) ((QuestionnaireItemComponent) adapter.get())
+                                .getOption()
+                                .get(0)
+                                .getValue())
+                        .getCode());
+        assertFalse(adapter.hasInitial());
+        assertEquals(0, adapter.getInitial().size());
+        assertNotNull(adapter.newResponseItem());
+        assertNull(adapter.newExpression("expression"));
     }
 
     @Test

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseAdapterTest.java
@@ -1,4 +1,4 @@
-package org.opencds.cqf.fhir.utility.adapter.r5;
+package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -7,9 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
-import org.hl7.fhir.r5.model.Library;
-import org.hl7.fhir.r5.model.QuestionnaireResponse;
-import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.dstu3.model.Library;
+import org.hl7.fhir.dstu3.model.QuestionnaireResponse;
+import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
 import org.junit.jupiter.api.Test;
 import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
 
@@ -28,7 +28,7 @@ class QuestionnaireResponseAdapterTest {
         var adapter = new QuestionnaireResponseAdapter(response);
         assertNotNull(adapter);
         assertEquals(response, adapter.get());
-        assertEquals(FhirVersionEnum.R5, adapter.fhirVersion());
+        assertEquals(FhirVersionEnum.DSTU3, adapter.fhirVersion());
         assertNotNull(adapter.getModelResolver());
         assertNotNull(adapter.getAdapterFactory());
     }
@@ -36,10 +36,14 @@ class QuestionnaireResponseAdapterTest {
     @Test
     void testItem() {
         var questionnaireResponse = new QuestionnaireResponse();
-        var item1 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("1"));
-        var item2 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("2"));
-        var item3 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("3"));
-        var item4 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("4"));
+        var item1 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("1"));
+        var item2 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("2"));
+        var item3 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("3"));
+        var item4 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("4"));
         questionnaireResponse.addItem((QuestionnaireResponseItemComponent) item1.get());
         questionnaireResponse.addItem((QuestionnaireResponseItemComponent) item2.get());
         var adapter = adapterFactory.createQuestionnaireResponse(questionnaireResponse);

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseAdapterTest.java
@@ -6,7 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.Date;
 import java.util.List;
+import org.hl7.fhir.dstu3.model.IdType;
 import org.hl7.fhir.dstu3.model.Library;
 import org.hl7.fhir.dstu3.model.QuestionnaireResponse;
 import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
@@ -25,12 +27,18 @@ class QuestionnaireResponseAdapterTest {
     @Test
     void test() {
         var response = new QuestionnaireResponse();
-        var adapter = new QuestionnaireResponseAdapter(response);
+        var adapter = adapterFactory.createQuestionnaireResponse(response);
+        assertNotNull(adapterFactory.createResource(response));
         assertNotNull(adapter);
         assertEquals(response, adapter.get());
         assertEquals(FhirVersionEnum.DSTU3, adapter.fhirVersion());
         assertNotNull(adapter.getModelResolver());
         assertNotNull(adapter.getAdapterFactory());
+        adapter.setId("test");
+        adapter.setQuestionnaire("test.com/Questionnaire/test");
+        adapter.setSubject(new IdType("test1"));
+        adapter.setAuthored(new Date());
+        adapter.setStatus("in-progress");
     }
 
     @Test

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseItemAnswerComponentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseItemAnswerComponentAdapterTest.java
@@ -1,0 +1,71 @@
+package org.opencds.cqf.fhir.utility.adapter.dstu3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.List;
+import org.hl7.fhir.dstu3.model.IntegerType;
+import org.hl7.fhir.dstu3.model.Library;
+import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent;
+import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.dstu3.model.StringType;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
+
+class QuestionnaireResponseItemAnswerComponentAdapterTest {
+    private final IAdapterFactory adapterFactory = new AdapterFactory();
+
+    @Test
+    void invalid_object_fails() {
+        var library = new Library();
+        assertThrows(
+                IllegalArgumentException.class, () -> adapterFactory.createQuestionnaireResponseItemAnswer(library));
+    }
+
+    @Test
+    void test() {
+        var answer = new QuestionnaireResponseItemAnswerComponent();
+        var adapter = new QuestionnaireResponseItemAnswerComponentAdapter(answer);
+        assertNotNull(adapter);
+        assertEquals(answer, adapter.get());
+        assertEquals(FhirVersionEnum.DSTU3, adapter.fhirVersion());
+        assertNotNull(adapter.getModelResolver());
+        assertNotNull(adapter.getAdapterFactory());
+    }
+
+    @Test
+    void testValue() {
+        var testValue = new StringType("test");
+        var answer = new QuestionnaireResponseItemAnswerComponent();
+        answer.setValue(testValue);
+        var adapter = adapterFactory.createQuestionnaireResponseItemAnswer(answer);
+        assertTrue(adapter.hasValue());
+        assertEquals(testValue, adapter.getValue());
+        var newValue = new IntegerType(1);
+        adapter.setValue(newValue);
+        assertEquals(newValue, adapter.getValue());
+    }
+
+    @Test
+    void testItem() {
+        var answer = new QuestionnaireResponseItemAnswerComponent();
+        var item1 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("1"));
+        var item2 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("2"));
+        var item3 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("3"));
+        var item4 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("4"));
+        answer.addItem((QuestionnaireResponseItemComponent) item1.get());
+        answer.addItem((QuestionnaireResponseItemComponent) item2.get());
+        var adapter = adapterFactory.createQuestionnaireResponseItemAnswer(answer);
+        assertTrue(adapter.hasItem());
+        assertEquals(2, adapter.getItem().size());
+        adapter.setItem(List.of(item1, item2, item3, item4));
+        assertEquals(4, adapter.getItem().size());
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseItemAnswerComponentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseItemAnswerComponentAdapterTest.java
@@ -28,7 +28,8 @@ class QuestionnaireResponseItemAnswerComponentAdapterTest {
     @Test
     void test() {
         var answer = new QuestionnaireResponseItemAnswerComponent();
-        var adapter = new QuestionnaireResponseItemAnswerComponentAdapter(answer);
+        var adapter = adapterFactory.createQuestionnaireResponseItemAnswer(answer);
+        assertNotNull(adapterFactory.createBase(answer));
         assertNotNull(adapter);
         assertEquals(answer, adapter.get());
         assertEquals(FhirVersionEnum.DSTU3, adapter.fhirVersion());

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseItemComponentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseItemComponentAdapterTest.java
@@ -1,4 +1,4 @@
-package org.opencds.cqf.fhir.utility.adapter.r5;
+package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -7,10 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
-import org.hl7.fhir.r5.model.IntegerType;
-import org.hl7.fhir.r5.model.Library;
-import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
-import org.hl7.fhir.r5.model.StringType;
+import org.hl7.fhir.dstu3.model.IntegerType;
+import org.hl7.fhir.dstu3.model.Library;
+import org.hl7.fhir.dstu3.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.dstu3.model.StringType;
 import org.junit.jupiter.api.Test;
 import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
 
@@ -29,7 +29,7 @@ class QuestionnaireResponseItemComponentAdapterTest {
         var adapter = new QuestionnaireResponseItemComponentAdapter(item);
         assertNotNull(adapter);
         assertEquals(item, adapter.get());
-        assertEquals(FhirVersionEnum.R5, adapter.fhirVersion());
+        assertEquals(FhirVersionEnum.DSTU3, adapter.fhirVersion());
         assertNotNull(adapter.getModelResolver());
         assertNotNull(adapter.getAdapterFactory());
     }
@@ -53,10 +53,14 @@ class QuestionnaireResponseItemComponentAdapterTest {
     @Test
     void testItem() {
         var item = new QuestionnaireResponseItemComponent();
-        var item1 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("1"));
-        var item2 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("2"));
-        var item3 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("3"));
-        var item4 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("4"));
+        var item1 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("1"));
+        var item2 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("2"));
+        var item3 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("3"));
+        var item4 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("4"));
         item.addItem((QuestionnaireResponseItemComponent) item1.get());
         item.addItem((QuestionnaireResponseItemComponent) item2.get());
         var adapter = adapterFactory.createQuestionnaireResponseItem(item);

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseItemComponentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/QuestionnaireResponseItemComponentAdapterTest.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -26,12 +27,20 @@ class QuestionnaireResponseItemComponentAdapterTest {
     @Test
     void test() {
         var item = new QuestionnaireResponseItemComponent();
-        var adapter = new QuestionnaireResponseItemComponentAdapter(item);
+        var adapter = adapterFactory.createQuestionnaireResponseItem(item);
+        assertNotNull(adapterFactory.createBase(item));
         assertNotNull(adapter);
         assertEquals(item, adapter.get());
         assertEquals(FhirVersionEnum.DSTU3, adapter.fhirVersion());
         assertNotNull(adapter.getModelResolver());
         assertNotNull(adapter.getAdapterFactory());
+        var linkId = "1";
+        adapter.setLinkId(linkId);
+        assertEquals(linkId, adapter.getLinkId());
+        assertFalse(adapter.hasDefinition());
+        var definition = "Observation.valueBoolean";
+        adapter.setDefinition(definition);
+        assertEquals(definition, adapter.getDefinition());
     }
 
     @Test

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/RequestActionAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/RequestActionAdapterTest.java
@@ -19,10 +19,10 @@ import org.hl7.fhir.dstu3.model.RequestGroup.RequestGroupActionComponent;
 import org.junit.jupiter.api.Test;
 
 class RequestActionAdapterTest {
+    private final org.opencds.cqf.fhir.utility.adapter.IAdapterFactory adapterFactory = new AdapterFactory();
 
     @Test
     void invalid_object_fails() {
-        var adapterFactory = new AdapterFactory();
         var action = new PlanDefinitionActionComponent();
         assertThrows(IllegalArgumentException.class, () -> adapterFactory.createRequestAction(action));
     }
@@ -30,7 +30,8 @@ class RequestActionAdapterTest {
     @Test
     void test() {
         var action = new RequestGroupActionComponent();
-        var adapter = new RequestActionAdapter(action);
+        var adapter = adapterFactory.createRequestAction(action);
+        assertNotNull(adapterFactory.createBase(action));
         assertNotNull(adapter);
         assertEquals(action, adapter.get());
         assertEquals(FhirVersionEnum.DSTU3, adapter.fhirContext().getVersion().getVersion());

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/StructureDefinitionAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/StructureDefinitionAdapterTest.java
@@ -1,8 +1,8 @@
 package org.opencds.cqf.fhir.utility.adapter.dstu3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -34,6 +34,7 @@ class StructureDefinitionAdapterTest {
     void invalid_object_fails() {
         var library = new Library();
         assertThrows(IllegalArgumentException.class, () -> new StructureDefinitionAdapter(library));
+        assertNotNull(adapterFactory.createStructureDefinition(new StructureDefinition()));
     }
 
     @Test
@@ -185,6 +186,9 @@ class StructureDefinitionAdapterTest {
     void adapter_get_elements() {
         var baseDefinition = "http://hl7.org/fhir/Observation";
         var structureDef = new StructureDefinition().setBaseDefinition(baseDefinition);
+        structureDef.getSnapshot().addElement().setPath("Observation");
+        structureDef.getSnapshot().addElement().setPath("Observation.id");
+        structureDef.getDifferential().addElement().setPath("Observation");
         structureDef
                 .getDifferential()
                 .addElement()
@@ -198,10 +202,10 @@ class StructureDefinitionAdapterTest {
                 .addType()
                 .setCode("Quantity");
         var adapter = (IStructureDefinitionAdapter) adapterFactory.createKnowledgeArtifactAdapter(structureDef);
-        assertFalse(adapter.hasSnapshot());
+        assertTrue(adapter.hasSnapshot());
         assertEquals(baseDefinition, adapter.getBaseDefinition().getValue());
         var snapshotElements = adapter.getSnapshotElements();
-        assertEquals(0, snapshotElements.size());
+        assertEquals(1, snapshotElements.size());
         var differentialElements = adapter.getDifferentialElements();
         assertEquals(2, differentialElements.size());
     }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ValueSetAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ValueSetAdapterTest.java
@@ -39,7 +39,7 @@ class ValueSetAdapterTest {
     void adapter_accepts_visitor() {
         var spyVisitor = spy(new TestVisitor());
         var valueSet = new ValueSet();
-        var adapter = adapterFactory.createKnowledgeArtifactAdapter(valueSet);
+        var adapter = adapterFactory.createValueSet(valueSet);
         doReturn(valueSet).when(spyVisitor).visit(any(ValueSetAdapter.class), any());
         adapter.accept(spyVisitor, null);
         verify(spyVisitor, times(1)).visit(any(ValueSetAdapter.class), any());

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ValueSetConceptReferenceAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/dstu3/ValueSetConceptReferenceAdapterTest.java
@@ -35,4 +35,12 @@ class ValueSetConceptReferenceAdapterTest {
         assertTrue(adapter.hasCode());
         assertEquals(code, adapter.getCode());
     }
+
+    @Test
+    void testDisplay() {
+        var display = "test";
+        var conceptRef = new ValueSet.ConceptReferenceComponent().setDisplay(display);
+        var adapter = new ValueSetConceptReferenceAdapter(conceptRef);
+        assertEquals(display, adapter.getDisplay());
+    }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireAdapterTest.java
@@ -14,6 +14,7 @@ import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import java.time.LocalDate;
 import java.util.Date;
 import java.util.List;
+import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
 import org.hl7.fhir.r4.model.Expression;
@@ -21,6 +22,7 @@ import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.Period;
 import org.hl7.fhir.r4.model.Questionnaire;
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType;
 import org.hl7.fhir.r4.model.RelatedArtifact;
 import org.junit.jupiter.api.Test;
@@ -215,7 +217,33 @@ class QuestionnaireAdapterTest {
         var extractedDependencies = adapter.getDependencies();
         assertEquals(dependencies.size(), extractedDependencies.size());
         extractedDependencies.forEach(dep -> {
-            assertTrue(dependencies.indexOf(dep.getReference()) >= 0);
+            assertTrue(dependencies.contains(dep.getReference()));
         });
+    }
+
+    @Test
+    void testItem() {
+        var questionnaire = new Questionnaire();
+        var item1 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent().setLinkId("1").setType(QuestionnaireItemType.BOOLEAN));
+        var item2 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent().setLinkId("2").setType(QuestionnaireItemType.BOOLEAN));
+        var item3 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent().setLinkId("3").setType(QuestionnaireItemType.BOOLEAN));
+        var item4 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent().setLinkId("4").setType(QuestionnaireItemType.BOOLEAN));
+        questionnaire.addItem((QuestionnaireItemComponent) item1.get());
+        questionnaire.addItem((QuestionnaireItemComponent) item2.get());
+        var adapter = adapterFactory.createQuestionnaire(questionnaire);
+        assertTrue(adapter.hasItem());
+        assertEquals(2, adapter.getItem().size());
+        adapter.addItem(item3);
+        assertEquals(3, adapter.getItem().size());
+        adapter.addItem((IBaseBackboneElement) item4.get());
+        assertEquals(4, adapter.getItem().size());
+        adapter.setItem(List.of(item1));
+        assertEquals(1, adapter.getItem().size());
+        adapter.addItems(List.of(item2, item3, item4));
+        assertEquals(4, adapter.getItem().size());
     }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireItemComponentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireItemComponentAdapterTest.java
@@ -1,0 +1,59 @@
+package org.opencds.cqf.fhir.utility.adapter.r4;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.List;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
+
+class QuestionnaireItemComponentAdapterTest {
+    private final IAdapterFactory adapterFactory = new AdapterFactory();
+
+    @Test
+    void invalid_object_fails() {
+        var library = new Library();
+        assertThrows(IllegalArgumentException.class, () -> adapterFactory.createQuestionnaireItem(library));
+    }
+
+    @Test
+    void test() {
+        var item = new QuestionnaireItemComponent();
+        var adapter = new QuestionnaireItemComponentAdapter(item);
+        assertNotNull(adapter);
+        assertEquals(item, adapter.get());
+        assertEquals(FhirVersionEnum.R4, adapter.fhirVersion());
+        assertNotNull(adapter.getModelResolver());
+        assertNotNull(adapter.getAdapterFactory());
+    }
+
+    @Test
+    void testItem() {
+        var item = new QuestionnaireItemComponent();
+        var item1 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent().setLinkId("1").setType(QuestionnaireItemType.BOOLEAN));
+        var item2 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent().setLinkId("2").setType(QuestionnaireItemType.BOOLEAN));
+        var item3 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent().setLinkId("3").setType(QuestionnaireItemType.BOOLEAN));
+        var item4 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent().setLinkId("4").setType(QuestionnaireItemType.BOOLEAN));
+        item.addItem((QuestionnaireItemComponent) item1.get());
+        item.addItem((QuestionnaireItemComponent) item2.get());
+        var adapter = adapterFactory.createQuestionnaireItem(item);
+        assertTrue(adapter.hasItem());
+        assertEquals(2, adapter.getItem().size());
+        adapter.addItem(item3);
+        assertEquals(3, adapter.getItem().size());
+        adapter.setItem(List.of(item1));
+        assertEquals(1, adapter.getItem().size());
+        adapter.addItems(List.of(item2, item3, item4));
+        assertEquals(4, adapter.getItem().size());
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireItemComponentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireItemComponentAdapterTest.java
@@ -1,12 +1,14 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
 import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType;
@@ -24,13 +26,45 @@ class QuestionnaireItemComponentAdapterTest {
 
     @Test
     void test() {
-        var item = new QuestionnaireItemComponent();
-        var adapter = new QuestionnaireItemComponentAdapter(item);
+        var text = "test";
+        var item = new QuestionnaireItemComponent().addCode(new Coding().setCode(text));
+        var adapter = adapterFactory.createQuestionnaireItem(item);
+        assertNotNull(adapterFactory.createBase(item));
         assertNotNull(adapter);
         assertEquals(item, adapter.get());
         assertEquals(FhirVersionEnum.R4, adapter.fhirVersion());
         assertNotNull(adapter.getModelResolver());
         assertNotNull(adapter.getAdapterFactory());
+        var linkId = "1";
+        adapter.setLinkId(linkId);
+        assertEquals(linkId, adapter.getLinkId());
+        assertEquals(text, adapter.getCode().get(0).getCode());
+        adapter.setText(text);
+        assertEquals(text, adapter.getText());
+        assertFalse(adapter.hasDefinition());
+        var definition = "Observation.valueBoolean";
+        adapter.setDefinition(definition);
+        assertEquals(definition, adapter.getDefinition());
+        adapter.setType("choice");
+        assertFalse(adapter.isGroupItem());
+        assertTrue(adapter.isChoiceItem());
+        adapter.setRequired(true);
+        assertTrue(adapter.getRequired());
+        adapter.setRepeats(false);
+        assertFalse(adapter.getRepeats());
+        var optionValue = "option";
+        adapter.addAnswerOption(new CodingAdapter(new Coding().setCode(optionValue)));
+        assertEquals(
+                optionValue,
+                ((Coding) ((QuestionnaireItemComponent) adapter.get())
+                                .getAnswerOption()
+                                .get(0)
+                                .getValue())
+                        .getCode());
+        assertFalse(adapter.hasInitial());
+        assertEquals(0, adapter.getInitial().size());
+        assertNotNull(adapter.newResponseItem());
+        assertNotNull(adapter.newExpression("expression"));
     }
 
     @Test

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseAdapterTest.java
@@ -6,7 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.Date;
 import java.util.List;
+import org.hl7.fhir.dstu3.model.IdType;
 import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.QuestionnaireResponse;
 import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
@@ -25,12 +27,18 @@ class QuestionnaireResponseAdapterTest {
     @Test
     void test() {
         var response = new QuestionnaireResponse();
-        var adapter = new QuestionnaireResponseAdapter(response);
+        var adapter = adapterFactory.createQuestionnaireResponse(response);
+        assertNotNull(adapterFactory.createResource(response));
         assertNotNull(adapter);
         assertEquals(response, adapter.get());
         assertEquals(FhirVersionEnum.R4, adapter.fhirVersion());
         assertNotNull(adapter.getModelResolver());
         assertNotNull(adapter.getAdapterFactory());
+        adapter.setId("test");
+        adapter.setQuestionnaire("test.com/Questionnaire/test");
+        adapter.setSubject(new IdType("test1"));
+        adapter.setAuthored(new Date());
+        adapter.setStatus("in-progress");
     }
 
     @Test

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseAdapterTest.java
@@ -1,4 +1,4 @@
-package org.opencds.cqf.fhir.utility.adapter.r5;
+package org.opencds.cqf.fhir.utility.adapter.r4;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -7,9 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
-import org.hl7.fhir.r5.model.Library;
-import org.hl7.fhir.r5.model.QuestionnaireResponse;
-import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.QuestionnaireResponse;
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
 import org.junit.jupiter.api.Test;
 import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
 
@@ -28,7 +28,7 @@ class QuestionnaireResponseAdapterTest {
         var adapter = new QuestionnaireResponseAdapter(response);
         assertNotNull(adapter);
         assertEquals(response, adapter.get());
-        assertEquals(FhirVersionEnum.R5, adapter.fhirVersion());
+        assertEquals(FhirVersionEnum.R4, adapter.fhirVersion());
         assertNotNull(adapter.getModelResolver());
         assertNotNull(adapter.getAdapterFactory());
     }
@@ -36,10 +36,14 @@ class QuestionnaireResponseAdapterTest {
     @Test
     void testItem() {
         var questionnaireResponse = new QuestionnaireResponse();
-        var item1 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("1"));
-        var item2 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("2"));
-        var item3 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("3"));
-        var item4 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("4"));
+        var item1 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("1"));
+        var item2 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("2"));
+        var item3 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("3"));
+        var item4 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("4"));
         questionnaireResponse.addItem((QuestionnaireResponseItemComponent) item1.get());
         questionnaireResponse.addItem((QuestionnaireResponseItemComponent) item2.get());
         var adapter = adapterFactory.createQuestionnaireResponse(questionnaireResponse);

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseItemAnswerComponentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseItemAnswerComponentAdapterTest.java
@@ -28,7 +28,8 @@ class QuestionnaireResponseItemAnswerComponentAdapterTest {
     @Test
     void test() {
         var answer = new QuestionnaireResponseItemAnswerComponent();
-        var adapter = new QuestionnaireResponseItemAnswerComponentAdapter(answer);
+        var adapter = adapterFactory.createQuestionnaireResponseItemAnswer(answer);
+        assertNotNull(adapterFactory.createBase(answer));
         assertNotNull(adapter);
         assertEquals(answer, adapter.get());
         assertEquals(FhirVersionEnum.R4, adapter.fhirVersion());

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseItemAnswerComponentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseItemAnswerComponentAdapterTest.java
@@ -1,0 +1,71 @@
+package org.opencds.cqf.fhir.utility.adapter.r4;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.List;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent;
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
+
+class QuestionnaireResponseItemAnswerComponentAdapterTest {
+    private final IAdapterFactory adapterFactory = new AdapterFactory();
+
+    @Test
+    void invalid_object_fails() {
+        var library = new Library();
+        assertThrows(
+                IllegalArgumentException.class, () -> adapterFactory.createQuestionnaireResponseItemAnswer(library));
+    }
+
+    @Test
+    void test() {
+        var answer = new QuestionnaireResponseItemAnswerComponent();
+        var adapter = new QuestionnaireResponseItemAnswerComponentAdapter(answer);
+        assertNotNull(adapter);
+        assertEquals(answer, adapter.get());
+        assertEquals(FhirVersionEnum.R4, adapter.fhirVersion());
+        assertNotNull(adapter.getModelResolver());
+        assertNotNull(adapter.getAdapterFactory());
+    }
+
+    @Test
+    void testValue() {
+        var testValue = new StringType("test");
+        var answer = new QuestionnaireResponseItemAnswerComponent();
+        answer.setValue(testValue);
+        var adapter = adapterFactory.createQuestionnaireResponseItemAnswer(answer);
+        assertTrue(adapter.hasValue());
+        assertEquals(testValue, adapter.getValue());
+        var newValue = new IntegerType(1);
+        adapter.setValue(newValue);
+        assertEquals(newValue, adapter.getValue());
+    }
+
+    @Test
+    void testItem() {
+        var answer = new QuestionnaireResponseItemAnswerComponent();
+        var item1 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("1"));
+        var item2 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("2"));
+        var item3 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("3"));
+        var item4 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("4"));
+        answer.addItem((QuestionnaireResponseItemComponent) item1.get());
+        answer.addItem((QuestionnaireResponseItemComponent) item2.get());
+        var adapter = adapterFactory.createQuestionnaireResponseItemAnswer(answer);
+        assertTrue(adapter.hasItem());
+        assertEquals(2, adapter.getItem().size());
+        adapter.setItem(List.of(item1, item2, item3, item4));
+        assertEquals(4, adapter.getItem().size());
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseItemComponentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseItemComponentAdapterTest.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -26,12 +27,20 @@ class QuestionnaireResponseItemComponentAdapterTest {
     @Test
     void test() {
         var item = new QuestionnaireResponseItemComponent();
-        var adapter = new QuestionnaireResponseItemComponentAdapter(item);
+        var adapter = adapterFactory.createQuestionnaireResponseItem(item);
+        assertNotNull(adapterFactory.createBase(item));
         assertNotNull(adapter);
         assertEquals(item, adapter.get());
         assertEquals(FhirVersionEnum.R4, adapter.fhirVersion());
         assertNotNull(adapter.getModelResolver());
         assertNotNull(adapter.getAdapterFactory());
+        var linkId = "1";
+        adapter.setLinkId(linkId);
+        assertEquals(linkId, adapter.getLinkId());
+        assertFalse(adapter.hasDefinition());
+        var definition = "Observation.valueBoolean";
+        adapter.setDefinition(definition);
+        assertEquals(definition, adapter.getDefinition());
     }
 
     @Test

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseItemComponentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/QuestionnaireResponseItemComponentAdapterTest.java
@@ -1,4 +1,4 @@
-package org.opencds.cqf.fhir.utility.adapter.r5;
+package org.opencds.cqf.fhir.utility.adapter.r4;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -7,10 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
-import org.hl7.fhir.r5.model.IntegerType;
-import org.hl7.fhir.r5.model.Library;
-import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
-import org.hl7.fhir.r5.model.StringType;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.Test;
 import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
 
@@ -29,7 +29,7 @@ class QuestionnaireResponseItemComponentAdapterTest {
         var adapter = new QuestionnaireResponseItemComponentAdapter(item);
         assertNotNull(adapter);
         assertEquals(item, adapter.get());
-        assertEquals(FhirVersionEnum.R5, adapter.fhirVersion());
+        assertEquals(FhirVersionEnum.R4, adapter.fhirVersion());
         assertNotNull(adapter.getModelResolver());
         assertNotNull(adapter.getAdapterFactory());
     }
@@ -53,10 +53,14 @@ class QuestionnaireResponseItemComponentAdapterTest {
     @Test
     void testItem() {
         var item = new QuestionnaireResponseItemComponent();
-        var item1 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("1"));
-        var item2 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("2"));
-        var item3 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("3"));
-        var item4 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("4"));
+        var item1 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("1"));
+        var item2 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("2"));
+        var item3 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("3"));
+        var item4 =
+                adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent().setLinkId("4"));
         item.addItem((QuestionnaireResponseItemComponent) item1.get());
         item.addItem((QuestionnaireResponseItemComponent) item2.get());
         var adapter = adapterFactory.createQuestionnaireResponseItem(item);

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/RequestActionAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/RequestActionAdapterTest.java
@@ -17,10 +17,10 @@ import org.hl7.fhir.r4.model.RequestGroup.RequestPriority;
 import org.junit.jupiter.api.Test;
 
 class RequestActionAdapterTest {
+    private final org.opencds.cqf.fhir.utility.adapter.IAdapterFactory adapterFactory = new AdapterFactory();
 
     @Test
     void invalid_object_fails() {
-        var adapterFactory = new AdapterFactory();
         var action = new PlanDefinitionActionComponent();
         assertThrows(IllegalArgumentException.class, () -> adapterFactory.createRequestAction(action));
     }
@@ -28,7 +28,8 @@ class RequestActionAdapterTest {
     @Test
     void test() {
         var action = new RequestGroupActionComponent();
-        var adapter = new RequestActionAdapter(action);
+        var adapter = adapterFactory.createRequestAction(action);
+        assertNotNull(adapterFactory.createBase(action));
         assertNotNull(adapter);
         assertEquals(action, adapter.get());
         assertEquals(FhirVersionEnum.R4, adapter.fhirContext().getVersion().getVersion());

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/StructureDefinitionAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/StructureDefinitionAdapterTest.java
@@ -1,7 +1,6 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -16,7 +15,6 @@ import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import java.time.LocalDate;
 import java.util.Date;
 import java.util.List;
-import org.hl7.fhir.instance.model.api.IDomainResource;
 import org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent;
 import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
 import org.hl7.fhir.r4.model.Expression;
@@ -36,7 +34,7 @@ class StructureDefinitionAdapterTest {
     void invalid_object_fails() {
         var library = new Library();
         assertThrows(IllegalArgumentException.class, () -> new StructureDefinitionAdapter(library));
-        assertNotNull(new StructureDefinitionAdapter((IDomainResource) new StructureDefinition()));
+        assertNotNull(adapterFactory.createStructureDefinition(new StructureDefinition()));
     }
 
     @Test
@@ -196,6 +194,9 @@ class StructureDefinitionAdapterTest {
     void adapter_get_elements() {
         var baseDefinition = "http://hl7.org/fhir/Observation";
         var structureDef = new StructureDefinition().setBaseDefinition(baseDefinition);
+        structureDef.getSnapshot().addElement().setPath("Observation");
+        structureDef.getSnapshot().addElement().setPath("Observation.id");
+        structureDef.getDifferential().addElement().setPath("Observation");
         structureDef
                 .getDifferential()
                 .addElement()
@@ -209,10 +210,10 @@ class StructureDefinitionAdapterTest {
                 .addType()
                 .setCode("Quantity");
         var adapter = (IStructureDefinitionAdapter) adapterFactory.createKnowledgeArtifactAdapter(structureDef);
-        assertFalse(adapter.hasSnapshot());
+        assertTrue(adapter.hasSnapshot());
         assertEquals(baseDefinition, adapter.getBaseDefinition().getValue());
         var snapshotElements = adapter.getSnapshotElements();
-        assertEquals(0, snapshotElements.size());
+        assertEquals(1, snapshotElements.size());
         var differentialElements = adapter.getDifferentialElements();
         assertEquals(2, differentialElements.size());
     }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/StructureDefinitionAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/StructureDefinitionAdapterTest.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.fhir.utility.adapter.r4;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -193,10 +194,23 @@ class StructureDefinitionAdapterTest {
 
     @Test
     void adapter_get_elements() {
-        var structureDef = new StructureDefinition();
-        structureDef.getDifferential().addElement().addType().setCode("String");
-        structureDef.getDifferential().addElement().addType().setCode("Quantity");
+        var baseDefinition = "http://hl7.org/fhir/Observation";
+        var structureDef = new StructureDefinition().setBaseDefinition(baseDefinition);
+        structureDef
+                .getDifferential()
+                .addElement()
+                .setPath("Observation.code")
+                .addType()
+                .setCode("String");
+        structureDef
+                .getDifferential()
+                .addElement()
+                .setPath("Observation.value")
+                .addType()
+                .setCode("Quantity");
         var adapter = (IStructureDefinitionAdapter) adapterFactory.createKnowledgeArtifactAdapter(structureDef);
+        assertFalse(adapter.hasSnapshot());
+        assertEquals(baseDefinition, adapter.getBaseDefinition().getValue());
         var snapshotElements = adapter.getSnapshotElements();
         assertEquals(0, snapshotElements.size());
         var differentialElements = adapter.getDifferentialElements();

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/ValueSetAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/ValueSetAdapterTest.java
@@ -40,7 +40,7 @@ class ValueSetAdapterTest {
     void adapter_accepts_visitor() {
         var spyVisitor = spy(new TestVisitor());
         var valueSet = new ValueSet();
-        var adapter = adapterFactory.createKnowledgeArtifactAdapter(valueSet);
+        var adapter = adapterFactory.createValueSet(valueSet);
         doReturn(valueSet).when(spyVisitor).visit(any(ValueSetAdapter.class), any());
         adapter.accept(spyVisitor, null);
         verify(spyVisitor, times(1)).visit(any(ValueSetAdapter.class), any());

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/ValueSetConceptReferenceAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r4/ValueSetConceptReferenceAdapterTest.java
@@ -35,4 +35,12 @@ class ValueSetConceptReferenceAdapterTest {
         assertTrue(adapter.hasCode());
         assertEquals(code, adapter.getCode());
     }
+
+    @Test
+    void testDisplay() {
+        var display = "test";
+        var conceptRef = new ValueSet.ConceptReferenceComponent().setDisplay(display);
+        var adapter = new ValueSetConceptReferenceAdapter(conceptRef);
+        assertEquals(display, adapter.getDisplay());
+    }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireAdapterTest.java
@@ -14,6 +14,7 @@ import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import java.time.LocalDate;
 import java.util.Date;
 import java.util.List;
+import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.r5.model.CanonicalType;
 import org.hl7.fhir.r5.model.Enumerations.PublicationStatus;
 import org.hl7.fhir.r5.model.Expression;
@@ -21,6 +22,7 @@ import org.hl7.fhir.r5.model.Extension;
 import org.hl7.fhir.r5.model.Library;
 import org.hl7.fhir.r5.model.Period;
 import org.hl7.fhir.r5.model.Questionnaire;
+import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemComponent;
 import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType;
 import org.hl7.fhir.r5.model.RelatedArtifact;
 import org.junit.jupiter.api.Test;
@@ -218,7 +220,33 @@ class QuestionnaireAdapterTest {
         var extractedDependencies = adapter.getDependencies();
         assertEquals(dependencies.size(), extractedDependencies.size());
         extractedDependencies.forEach(dep -> {
-            assertTrue(dependencies.indexOf(dep.getReference()) >= 0);
+            assertTrue(dependencies.contains(dep.getReference()));
         });
+    }
+
+    @Test
+    void testItem() {
+        var questionnaire = new Questionnaire();
+        var item1 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent("1", QuestionnaireItemType.BOOLEAN));
+        var item2 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent("2", QuestionnaireItemType.BOOLEAN));
+        var item3 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent("3", QuestionnaireItemType.BOOLEAN));
+        var item4 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent("4", QuestionnaireItemType.BOOLEAN));
+        questionnaire.addItem((QuestionnaireItemComponent) item1.get());
+        questionnaire.addItem((QuestionnaireItemComponent) item2.get());
+        var adapter = adapterFactory.createQuestionnaire(questionnaire);
+        assertTrue(adapter.hasItem());
+        assertEquals(2, adapter.getItem().size());
+        adapter.addItem(item3);
+        assertEquals(3, adapter.getItem().size());
+        adapter.addItem((IBaseBackboneElement) item4.get());
+        assertEquals(4, adapter.getItem().size());
+        adapter.setItem(List.of(item1));
+        assertEquals(1, adapter.getItem().size());
+        adapter.addItems(List.of(item2, item3, item4));
+        assertEquals(4, adapter.getItem().size());
     }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireItemComponentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireItemComponentAdapterTest.java
@@ -1,0 +1,59 @@
+package org.opencds.cqf.fhir.utility.adapter.r5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.List;
+import org.hl7.fhir.r5.model.Library;
+import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
+
+class QuestionnaireItemComponentAdapterTest {
+    private final IAdapterFactory adapterFactory = new AdapterFactory();
+
+    @Test
+    void invalid_object_fails() {
+        var library = new Library();
+        assertThrows(IllegalArgumentException.class, () -> adapterFactory.createQuestionnaireItem(library));
+    }
+
+    @Test
+    void test() {
+        var item = new QuestionnaireItemComponent();
+        var adapter = new QuestionnaireItemComponentAdapter(item);
+        assertNotNull(adapter);
+        assertEquals(item, adapter.get());
+        assertEquals(FhirVersionEnum.R5, adapter.fhirVersion());
+        assertNotNull(adapter.getModelResolver());
+        assertNotNull(adapter.getAdapterFactory());
+    }
+
+    @Test
+    void testItem() {
+        var item = new QuestionnaireItemComponent();
+        var item1 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent("1", QuestionnaireItemType.BOOLEAN));
+        var item2 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent("2", QuestionnaireItemType.BOOLEAN));
+        var item3 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent("3", QuestionnaireItemType.BOOLEAN));
+        var item4 = adapterFactory.createQuestionnaireItem(
+                new QuestionnaireItemComponent("4", QuestionnaireItemType.BOOLEAN));
+        item.addItem((QuestionnaireItemComponent) item1.get());
+        item.addItem((QuestionnaireItemComponent) item2.get());
+        var adapter = adapterFactory.createQuestionnaireItem(item);
+        assertTrue(adapter.hasItem());
+        assertEquals(2, adapter.getItem().size());
+        adapter.addItem(item3);
+        assertEquals(3, adapter.getItem().size());
+        adapter.setItem(List.of(item1));
+        assertEquals(1, adapter.getItem().size());
+        adapter.addItems(List.of(item2, item3, item4));
+        assertEquals(4, adapter.getItem().size());
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireItemComponentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireItemComponentAdapterTest.java
@@ -1,12 +1,14 @@
 package org.opencds.cqf.fhir.utility.adapter.r5;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
+import org.hl7.fhir.r5.model.Coding;
 import org.hl7.fhir.r5.model.Library;
 import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemComponent;
 import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemType;
@@ -24,13 +26,45 @@ class QuestionnaireItemComponentAdapterTest {
 
     @Test
     void test() {
-        var item = new QuestionnaireItemComponent();
-        var adapter = new QuestionnaireItemComponentAdapter(item);
+        var text = "test";
+        var item = new QuestionnaireItemComponent().addCode(new Coding().setCode(text));
+        var adapter = adapterFactory.createQuestionnaireItem(item);
+        assertNotNull(adapterFactory.createBase(item));
         assertNotNull(adapter);
         assertEquals(item, adapter.get());
         assertEquals(FhirVersionEnum.R5, adapter.fhirVersion());
         assertNotNull(adapter.getModelResolver());
         assertNotNull(adapter.getAdapterFactory());
+        var linkId = "1";
+        adapter.setLinkId(linkId);
+        assertEquals(linkId, adapter.getLinkId());
+        assertEquals(text, adapter.getCode().get(0).getCode());
+        adapter.setText(text);
+        assertEquals(text, adapter.getText());
+        assertFalse(adapter.hasDefinition());
+        var definition = "Observation.valueBoolean";
+        adapter.setDefinition(definition);
+        assertEquals(definition, adapter.getDefinition());
+        adapter.setType("question");
+        assertFalse(adapter.isGroupItem());
+        assertTrue(adapter.isChoiceItem());
+        adapter.setRequired(true);
+        assertTrue(adapter.getRequired());
+        adapter.setRepeats(false);
+        assertFalse(adapter.getRepeats());
+        var optionValue = "option";
+        adapter.addAnswerOption(new CodingAdapter(new Coding().setCode(optionValue)));
+        assertEquals(
+                optionValue,
+                ((Coding) ((QuestionnaireItemComponent) adapter.get())
+                                .getAnswerOption()
+                                .get(0)
+                                .getValue())
+                        .getCode());
+        assertFalse(adapter.hasInitial());
+        assertEquals(0, adapter.getInitial().size());
+        assertNotNull(adapter.newResponseItem());
+        assertNotNull(adapter.newExpression("expression"));
     }
 
     @Test

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseAdapterTest.java
@@ -34,18 +34,22 @@ class QuestionnaireResponseAdapterTest {
     }
 
     @Test
-    void testInfo() {}
+    void testInfo() {
+        var questionnaireResponse = new QuestionnaireResponse();
+        var adapter = adapterFactory.createQuestionnaireResponse(questionnaireResponse);
+        assertNotNull(adapter);
+    }
 
     @Test
     void testItem() {
-        var questionnaire = new QuestionnaireResponse();
+        var questionnaireResponse = new QuestionnaireResponse();
         var item1 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("1"));
         var item2 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("2"));
         var item3 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("3"));
         var item4 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("4"));
-        questionnaire.addItem((QuestionnaireResponseItemComponent) item1.get());
-        questionnaire.addItem((QuestionnaireResponseItemComponent) item2.get());
-        var adapter = adapterFactory.createQuestionnaireResponse(questionnaire);
+        questionnaireResponse.addItem((QuestionnaireResponseItemComponent) item1.get());
+        questionnaireResponse.addItem((QuestionnaireResponseItemComponent) item2.get());
+        var adapter = adapterFactory.createQuestionnaireResponse(questionnaireResponse);
         assertTrue(adapter.hasItem());
         assertEquals(2, adapter.getItem().size());
         adapter.addItem(item3);

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseAdapterTest.java
@@ -1,0 +1,58 @@
+package org.opencds.cqf.fhir.utility.adapter.r5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.List;
+import org.hl7.fhir.r5.model.Library;
+import org.hl7.fhir.r5.model.QuestionnaireResponse;
+import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
+
+class QuestionnaireResponseAdapterTest {
+    private final IAdapterFactory adapterFactory = new AdapterFactory();
+
+    @Test
+    void invalid_object_fails() {
+        var library = new Library();
+        assertThrows(IllegalArgumentException.class, () -> adapterFactory.createQuestionnaireResponse(library));
+    }
+
+    @Test
+    void test() {
+        var response = new QuestionnaireResponse();
+        var adapter = new QuestionnaireResponseAdapter(response);
+        assertNotNull(adapter);
+        assertEquals(response, adapter.get());
+        assertEquals(FhirVersionEnum.R5, adapter.fhirVersion());
+        assertNotNull(adapter.getModelResolver());
+        assertNotNull(adapter.getAdapterFactory());
+    }
+
+    @Test
+    void testInfo() {}
+
+    @Test
+    void testItem() {
+        var questionnaire = new QuestionnaireResponse();
+        var item1 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("1"));
+        var item2 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("2"));
+        var item3 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("3"));
+        var item4 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("4"));
+        questionnaire.addItem((QuestionnaireResponseItemComponent) item1.get());
+        questionnaire.addItem((QuestionnaireResponseItemComponent) item2.get());
+        var adapter = adapterFactory.createQuestionnaireResponse(questionnaire);
+        assertTrue(adapter.hasItem());
+        assertEquals(2, adapter.getItem().size());
+        adapter.addItem(item3);
+        assertEquals(3, adapter.getItem().size());
+        adapter.setItem(List.of(item1));
+        assertEquals(1, adapter.getItem().size());
+        adapter.addItems(List.of(item2, item3, item4));
+        assertEquals(4, adapter.getItem().size());
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseAdapterTest.java
@@ -6,7 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.Date;
 import java.util.List;
+import org.hl7.fhir.dstu3.model.IdType;
 import org.hl7.fhir.r5.model.Library;
 import org.hl7.fhir.r5.model.QuestionnaireResponse;
 import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
@@ -25,12 +27,18 @@ class QuestionnaireResponseAdapterTest {
     @Test
     void test() {
         var response = new QuestionnaireResponse();
-        var adapter = new QuestionnaireResponseAdapter(response);
+        var adapter = adapterFactory.createQuestionnaireResponse(response);
+        assertNotNull(adapterFactory.createResource(response));
         assertNotNull(adapter);
         assertEquals(response, adapter.get());
         assertEquals(FhirVersionEnum.R5, adapter.fhirVersion());
         assertNotNull(adapter.getModelResolver());
         assertNotNull(adapter.getAdapterFactory());
+        adapter.setId("test");
+        adapter.setQuestionnaire("test.com/Questionnaire/test");
+        adapter.setSubject(new IdType("test1"));
+        adapter.setAuthored(new Date());
+        adapter.setStatus("in-progress");
     }
 
     @Test

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseItemAnswerComponentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseItemAnswerComponentAdapterTest.java
@@ -28,7 +28,8 @@ class QuestionnaireResponseItemAnswerComponentAdapterTest {
     @Test
     void test() {
         var answer = new QuestionnaireResponseItemAnswerComponent();
-        var adapter = new QuestionnaireResponseItemAnswerComponentAdapter(answer);
+        var adapter = adapterFactory.createQuestionnaireResponseItemAnswer(answer);
+        assertNotNull(adapterFactory.createBase(answer));
         assertNotNull(adapter);
         assertEquals(answer, adapter.get());
         assertEquals(FhirVersionEnum.R5, adapter.fhirVersion());

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseItemAnswerComponentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseItemAnswerComponentAdapterTest.java
@@ -1,0 +1,67 @@
+package org.opencds.cqf.fhir.utility.adapter.r5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.List;
+import org.hl7.fhir.r5.model.IntegerType;
+import org.hl7.fhir.r5.model.Library;
+import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent;
+import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.r5.model.StringType;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
+
+class QuestionnaireResponseItemAnswerComponentAdapterTest {
+    private final IAdapterFactory adapterFactory = new AdapterFactory();
+
+    @Test
+    void invalid_object_fails() {
+        var library = new Library();
+        assertThrows(
+                IllegalArgumentException.class, () -> adapterFactory.createQuestionnaireResponseItemAnswer(library));
+    }
+
+    @Test
+    void test() {
+        var answer = new QuestionnaireResponseItemAnswerComponent();
+        var adapter = new QuestionnaireResponseItemAnswerComponentAdapter(answer);
+        assertNotNull(adapter);
+        assertEquals(answer, adapter.get());
+        assertEquals(FhirVersionEnum.R5, adapter.fhirVersion());
+        assertNotNull(adapter.getModelResolver());
+        assertNotNull(adapter.getAdapterFactory());
+    }
+
+    @Test
+    void testValue() {
+        var testValue = new StringType("test");
+        var answer = new QuestionnaireResponseItemAnswerComponent();
+        answer.setValue(testValue);
+        var adapter = adapterFactory.createQuestionnaireResponseItemAnswer(answer);
+        assertTrue(adapter.hasValue());
+        assertEquals(testValue, adapter.getValue());
+        var newValue = new IntegerType(1);
+        adapter.setValue(newValue);
+        assertEquals(newValue, adapter.getValue());
+    }
+
+    @Test
+    void testItem() {
+        var answer = new QuestionnaireResponseItemAnswerComponent();
+        var item1 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("1"));
+        var item2 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("2"));
+        var item3 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("3"));
+        var item4 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("4"));
+        answer.addItem((QuestionnaireResponseItemComponent) item1.get());
+        answer.addItem((QuestionnaireResponseItemComponent) item2.get());
+        var adapter = adapterFactory.createQuestionnaireResponseItemAnswer(answer);
+        assertTrue(adapter.hasItem());
+        assertEquals(2, adapter.getItem().size());
+        adapter.setItem(List.of(item1, item2, item3, item4));
+        assertEquals(4, adapter.getItem().size());
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseItemComponentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseItemComponentAdapterTest.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.fhir.utility.adapter.r5;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -26,12 +27,20 @@ class QuestionnaireResponseItemComponentAdapterTest {
     @Test
     void test() {
         var item = new QuestionnaireResponseItemComponent();
-        var adapter = new QuestionnaireResponseItemComponentAdapter(item);
+        var adapter = adapterFactory.createQuestionnaireResponseItem(item);
+        assertNotNull(adapterFactory.createBase(item));
         assertNotNull(adapter);
         assertEquals(item, adapter.get());
         assertEquals(FhirVersionEnum.R5, adapter.fhirVersion());
         assertNotNull(adapter.getModelResolver());
         assertNotNull(adapter.getAdapterFactory());
+        var linkId = "1";
+        adapter.setLinkId(linkId);
+        assertEquals(linkId, adapter.getLinkId());
+        assertFalse(adapter.hasDefinition());
+        var definition = "Observation.valueBoolean";
+        adapter.setDefinition(definition);
+        assertEquals(definition, adapter.getDefinition());
     }
 
     @Test

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseItemComponentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/QuestionnaireResponseItemComponentAdapterTest.java
@@ -1,0 +1,72 @@
+package org.opencds.cqf.fhir.utility.adapter.r5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.List;
+import org.hl7.fhir.r5.model.IntegerType;
+import org.hl7.fhir.r5.model.Library;
+import org.hl7.fhir.r5.model.QuestionnaireResponse.QuestionnaireResponseItemComponent;
+import org.hl7.fhir.r5.model.StringType;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
+
+class QuestionnaireResponseItemComponentAdapterTest {
+    private final IAdapterFactory adapterFactory = new AdapterFactory();
+
+    @Test
+    void invalid_object_fails() {
+        var library = new Library();
+        assertThrows(IllegalArgumentException.class, () -> adapterFactory.createQuestionnaireResponseItem(library));
+    }
+
+    @Test
+    void test() {
+        var item = new QuestionnaireResponseItemComponent();
+        var adapter = new QuestionnaireResponseItemComponentAdapter(item);
+        assertNotNull(adapter);
+        assertEquals(item, adapter.get());
+        assertEquals(FhirVersionEnum.R5, adapter.fhirVersion());
+        assertNotNull(adapter.getModelResolver());
+        assertNotNull(adapter.getAdapterFactory());
+    }
+
+    @Test
+    void testAnswer() {
+        var testValue = new StringType("test");
+        var item = new QuestionnaireResponseItemComponent();
+        item.addAnswer().setValue(testValue);
+        var adapter = adapterFactory.createQuestionnaireResponseItem(item);
+        assertTrue(adapter.hasAnswer());
+        assertEquals(1, adapter.getAnswer().size());
+        assertEquals(testValue, adapter.getAnswer().get(0).getValue());
+        var newValue = new IntegerType(1);
+        var newAnswer = adapter.createAnswer(newValue);
+        adapter.setAnswer(List.of(newAnswer));
+        assertEquals(1, adapter.getAnswer().size());
+        assertEquals(newValue, adapter.getAnswer().get(0).getValue());
+    }
+
+    @Test
+    void testItem() {
+        var item = new QuestionnaireResponseItemComponent();
+        var item1 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("1"));
+        var item2 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("2"));
+        var item3 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("3"));
+        var item4 = adapterFactory.createQuestionnaireResponseItem(new QuestionnaireResponseItemComponent("4"));
+        item.addItem((QuestionnaireResponseItemComponent) item1.get());
+        item.addItem((QuestionnaireResponseItemComponent) item2.get());
+        var adapter = adapterFactory.createQuestionnaireResponseItem(item);
+        assertTrue(adapter.hasItem());
+        assertEquals(2, adapter.getItem().size());
+        adapter.addItem(item3);
+        assertEquals(3, adapter.getItem().size());
+        adapter.setItem(List.of(item1));
+        assertEquals(1, adapter.getItem().size());
+        adapter.addItems(List.of(item2, item3, item4));
+        assertEquals(4, adapter.getItem().size());
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/RequestActionAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/RequestActionAdapterTest.java
@@ -17,10 +17,10 @@ import org.hl7.fhir.r5.model.RequestOrchestration.RequestOrchestrationActionComp
 import org.junit.jupiter.api.Test;
 
 class RequestActionAdapterTest {
+    private final org.opencds.cqf.fhir.utility.adapter.IAdapterFactory adapterFactory = new AdapterFactory();
 
     @Test
     void invalid_object_fails() {
-        var adapterFactory = new AdapterFactory();
         var action = new PlanDefinitionActionComponent();
         assertThrows(IllegalArgumentException.class, () -> adapterFactory.createRequestAction(action));
     }
@@ -28,7 +28,8 @@ class RequestActionAdapterTest {
     @Test
     void test() {
         var action = new RequestOrchestrationActionComponent();
-        var adapter = new RequestActionAdapter(action);
+        var adapter = adapterFactory.createRequestAction(action);
+        assertNotNull(adapterFactory.createBase(action));
         assertNotNull(adapter);
         assertEquals(action, adapter.get());
         assertEquals(FhirVersionEnum.R5, adapter.fhirContext().getVersion().getVersion());

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/StructureDefinitionAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/StructureDefinitionAdapterTest.java
@@ -16,7 +16,6 @@ import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import java.time.LocalDate;
 import java.util.Date;
 import java.util.List;
-import org.hl7.fhir.instance.model.api.IDomainResource;
 import org.hl7.fhir.r5.model.DateTimeType;
 import org.hl7.fhir.r5.model.DateType;
 import org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent;
@@ -39,7 +38,7 @@ class StructureDefinitionAdapterTest {
     void invalid_object_fails() {
         var library = new Library();
         assertThrows(IllegalArgumentException.class, () -> new StructureDefinitionAdapter(library));
-        assertNotNull(new StructureDefinitionAdapter((IDomainResource) new StructureDefinition()));
+        assertNotNull(adapterFactory.createStructureDefinition(new StructureDefinition()));
     }
 
     @Test
@@ -207,6 +206,9 @@ class StructureDefinitionAdapterTest {
     void adapter_get_elements() {
         var baseDefinition = "http://hl7.org/fhir/Observation";
         var structureDef = new StructureDefinition().setBaseDefinition(baseDefinition);
+        structureDef.getSnapshot().addElement().setPath("Observation");
+        structureDef.getSnapshot().addElement().setPath("Observation.id");
+        structureDef.getDifferential().addElement().setPath("Observation");
         structureDef
                 .getDifferential()
                 .addElement()
@@ -220,10 +222,10 @@ class StructureDefinitionAdapterTest {
                 .addType()
                 .setCode("Quantity");
         var adapter = (IStructureDefinitionAdapter) adapterFactory.createKnowledgeArtifactAdapter(structureDef);
-        assertFalse(adapter.hasSnapshot());
+        assertTrue(adapter.hasSnapshot());
         assertEquals(baseDefinition, adapter.getBaseDefinition().getValue());
         var snapshotElements = adapter.getSnapshotElements();
-        assertEquals(0, snapshotElements.size());
+        assertEquals(1, snapshotElements.size());
         var differentialElements = adapter.getDifferentialElements();
         assertEquals(2, differentialElements.size());
     }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/StructureDefinitionAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/StructureDefinitionAdapterTest.java
@@ -205,10 +205,23 @@ class StructureDefinitionAdapterTest {
 
     @Test
     void adapter_get_elements() {
-        var structureDef = new StructureDefinition();
-        structureDef.getDifferential().addElement().addType().setCode("String");
-        structureDef.getDifferential().addElement().addType().setCode("Quantity");
+        var baseDefinition = "http://hl7.org/fhir/Observation";
+        var structureDef = new StructureDefinition().setBaseDefinition(baseDefinition);
+        structureDef
+                .getDifferential()
+                .addElement()
+                .setPath("Observation.code")
+                .addType()
+                .setCode("String");
+        structureDef
+                .getDifferential()
+                .addElement()
+                .setPath("Observation.value")
+                .addType()
+                .setCode("Quantity");
         var adapter = (IStructureDefinitionAdapter) adapterFactory.createKnowledgeArtifactAdapter(structureDef);
+        assertFalse(adapter.hasSnapshot());
+        assertEquals(baseDefinition, adapter.getBaseDefinition().getValue());
         var snapshotElements = adapter.getSnapshotElements();
         assertEquals(0, snapshotElements.size());
         var differentialElements = adapter.getDifferentialElements();

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/ValueSetConceptReferenceAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/r5/ValueSetConceptReferenceAdapterTest.java
@@ -35,4 +35,12 @@ class ValueSetConceptReferenceAdapterTest {
         assertTrue(adapter.hasCode());
         assertEquals(code, adapter.getCode());
     }
+
+    @Test
+    void testDisplay() {
+        var display = "test";
+        var conceptRef = new ValueSet.ConceptReferenceComponent().setDisplay(display);
+        var adapter = new ValueSetConceptReferenceAdapter(conceptRef);
+        assertEquals(display, adapter.getDisplay());
+    }
 }


### PR DESCRIPTION
Add adapters for Questionnaires and change the Questionnaire and QuestionnaireResponse processors to use them.

Includes a change to the messages extension used to convey errors during processing from "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-messages" to "http://hl7.org/fhir/StructureDefinition/cqf-messages".

Also includes general cleanup of warnings.