### PR TITLE
Add validation for duplicate population IDs within measure groups

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/dstu3/Dstu3MeasureDefBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/dstu3/Dstu3MeasureDefBuilder.java
@@ -6,7 +6,10 @@ import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.IM
 
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Coding;
@@ -34,6 +37,9 @@ public class Dstu3MeasureDefBuilder implements MeasureDefBuilder<Measure> {
     @Override
     public MeasureDef build(Measure measure) {
         checkId(measure);
+
+        // Validate unique population IDs within each group
+        validateUniquePopulationIds(measure);
 
         // SDES
         List<SdeDef> sdes = new ArrayList<>();
@@ -141,6 +147,37 @@ public class Dstu3MeasureDefBuilder implements MeasureDefBuilder<Measure> {
         }
     }
 
+    /**
+     * Validates that all population IDs within each group are unique.
+     *
+     * @param measure the Measure to validate
+     * @throws InvalidRequestException if duplicate population IDs exist within a group
+     */
+    private void validateUniquePopulationIds(Measure measure) {
+        String measureIdentifier = measure.hasUrl() ? measure.getUrl() : measure.getId();
+
+        for (int groupIndex = 0; groupIndex < measure.getGroup().size(); groupIndex++) {
+            MeasureGroupComponent group = measure.getGroup().get(groupIndex);
+            String groupIdentifier = group.hasId() ? group.getId() : "group-" + (groupIndex + 1);
+
+            Set<String> seenPopulationIds = new HashSet<>();
+
+            for (MeasureGroupPopulationComponent population : group.getPopulation()) {
+                String populationId = population.getId();
+
+                // Skip null/blank IDs - they will be caught by checkId() validation
+                if (populationId == null || populationId.isBlank()) {
+                    continue;
+                }
+
+                if (!seenPopulationIds.add(populationId)) {
+                    throw new InvalidRequestException("Duplicate population ID '%s' found in %s of Measure: %s"
+                            .formatted(populationId, groupIdentifier, measureIdentifier));
+                }
+            }
+        }
+    }
+
     private void validateImprovementNotationCode(Measure measure, CodeDef improvementNotation) {
         if (improvementNotation != null) {
             var code = improvementNotation.code();
@@ -185,10 +222,7 @@ public class Dstu3MeasureDefBuilder implements MeasureDefBuilder<Measure> {
     }
 
     private CodeDef getImprovementNotation(CodeDef measureImpNotation) {
-        if (measureImpNotation != null) {
-            return measureImpNotation;
-        } else {
-            return new CodeDef(null, IMPROVEMENT_NOTATION_SYSTEM_INCREASE);
-        }
+        return Objects.requireNonNullElseGet(
+                measureImpNotation, () -> new CodeDef(null, IMPROVEMENT_NOTATION_SYSTEM_INCREASE));
     }
 }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/dstu3/InvalidMeasureTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/dstu3/InvalidMeasureTest.java
@@ -36,7 +36,19 @@ class InvalidMeasureTest {
                 .when()
                 .measureId("LibraryMissingContent")
                 .evaluate();
-        var e = assertThrows(IllegalStateException.class, () -> when.then());
+        var e = assertThrows(IllegalStateException.class, when::then);
         assertTrue(e.getMessage().contains("Unable to load CQL/ELM for library"));
+    }
+
+    @Test
+    void evaluateThrowsErrorWithDuplicatePopulationIds() {
+        var when = GIVEN_INVALID_MEASURE_REPO
+                .when()
+                .measureId("DuplicatePopulationIds")
+                .evaluate();
+        var e = assertThrows(InvalidRequestException.class, when::then);
+        assertTrue(e.getMessage().contains("Duplicate population ID"));
+        assertTrue(e.getMessage().contains("initial-population"));
+        assertTrue(e.getMessage().contains("group-1"));
     }
 }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/InvalidMeasureTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/InvalidMeasureTest.java
@@ -39,4 +39,16 @@ class InvalidMeasureTest {
         var e = assertThrows(IllegalStateException.class, when::then);
         assertTrue(e.getMessage().contains("Unable to load CQL/ELM for libraries"));
     }
+
+    @Test
+    void evaluateThrowsErrorWithDuplicatePopulationIds() {
+        var when = GIVEN_INVALID_MEASURE_REPO
+                .when()
+                .measureId("DuplicatePopulationIds")
+                .evaluate();
+        var e = assertThrows(InvalidRequestException.class, when::then);
+        assertTrue(e.getMessage().contains("Duplicate population ID"));
+        assertTrue(e.getMessage().contains("initial-population"));
+        assertTrue(e.getMessage().contains("group-1"));
+    }
 }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureScoringTypeRatioContVariableTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureScoringTypeRatioContVariableTest.java
@@ -1,7 +1,9 @@
 package org.opencds.cqf.fhir.cr.measure.r4;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import org.hl7.fhir.r4.model.MeasureReport.MeasureReportStatus;
 import org.junit.jupiter.api.Test;
 import org.opencds.cqf.fhir.cr.measure.common.ContinuousVariableObservationAggregateMethod;
@@ -1198,16 +1200,14 @@ class MeasureScoringTypeRatioContVariableTest {
      */
     @Test
     void ratioContinuousVariableBadDenDef() {
-        try {
-            given.when()
-                    .measureId("RatioContVarResourceSumError2")
-                    .subject("Patient/patient-9")
-                    .evaluate()
-                    .then()
-                    .report();
-        } catch (Exception ex) {
-            assertTrue(ex.getMessage().contains("no matching criteria reference was found for extension"));
-        }
+        var expectedException = assertThrows(InvalidRequestException.class, () -> given.when()
+                .measureId("RatioContVarResourceSumError2")
+                .subject("Patient/patient-9")
+                .evaluate()
+                .then()
+                .report());
+
+        assertTrue(expectedException.getMessage().contains("no matching criteria reference was found for extension"));
     }
 
     /**

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasureServiceTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasureServiceTest.java
@@ -1,7 +1,9 @@
 package org.opencds.cqf.fhir.cr.measure.r4;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.ZoneId;
@@ -1081,5 +1083,22 @@ class MultiMeasureServiceTest {
                 .hasMeasureReportStatus(MeasureReportStatus.ERROR)
                 .hasContainedOperationOutcome()
                 .hasContainedOperationOutcomeMsg("Patient/female-1988-2");
+    }
+
+    @Test
+    void MultiMeasure_ThrowsErrorWithDuplicatePopulationIds() {
+        var givenInvalidRepo = MultiMeasure.given().repositoryFor("InvalidMeasure");
+
+        var when = givenInvalidRepo
+                .when()
+                .measureId("DuplicatePopulationIds")
+                .periodStart("2024-01-01")
+                .periodEnd("2024-12-31")
+                .reportType("population")
+                .evaluate();
+
+        var e = assertThrows(InvalidRequestException.class, when::then);
+        assertTrue(e.getMessage().contains("Duplicate population ID"));
+        assertTrue(e.getMessage().contains("initial-population"));
     }
 }

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/dstu3/InvalidMeasure/input/resources/measure/DuplicatePopulationIds.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/dstu3/InvalidMeasure/input/resources/measure/DuplicatePopulationIds.json
@@ -1,0 +1,57 @@
+{
+  "id": "DuplicatePopulationIds",
+  "resourceType": "Measure",
+  "url": "http://example.com/Measure/DuplicatePopulationIds",
+  "library": [
+    {
+      "reference": "Library/MinimalProportionBooleanBasisSingleGroup"
+    }
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "boolean"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "proportion"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": "Initial Population"
+        },
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "denominator",
+                "display": "Denominator"
+              }
+            ]
+          },
+          "criteria": "Denominator"
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/InvalidMeasure/input/resources/measure/DuplicatePopulationIds.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/InvalidMeasure/input/resources/measure/DuplicatePopulationIds.json
@@ -1,0 +1,61 @@
+{
+  "id": "DuplicatePopulationIds",
+  "resourceType": "Measure",
+  "url": "http://example.com/Measure/DuplicatePopulationIds",
+  "library": [
+    "http://example.com/Library/MinimalProportionBooleanBasisSingleGroup"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "boolean"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "proportion"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population"
+          }
+        },
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "denominator",
+                "display": "Denominator"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Denominator"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/RatioContVarResourceSumError2.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/RatioContVarResourceSumError2.json
@@ -125,7 +125,7 @@
           }
         },
         {
-          "id": "observation-num",
+          "id": "observation-den",
           "extension": [ {
             "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",
             "valueCode": "sum"


### PR DESCRIPTION
## Summary

This MR adds early validation to detect duplicate population IDs within measure groups during first-pass validation, before CQL evaluation begins. The validation ensures measures fail fast with a clear error message identifying the duplicate ID, affected group, and measure URL, preventing cryptic downstream errors during measure evaluation.

1. **First-pass validation for duplicate population IDs** - Added `validateUniquePopulationIds()` methods to R4 and DSTU3 measure def builders that check for duplicate non-null population IDs within each group and throw `InvalidRequestException` with descriptive error messages
2. **Null ID handling strategy** - The validation intentionally skips null/blank population IDs, allowing the existing `checkId()` validation to catch them first, ensuring proper validation ordering and preventing confusing "duplicate null ID" errors
3. **Test coverage for both single and multi-measure evaluation paths** - Added dedicated test measures and test cases covering both single-measure (`InvalidMeasureTest`) and multi-measure (`MultiMeasureServiceTest`) evaluation scenarios for R4 and DSTU3
4. **Fixed existing test measure with duplicate IDs** - Corrected `RatioContVarResourceSumError2.json` which had duplicate population IDs that would now be caught by validation, ensuring the test validates its intended scenario (invalid criteria reference)

## Code Review Suggestions

- [ ] **Validation timing and ordering** - Verify that `validateUniquePopulationIds()` is called at the correct point in the validation flow (after measure ID check, before SDE/group processing) in both `R4MeasureDefBuilder.triggerFirstPassValidation()` (line 342) and `Dstu3MeasureDefBuilder.build()` (line 41). Confirm this timing works correctly for both single-measure and multi-measure evaluation paths.

- [ ] **Null ID skip logic** - Review the decision to skip null/blank IDs in the duplicate validation (R4: line 416, DSTU3: line 169). Confirm this doesn't create a gap where multiple populations with null IDs could pass validation but cause issues later. The assumption is that `checkId()` catches these first, but verify this holds for all code paths (especially in DSTU3 where `checkId()` is called per-population during iteration rather than in first-pass validation).

- [ ] **Error message format and user experience** - Evaluate whether the error message format `"Duplicate population ID '%s' found in %s of Measure: %s"` provides sufficient context for users to fix their measures. Consider whether additional information (like population type or criteria expression) would help users identify which populations are duplicated, especially in large measures.

- [ ] **Cross-version consistency** - Verify that R4 and DSTU3 implementations have identical behavior for edge cases: measures with no groups, groups with no populations, unnamed groups, and measures with multiple groups where different groups have the same population IDs (which should be allowed per requirements).

- [ ] **Multi-measure evaluation impact** - Consider whether this validation could cause performance issues in multi-measure scenarios where hundreds of measures are validated. The HashSet approach is O(n) per group, but confirm this is acceptable for typical measure sizes and multi-measure batch sizes.

## QA Test Suggestions

### Setup
1. Set up a FHIR server with the clinical reasoning operations enabled
2. Ensure you have access to create/upload Measure resources
3. Have test patients and libraries available for measure evaluation

### Test Cases

- [ ] **Test duplicate population IDs within single group** - Create a Measure with a single group containing two populations with identical IDs (e.g., both named "initial-population"). Attempt to evaluate the measure via `$evaluate-measure`. Verify the operation fails with `InvalidRequestException` and the error message clearly identifies the duplicate ID, group identifier, and measure URL.

- [ ] **Test duplicate IDs across multiple groups (should succeed)** - Create a Measure with two groups, where each group has a population with the same ID (e.g., group-1 has "initial-population" and group-2 has "initial-population"). Verify this measure evaluates successfully, confirming validation is scoped to within each group only.

- [ ] **Test measure with all null population IDs** - Create a Measure where all population IDs are null/missing. Verify the measure fails with the existing "id is required" error message (not the duplicate ID error), confirming null ID validation occurs first.

- [ ] **Test measure with one null and one valid population ID** - Create a Measure with two populations where one has a null ID and one has a valid ID. Verify the measure fails with the "id is required" error for the null ID (not the duplicate ID error).

- [ ] **Test multi-measure evaluation with one invalid measure** - Use the multi-measure evaluation endpoint to evaluate multiple measures where one measure has duplicate population IDs. Verify the operation fails fast for that measure with the duplicate ID error, and confirm other measures in the batch are not evaluated (fail-fast behavior).

- [ ] **Test existing measures still work** - Run evaluation on several existing valid measures from the test suite (e.g., EXM105, proportion measures, ratio measures) to ensure the new validation doesn't break existing functionality or introduce performance regression.

- [ ] **Test measure with unnamed group** - Create a Measure with a group that has no ID, containing populations with duplicate IDs. Verify the error message uses the "group-N" format (e.g., "group-1") to identify the problematic group.

- [ ] **Test DSTU3 vs R4 consistency** - Perform the same duplicate ID validation test on both DSTU3 and R4 versions of the same measure and verify identical error messages and behavior across both FHIR versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)