### PR TITLE
Improve cqf-fhir-utility test coverage from 69% to 80%

### DIFF
--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/BundleHelperTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/BundleHelperTest.java
@@ -1,0 +1,407 @@
+package org.opencds.cqf.fhir.utility;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class BundleHelperTest {
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void newBundleDefaultType(FhirVersionEnum version) {
+        var bundle = BundleHelper.newBundle(version);
+        assertNotNull(bundle);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void newBundleWithType(FhirVersionEnum version) {
+        var bundle = BundleHelper.newBundle(version, "transaction");
+        assertNotNull(bundle);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void newBundleWithIdAndType(FhirVersionEnum version) {
+        var bundle = BundleHelper.newBundle(version, "test-id", "searchset");
+        assertNotNull(bundle);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void newBundleWithNullId(FhirVersionEnum version) {
+        var bundle = BundleHelper.newBundle(version, null, null);
+        assertNotNull(bundle);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void newBundleWithEmptyId(FhirVersionEnum version) {
+        var bundle = BundleHelper.newBundle(version, "", "");
+        assertNotNull(bundle);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void getEntryFirstRep(FhirVersionEnum version) {
+        var bundle = BundleHelper.newBundle(version);
+        var entry = BundleHelper.getEntryFirstRep(bundle);
+        assertNotNull(entry);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void getEntryResourceFirstRepEmptyBundle(FhirVersionEnum version) {
+        var bundle = BundleHelper.newBundle(version);
+        var resource = BundleHelper.getEntryResourceFirstRep(bundle);
+        assertNull(resource);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void getEntryResourceFirstRepWithResource(FhirVersionEnum version) {
+        var bundle = BundleHelper.newBundle(version);
+        var patient = createPatient(version);
+        var entry = BundleHelper.newEntryWithResource(patient);
+        BundleHelper.addEntry(bundle, entry);
+        var resource = BundleHelper.getEntryResourceFirstRep(bundle);
+        assertNotNull(resource);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void getEntryResources(FhirVersionEnum version) {
+        var bundle = BundleHelper.newBundle(version);
+        var patient = createPatient(version);
+        BundleHelper.addEntry(bundle, BundleHelper.newEntryWithResource(patient));
+        var resources = BundleHelper.getEntryResources(bundle);
+        assertEquals(1, resources.size());
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void getEntry(FhirVersionEnum version) {
+        var bundle = BundleHelper.newBundle(version);
+        var entries = BundleHelper.getEntry(bundle);
+        assertNotNull(entries);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void setEntry(FhirVersionEnum version) {
+        var bundle = BundleHelper.newBundle(version);
+        var patient = createPatient(version);
+        var entry = BundleHelper.newEntryWithResource(patient);
+        BundleHelper.setEntry(bundle, List.of(entry));
+        assertEquals(1, BundleHelper.getEntry(bundle).size());
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void getEntryResource(FhirVersionEnum version) {
+        var patient = createPatient(version);
+        var entry = BundleHelper.newEntryWithResource(patient);
+        var resource = BundleHelper.getEntryResource(version, entry);
+        assertNotNull(resource);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void setBundleType(FhirVersionEnum version) {
+        var bundle = BundleHelper.newBundle(version);
+        var result = BundleHelper.setBundleType(bundle, "transaction");
+        assertNotNull(result);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void setBundleTotal(FhirVersionEnum version) {
+        var bundle = BundleHelper.newBundle(version);
+        var result = BundleHelper.setBundleTotal(bundle, 42);
+        assertNotNull(result);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void newEntry(FhirVersionEnum version) {
+        var entry = BundleHelper.newEntry(version);
+        assertNotNull(entry);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void newEntryWithResponse(FhirVersionEnum version) {
+        var response = BundleHelper.newResponseWithLocation(version, "Patient/123");
+        var entry = BundleHelper.newEntryWithResponse(version, response);
+        assertNotNull(entry);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void newResponseWithLocation(FhirVersionEnum version) {
+        var response = BundleHelper.newResponseWithLocation(version, "Patient/123");
+        assertNotNull(response);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void newRequestWithMethodAndUrl(FhirVersionEnum version) {
+        var request = BundleHelper.newRequest(version, "PUT", "Patient/123");
+        assertNotNull(request);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void newRequestWithMethodOnly(FhirVersionEnum version) {
+        var request = BundleHelper.newRequest(version, "POST");
+        assertNotNull(request);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void setRequestUrl(FhirVersionEnum version) {
+        var request = BundleHelper.newRequest(version, "PUT");
+        var result = BundleHelper.setRequestUrl(version, request, "Patient/456");
+        assertNotNull(result);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void setRequestIfNoneExist(FhirVersionEnum version) {
+        var request = BundleHelper.newRequest(version, "POST");
+        var result = BundleHelper.setRequestIfNoneExist(version, request, "identifier=123");
+        assertNotNull(result);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void setEntryFullUrl(FhirVersionEnum version) {
+        var entry = BundleHelper.newEntry(version);
+        var result = BundleHelper.setEntryFullUrl(version, entry, "urn:uuid:1234");
+        assertNotNull(result);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void setEntryRequest(FhirVersionEnum version) {
+        var entry = BundleHelper.newEntry(version);
+        var request = BundleHelper.newRequest(version, "PUT", "Patient/123");
+        var result = BundleHelper.setEntryRequest(version, entry, request);
+        assertNotNull(result);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void setEntryRequestNull(FhirVersionEnum version) {
+        var entry = BundleHelper.newEntry(version);
+        var result = BundleHelper.setEntryRequest(version, entry, null);
+        assertNotNull(result);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void isEntryRequestPut(FhirVersionEnum version) {
+        var entry = BundleHelper.newEntry(version);
+        var request = BundleHelper.newRequest(version, "PUT", "Patient/123");
+        BundleHelper.setEntryRequest(version, entry, request);
+        assertTrue(BundleHelper.isEntryRequestPut(version, entry));
+        assertFalse(BundleHelper.isEntryRequestPost(version, entry));
+        assertFalse(BundleHelper.isEntryRequestDelete(version, entry));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void isEntryRequestPost(FhirVersionEnum version) {
+        var entry = BundleHelper.newEntry(version);
+        var request = BundleHelper.newRequest(version, "POST", "Patient");
+        BundleHelper.setEntryRequest(version, entry, request);
+        assertTrue(BundleHelper.isEntryRequestPost(version, entry));
+        assertFalse(BundleHelper.isEntryRequestPut(version, entry));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void isEntryRequestDelete(FhirVersionEnum version) {
+        var entry = BundleHelper.newEntry(version);
+        var request = BundleHelper.newRequest(version, "DELETE", "Patient/123");
+        BundleHelper.setEntryRequest(version, entry, request);
+        assertTrue(BundleHelper.isEntryRequestDelete(version, entry));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void isEntryRequestNoRequest(FhirVersionEnum version) {
+        var entry = BundleHelper.newEntry(version);
+        assertFalse(BundleHelper.isEntryRequestPut(version, entry));
+        assertFalse(BundleHelper.isEntryRequestPost(version, entry));
+        assertFalse(BundleHelper.isEntryRequestDelete(version, entry));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void getEntryRequestUrl(FhirVersionEnum version) {
+        var entry = BundleHelper.newEntry(version);
+        var request = BundleHelper.newRequest(version, "PUT", "Patient/123");
+        BundleHelper.setEntryRequest(version, entry, request);
+        assertEquals("Patient/123", BundleHelper.getEntryRequestUrl(version, entry));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void getEntryRequestId(FhirVersionEnum version) {
+        var entry = BundleHelper.newEntry(version);
+        var request = BundleHelper.newRequest(version, "PUT", "Patient/123");
+        BundleHelper.setEntryRequest(version, entry, request);
+        var id = BundleHelper.getEntryRequestId(version, entry);
+        assertTrue(id.isPresent());
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void getBundleEntryResourceIds(FhirVersionEnum version) {
+        var bundle = BundleHelper.newBundle(version);
+        var ids = BundleHelper.getBundleEntryResourceIds(version, bundle);
+        assertTrue(ids.isEmpty());
+    }
+
+    @Test
+    void getBundleEntryResourceIdsWithContext() {
+        var ctx = FhirContext.forR4Cached();
+        var bundle = BundleHelper.newBundle(FhirVersionEnum.R4);
+        var patient = new org.hl7.fhir.r4.model.Patient();
+        patient.setId("test-123");
+        BundleHelper.addEntry(bundle, BundleHelper.newEntryWithResource(patient));
+        var ids = BundleHelper.getBundleEntryResourceIds(ctx, bundle);
+        assertEquals(1, ids.size());
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void resourceToRuntimeSearchParam(FhirVersionEnum version) {
+        var sp = createSearchParameter(version);
+        var result = BundleHelper.resourceToRuntimeSearchParam(sp);
+        assertNotNull(result);
+        assertEquals("test-code", result.getName());
+    }
+
+    @Test
+    void unsupportedVersionThrows() {
+        assertThrows(IllegalArgumentException.class, () -> BundleHelper.newBundle(FhirVersionEnum.DSTU2));
+    }
+
+    private org.hl7.fhir.instance.model.api.IBaseResource createPatient(FhirVersionEnum version) {
+        return switch (version) {
+            case DSTU3 -> new org.hl7.fhir.dstu3.model.Patient().setId("test");
+            case R4 -> new org.hl7.fhir.r4.model.Patient().setId("test");
+            case R5 -> new org.hl7.fhir.r5.model.Patient().setId("test");
+            default -> throw new IllegalArgumentException("Unsupported");
+        };
+    }
+
+    private org.hl7.fhir.instance.model.api.IBaseResource createSearchParameter(FhirVersionEnum version) {
+        return switch (version) {
+            case DSTU3 -> {
+                var sp = new org.hl7.fhir.dstu3.model.SearchParameter();
+                sp.setId("test-sp");
+                sp.setUrl("http://example.org/sp");
+                sp.setCode("test-code");
+                sp.setDescription("Test");
+                sp.setExpression("Patient.name");
+                yield sp;
+            }
+            case R4 -> {
+                var sp = new org.hl7.fhir.r4.model.SearchParameter();
+                sp.setId("test-sp");
+                sp.setUrl("http://example.org/sp");
+                sp.setCode("test-code");
+                sp.setDescription("Test");
+                sp.setExpression("Patient.name");
+                yield sp;
+            }
+            case R5 -> {
+                var sp = new org.hl7.fhir.r5.model.SearchParameter();
+                sp.setId("test-sp");
+                sp.setUrl("http://example.org/sp");
+                sp.setCode("test-code");
+                sp.setDescription("Test");
+                sp.setExpression("Patient.name");
+                yield sp;
+            }
+            default -> throw new IllegalArgumentException("Unsupported");
+        };
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/IdsTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/IdsTest.java
@@ -2,11 +2,12 @@ package org.opencds.cqf.fhir.utility;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
-import org.hl7.fhir.instance.model.api.IIdType;
 import org.junit.jupiter.api.Test;
 
 class IdsTest {
@@ -22,13 +23,13 @@ class IdsTest {
 
     @Test
     void contextSupported() {
-        IIdType id = Ids.newId(FhirContext.forDstu3Cached(), "Patient/123");
+        var id = Ids.newId(FhirContext.forDstu3Cached(), "Patient/123");
         assertTrue(id instanceof org.hl7.fhir.dstu3.model.IdType);
     }
 
     @Test
     void partsSupported() {
-        IIdType id = Ids.newId(FhirVersionEnum.DSTU3, "Patient", "123");
+        var id = Ids.newId(FhirVersionEnum.DSTU3, "Patient", "123");
         assertTrue(id instanceof org.hl7.fhir.dstu3.model.IdType);
 
         assertEquals("Patient", id.getResourceType());
@@ -37,9 +38,81 @@ class IdsTest {
 
     @Test
     void classSupported() {
-        IIdType id = Ids.newId(org.hl7.fhir.dstu3.model.Library.class, "123");
+        var id = Ids.newId(org.hl7.fhir.dstu3.model.Library.class, "123");
         assertTrue(id instanceof org.hl7.fhir.dstu3.model.IdType);
         assertEquals("Library", id.getResourceType());
         assertEquals("123", id.getIdPart());
+    }
+
+    @Test
+    void ensureIdTypeWithSlash() {
+        assertEquals("Patient/123", Ids.ensureIdType("Patient/123", "Patient"));
+    }
+
+    @Test
+    void ensureIdTypeWithoutSlash() {
+        assertEquals("Patient/123", Ids.ensureIdType("123", "Patient"));
+    }
+
+    @Test
+    void newIdWithContext() {
+        var id = Ids.newId(FhirContext.forR4Cached(), "Patient", "456");
+        assertTrue(id instanceof org.hl7.fhir.r4.model.IdType);
+        assertEquals("Patient", id.getResourceType());
+        assertEquals("456", id.getIdPart());
+    }
+
+    @Test
+    void newRandomId() {
+        var id = Ids.newRandomId(FhirContext.forR4Cached(), "Patient");
+        assertNotNull(id);
+        assertEquals("Patient", id.getResourceType());
+        assertNotNull(id.getIdPart());
+    }
+
+    @Test
+    void newIdWithBaseTypeClass() {
+        var id = Ids.newId(org.hl7.fhir.r4.model.StringType.class, "Library", "test-123");
+        assertTrue(id instanceof org.hl7.fhir.r4.model.IdType);
+        assertEquals("Library", id.getResourceType());
+        assertEquals("test-123", id.getIdPart());
+    }
+
+    @Test
+    void simpleFromResource() {
+        var patient = new org.hl7.fhir.r4.model.Patient();
+        patient.setId("Patient/123");
+        assertEquals("Patient/123", Ids.simple(patient));
+    }
+
+    @Test
+    void simpleFromIdType() {
+        var id = new org.hl7.fhir.r4.model.IdType("Patient/123");
+        assertEquals("Patient/123", Ids.simple(id));
+    }
+
+    @Test
+    void simplePartFromResource() {
+        var patient = new org.hl7.fhir.r4.model.Patient();
+        patient.setId("Patient/123");
+        assertEquals("123", Ids.simplePart(patient));
+    }
+
+    @Test
+    void simplePartFromIdType() {
+        var id = new org.hl7.fhir.r4.model.IdType("Patient/123");
+        assertEquals("123", Ids.simplePart(id));
+    }
+
+    @Test
+    void simpleThrowsForIdWithoutResourceType() {
+        var id = new org.hl7.fhir.r4.model.IdType("123");
+        assertThrows(IllegalArgumentException.class, () -> Ids.simple(id));
+    }
+
+    @Test
+    void r5Version() {
+        var id = Ids.newId(FhirVersionEnum.R5, "Patient/789");
+        assertTrue(id instanceof org.hl7.fhir.r5.model.IdType);
     }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/PackageHelperTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/PackageHelperTest.java
@@ -10,11 +10,13 @@ import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.List;
 import org.hl7.fhir.r4.model.IntegerType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class PackageHelperTest {
 
     @Test
-    void testPackageParameters() {
+    void packageParametersWithAllFields() {
         var actual = packageParameters(
                 FhirVersionEnum.R4, new IntegerType(1), new IntegerType(1), "searchset", null, null, false);
         assertInstanceOf(org.hl7.fhir.r4.model.Parameters.class, actual);
@@ -27,7 +29,7 @@ class PackageHelperTest {
     }
 
     @Test
-    void testR4PackageParametersIncludeOnly() {
+    void r4PackageParametersIncludeOnly() {
         var actual = packageParameters(
                 FhirVersionEnum.R4, null, null, null, List.of("PlanDefinition", "ValueSet"), null, false);
         assertInstanceOf(org.hl7.fhir.r4.model.Parameters.class, actual);
@@ -42,7 +44,7 @@ class PackageHelperTest {
     }
 
     @Test
-    void testR5PackageParametersIncludeOnly() {
+    void r5PackageParametersIncludeOnly() {
         var actual = packageParameters(
                 FhirVersionEnum.R5, null, null, null, List.of("PlanDefinition", "ValueSet"), null, false);
         assertInstanceOf(org.hl7.fhir.r5.model.Parameters.class, actual);
@@ -54,5 +56,88 @@ class PackageHelperTest {
                         .size());
         assertFalse(((org.hl7.fhir.r5.model.Parameters) actual).hasParameter("terminologyEndpoint"));
         assertTrue(((org.hl7.fhir.r5.model.Parameters) actual).hasParameter("isPut"));
+    }
+
+    @Test
+    void createEntryWithPutR4() {
+        var vs = new org.hl7.fhir.r4.model.ValueSet();
+        vs.setId("test-vs");
+        vs.setUrl("http://example.org/ValueSet/test");
+        vs.setVersion("1.0");
+        var entry = PackageHelper.createEntry(vs, true);
+        var r4Entry = (org.hl7.fhir.r4.model.Bundle.BundleEntryComponent) entry;
+        assertEquals("PUT", r4Entry.getRequest().getMethod().toCode());
+        assertTrue(r4Entry.getRequest().getUrl().contains("test-vs"));
+        assertEquals("http://example.org/ValueSet/test", r4Entry.getFullUrl());
+    }
+
+    @Test
+    void createEntryWithPostR4() {
+        var vs = new org.hl7.fhir.r4.model.ValueSet();
+        vs.setId("test-vs");
+        vs.setUrl("http://example.org/ValueSet/test");
+        vs.setVersion("1.0");
+        var entry = PackageHelper.createEntry(vs, false);
+        var r4Entry = (org.hl7.fhir.r4.model.Bundle.BundleEntryComponent) entry;
+        assertEquals("POST", r4Entry.getRequest().getMethod().toCode());
+        assertTrue(r4Entry.getRequest().getIfNoneExist().contains("url="));
+        assertTrue(r4Entry.getRequest().getIfNoneExist().contains("version=1.0"));
+    }
+
+    @Test
+    void createEntryPostWithoutVersion() {
+        var vs = new org.hl7.fhir.r4.model.ValueSet();
+        vs.setUrl("http://example.org/ValueSet/test");
+        var entry = PackageHelper.createEntry(vs, false);
+        var r4Entry = (org.hl7.fhir.r4.model.Bundle.BundleEntryComponent) entry;
+        assertTrue(r4Entry.getRequest().getIfNoneExist().startsWith("url="));
+        assertFalse(r4Entry.getRequest().getIfNoneExist().contains("version="));
+    }
+
+    @Test
+    void createEntryNonMetadataResource() {
+        var patient = new org.hl7.fhir.r4.model.Patient();
+        patient.setId("p1");
+        var entry = PackageHelper.createEntry(patient, true);
+        var r4Entry = (org.hl7.fhir.r4.model.Bundle.BundleEntryComponent) entry;
+        assertEquals("PUT", r4Entry.getRequest().getMethod().toCode());
+        assertEquals("Patient/p1", r4Entry.getRequest().getUrl());
+    }
+
+    @Test
+    void deleteEntry() {
+        var vs = new org.hl7.fhir.r4.model.ValueSet();
+        vs.setId("test-vs");
+        var entry = PackageHelper.deleteEntry(vs);
+        var r4Entry = (org.hl7.fhir.r4.model.Bundle.BundleEntryComponent) entry;
+        assertEquals("DELETE", r4Entry.getRequest().getMethod().toCode());
+        assertEquals("ValueSet/test-vs", r4Entry.getRequest().getUrl());
+    }
+
+    @Test
+    void createEntryR5() {
+        var vs = new org.hl7.fhir.r5.model.ValueSet();
+        vs.setId("r5-vs");
+        vs.setUrl("http://example.org/ValueSet/r5");
+        var entry = PackageHelper.createEntry(vs, true);
+        assertInstanceOf(org.hl7.fhir.r5.model.Bundle.BundleEntryComponent.class, entry);
+    }
+
+    @Test
+    void createEntryDstu3() {
+        var vs = new org.hl7.fhir.dstu3.model.ValueSet();
+        vs.setId("dstu3-vs");
+        vs.setUrl("http://example.org/ValueSet/dstu3");
+        var entry = PackageHelper.createEntry(vs, false);
+        assertInstanceOf(org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent.class, entry);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = FhirVersionEnum.class,
+            names = {"DSTU3", "R4", "R5"})
+    void packageParametersMinimal(FhirVersionEnum version) {
+        var params = PackageHelper.packageParameters(version, null, false);
+        assertInstanceOf(org.hl7.fhir.instance.model.api.IBaseParameters.class, params);
     }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/ParametersCreationTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/ParametersCreationTest.java
@@ -1,0 +1,190 @@
+package org.opencds.cqf.fhir.utility;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.Test;
+
+class ParametersCreationTest {
+
+    private static final FhirContext CTX = FhirContext.forR4Cached();
+
+    @Test
+    void newParametersWithParts() {
+        var part = Parameters.newPart(CTX, "testParam");
+        var params = Parameters.newParameters(CTX, part);
+        assertNotNull(params);
+    }
+
+    @Test
+    void newParametersWithIdType() {
+        var part = Parameters.newPart(CTX, "testParam");
+        var params = Parameters.newParameters(CTX, new IdType("test-id"), part);
+        assertNotNull(params);
+        assertEquals("test-id", params.getIdElement().getIdPart());
+    }
+
+    @Test
+    void newParametersWithStringId() {
+        var params = Parameters.newParameters(CTX, "test-id");
+        assertNotNull(params);
+    }
+
+    @Test
+    void newPartWithTypeName() {
+        var part = Parameters.newPart(CTX, "string", "myParam", "myValue");
+        assertNotNull(part);
+    }
+
+    @Test
+    void newPartWithTypeClass() {
+        var part = Parameters.newPart(CTX, StringType.class, "myParam", "myValue");
+        assertNotNull(part);
+    }
+
+    @Test
+    void newPartWithResource() {
+        var patient = new Patient();
+        patient.setId("test");
+        var part = Parameters.newPart(CTX, "myParam", patient);
+        assertNotNull(part);
+    }
+
+    @Test
+    void newStringPart() {
+        var part = Parameters.newStringPart(CTX, "name", "value");
+        assertNotNull(part);
+    }
+
+    @Test
+    void newBooleanPart() {
+        var part = Parameters.newBooleanPart(CTX, "flag", true);
+        assertNotNull(part);
+    }
+
+    @Test
+    void newIntegerPart() {
+        var part = Parameters.newIntegerPart(CTX, "count", 42);
+        assertNotNull(part);
+    }
+
+    @Test
+    void newCodePart() {
+        var part = Parameters.newCodePart(CTX, "status", "active");
+        assertNotNull(part);
+    }
+
+    @Test
+    void newUriPart() {
+        var part = Parameters.newUriPart(CTX, "url", "http://example.org");
+        assertNotNull(part);
+    }
+
+    @Test
+    void newDatePart() {
+        var part = Parameters.newDatePart(CTX, "date", "2024-01-01");
+        assertNotNull(part);
+    }
+
+    @Test
+    void newDecimalPart() {
+        var part = Parameters.newDecimalPart(CTX, "value", 3.14);
+        assertNotNull(part);
+    }
+
+    @Test
+    void newCanonicalPart() {
+        var part = Parameters.newCanonicalPart(CTX, "ref", "http://example.org/Library/test");
+        assertNotNull(part);
+    }
+
+    @Test
+    void newBase64BinaryPart() {
+        var part = Parameters.newBase64BinaryPart(CTX, "data", "dGVzdA==");
+        assertNotNull(part);
+    }
+
+    @Test
+    void newDateTimePart() {
+        var part = Parameters.newDateTimePart(CTX, "timestamp", "2024-01-01T00:00:00Z");
+        assertNotNull(part);
+    }
+
+    @Test
+    void newIdPart() {
+        var part = Parameters.newIdPart(CTX, "id", "test-123");
+        assertNotNull(part);
+    }
+
+    @Test
+    void newMarkdownPart() {
+        var part = Parameters.newMarkdownPart(CTX, "text", "# Hello");
+        assertNotNull(part);
+    }
+
+    @Test
+    void newOidPart() {
+        var part = Parameters.newOidPart(CTX, "oid", "urn:oid:1.2.3");
+        assertNotNull(part);
+    }
+
+    @Test
+    void newPositiveIntPart() {
+        var part = Parameters.newPositiveIntPart(CTX, "count", 1);
+        assertNotNull(part);
+    }
+
+    @Test
+    void newUnsignedIntPart() {
+        var part = Parameters.newUnsignedIntPart(CTX, "count", 0);
+        assertNotNull(part);
+    }
+
+    @Test
+    void newUrlPart() {
+        var part = Parameters.newUrlPart(CTX, "endpoint", "http://example.org");
+        assertNotNull(part);
+    }
+
+    @Test
+    void newTimePart() {
+        var part = Parameters.newTimePart(CTX, "time", "12:00:00");
+        assertNotNull(part);
+    }
+
+    @Test
+    void newUuidPart() {
+        var part = Parameters.newUuidPart(CTX, "uuid", "urn:uuid:12345");
+        assertNotNull(part);
+    }
+
+    @Test
+    void getSingularStringPart() {
+        var params = new org.hl7.fhir.r4.model.Parameters();
+        params.addParameter().setName("test").setValue(new StringType("hello"));
+        var result = Parameters.getSingularStringPart(CTX, params, "test");
+        assertTrue(result.isPresent());
+        assertEquals("hello", result.get());
+    }
+
+    @Test
+    void getSingularStringPartNotFound() {
+        var params = new org.hl7.fhir.r4.model.Parameters();
+        var result = Parameters.getSingularStringPart(CTX, params, "missing");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getPartsByName() {
+        var params = new org.hl7.fhir.r4.model.Parameters();
+        params.addParameter().setName("test").setValue(new StringType("hello"));
+        var result = Parameters.getPartsByName(CTX, params, "test");
+        assertNotNull(result);
+        assertEquals(1, result.size());
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/ResourcesTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/ResourcesTest.java
@@ -1,9 +1,14 @@
 package org.opencds.cqf.fhir.utility;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ca.uhn.fhir.context.FhirVersionEnum;
 import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.Test;
 
 class ResourcesTest {
@@ -24,5 +29,74 @@ class ResourcesTest {
         var lib = new Library();
         var s = Resources.stringify(lib);
         assertTrue(s.contains("Library"));
+    }
+
+    @Test
+    void castOrThrowNull() {
+        var result = Resources.castOrThrow(null, Patient.class, "error");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void castOrThrowValid() {
+        var patient = new Patient();
+        var result = Resources.castOrThrow(patient, Patient.class, "error");
+        assertTrue(result.isPresent());
+        assertEquals(patient, result.get());
+    }
+
+    @Test
+    void castOrThrowInvalid() {
+        var library = new Library();
+        assertThrows(IllegalArgumentException.class, () -> Resources.castOrThrow(library, Patient.class, "wrong type"));
+    }
+
+    @Test
+    void newResourceWithId() {
+        var patient = Resources.newResource(Patient.class, "123");
+        assertNotNull(patient);
+        assertEquals("123", patient.getIdElement().getIdPart());
+    }
+
+    @Test
+    void newResourceWithIdContainingSlashThrows() {
+        assertThrows(IllegalArgumentException.class, () -> Resources.newResource(Patient.class, "Patient/123"));
+    }
+
+    @Test
+    void newResourceWithoutId() {
+        var patient = Resources.newResource(Patient.class);
+        assertNotNull(patient);
+    }
+
+    @Test
+    void newBackboneElement() {
+        var entry = Resources.newBackboneElement(org.hl7.fhir.r4.model.Bundle.BundleEntryComponent.class);
+        assertNotNull(entry);
+    }
+
+    @Test
+    void newBaseForVersion() {
+        var patient = Resources.newBaseForVersion("Patient", FhirVersionEnum.R4);
+        assertNotNull(patient);
+    }
+
+    @Test
+    void newBase() {
+        var patient = Resources.newBase(Patient.class);
+        assertNotNull(patient);
+    }
+
+    @Test
+    void getClassForTypeAndVersion() {
+        var clazz = Resources.getClassForTypeAndVersion("Patient", FhirVersionEnum.R4);
+        assertEquals(Patient.class, clazz);
+    }
+
+    @Test
+    void getClassForTypeAndVersionInvalid() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> Resources.getClassForTypeAndVersion("NonExistentType", FhirVersionEnum.R4));
     }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/ValidationProfileTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/ValidationProfileTest.java
@@ -1,0 +1,35 @@
+package org.opencds.cqf.fhir.utility;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ValidationProfileTest {
+
+    @Test
+    void defaultConstructor() {
+        var vp = new ValidationProfile();
+        assertNotNull(vp);
+    }
+
+    @Test
+    void constructorWithArgs() {
+        var vp = new ValidationProfile("test-profile", new ArrayList<>(List.of("key1")));
+        assertEquals("test-profile", vp.getName());
+        assertEquals(1, vp.getIgnoreKeys().size());
+    }
+
+    @Test
+    void settersAndGetters() {
+        var vp = new ValidationProfile();
+        vp.setName("profile-1");
+        assertEquals("profile-1", vp.getName());
+        vp.setIgnoreKeys(new ArrayList<>(List.of("a", "b")));
+        assertEquals(2, vp.getIgnoreKeys().size());
+        vp.addIgnoreKey("c");
+        assertEquals(3, vp.getIgnoreKeys().size());
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/AttachmentAdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/AttachmentAdapterTest.java
@@ -1,0 +1,58 @@
+package org.opencds.cqf.fhir.utility.adapter;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class AttachmentAdapterTest {
+
+    @Test
+    void r4AttachmentAdapter() {
+        var attachment = new org.hl7.fhir.r4.model.Attachment();
+        attachment.setContentType("application/json");
+        attachment.setData(new byte[] {1, 2, 3});
+        var adapter = IAdapterFactory.forFhirVersion(ca.uhn.fhir.context.FhirVersionEnum.R4)
+                .createAttachment(attachment);
+        assertEquals("application/json", adapter.getContentType());
+        assertArrayEquals(new byte[] {1, 2, 3}, adapter.getData());
+        adapter.setContentType("text/plain");
+        assertEquals("text/plain", adapter.getContentType());
+        adapter.setData(new byte[] {4, 5});
+        assertArrayEquals(new byte[] {4, 5}, adapter.getData());
+        assertNotNull(adapter.get());
+    }
+
+    @Test
+    void r5AttachmentAdapter() {
+        var attachment = new org.hl7.fhir.r5.model.Attachment();
+        attachment.setContentType("text/xml");
+        attachment.setData(new byte[] {10, 20});
+        var adapter = IAdapterFactory.forFhirVersion(ca.uhn.fhir.context.FhirVersionEnum.R5)
+                .createAttachment(attachment);
+        assertEquals("text/xml", adapter.getContentType());
+        assertArrayEquals(new byte[] {10, 20}, adapter.getData());
+        adapter.setContentType("application/fhir+json");
+        assertEquals("application/fhir+json", adapter.getContentType());
+    }
+
+    @Test
+    void dstu3AttachmentAdapter() {
+        var attachment = new org.hl7.fhir.dstu3.model.Attachment();
+        attachment.setContentType("application/octet-stream");
+        attachment.setData(new byte[] {99});
+        var adapter = IAdapterFactory.forFhirVersion(ca.uhn.fhir.context.FhirVersionEnum.DSTU3)
+                .createAttachment(attachment);
+        assertEquals("application/octet-stream", adapter.getContentType());
+        assertArrayEquals(new byte[] {99}, adapter.getData());
+    }
+
+    @Test
+    void r4WrongTypeThrows() {
+        assertThrows(IllegalArgumentException.class, () -> IAdapterFactory.forFhirVersion(
+                        ca.uhn.fhir.context.FhirVersionEnum.R4)
+                .createAttachment(new org.hl7.fhir.r4.model.Patient()));
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/builder/BuilderTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/builder/BuilderTest.java
@@ -1,0 +1,323 @@
+package org.opencds.cqf.fhir.utility.builder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Date;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.junit.jupiter.api.Test;
+
+class BuilderTest {
+
+    // -- CodingSettings --
+
+    @Test
+    void codingSettingsWithDisplay() {
+        var cs = new CodingSettings("sys", "code", "display");
+        assertEquals("sys", cs.getSystem());
+        assertEquals("code", cs.getCode());
+        assertEquals("display", cs.getDisplay());
+    }
+
+    @Test
+    void codingSettingsWithoutDisplay() {
+        var cs = new CodingSettings("sys", "code");
+        assertEquals("sys", cs.getSystem());
+        assertEquals("code", cs.getCode());
+    }
+
+    // -- NarrativeSettings --
+
+    @Test
+    void narrativeSettingsDefaults() {
+        var ns = new NarrativeSettings("<div>text</div>");
+        assertEquals("<div>text</div>", ns.getText());
+        assertEquals("generated", ns.getStatus());
+    }
+
+    @Test
+    void narrativeSettingsCustomStatus() {
+        var ns = new NarrativeSettings("<div>text</div>", "additional");
+        assertEquals("additional", ns.getStatus());
+    }
+
+    // -- CodeableConceptSettings --
+
+    @Test
+    void codeableConceptSettings() {
+        var ccs = new CodeableConceptSettings();
+        ccs.add("sys1", "code1").add("sys2", "code2", "display2");
+        assertEquals(2, ccs.getCodingSettings().size());
+        assertEquals(2, ccs.getCodingSettingsArray().length);
+    }
+
+    // -- BaseResourceBuilder --
+
+    @Test
+    void ensurePatientReference() {
+        assertEquals("Patient/123", BaseResourceBuilder.ensurePatientReference("123"));
+        assertEquals("Patient/123", BaseResourceBuilder.ensurePatientReference("Patient/123"));
+        assertNull(BaseResourceBuilder.ensurePatientReference(null));
+        assertEquals("", BaseResourceBuilder.ensurePatientReference(""));
+    }
+
+    @Test
+    void ensureOrganizationReference() {
+        assertEquals("Organization/123", BaseResourceBuilder.ensureOrganizationReference("123"));
+        assertEquals("Organization/123", BaseResourceBuilder.ensureOrganizationReference("Organization/123"));
+    }
+
+    // -- BundleBuilder (R4) --
+
+    @Test
+    void bundleBuilderR4() {
+        var bundle = new BundleBuilder<>(org.hl7.fhir.r4.model.Bundle.class, "test-id", "COLLECTION")
+                .withTimestamp(new Date())
+                .build();
+        assertNotNull(bundle);
+        assertEquals("test-id", bundle.getIdElement().getIdPart());
+        assertEquals(org.hl7.fhir.r4.model.Bundle.BundleType.COLLECTION, bundle.getType());
+    }
+
+    @Test
+    void bundleBuilderDstu3() {
+        var bundle = new BundleBuilder<>(org.hl7.fhir.dstu3.model.Bundle.class, "test-id")
+                .withType("COLLECTION")
+                .build();
+        assertNotNull(bundle);
+        assertEquals(org.hl7.fhir.dstu3.model.Bundle.BundleType.COLLECTION, bundle.getType());
+    }
+
+    @Test
+    void bundleBuilderR5() {
+        var bundle = new BundleBuilder<>(org.hl7.fhir.r5.model.Bundle.class)
+                .withType("COLLECTION")
+                .withId("test-r5")
+                .build();
+        assertNotNull(bundle);
+    }
+
+    @Test
+    void bundleBuilderNoTypeThrows() {
+        var builder = new BundleBuilder<>(org.hl7.fhir.r4.model.Bundle.class);
+        assertThrows(NullPointerException.class, builder::build);
+    }
+
+    // -- BundleBuilder with profile and identifier --
+
+    @Test
+    void bundleBuilderWithProfileAndIdentifier() {
+        var bundle = new BundleBuilder<>(org.hl7.fhir.r4.model.Bundle.class, "test-id")
+                .withType("COLLECTION")
+                .withProfile("http://example.org/profile")
+                .withIdentifier(new ImmutablePair<>("sys", "val"))
+                .build();
+        assertNotNull(bundle);
+        assertTrue(bundle.getMeta().getProfile().stream()
+                .anyMatch(p -> p.getValue().equals("http://example.org/profile")));
+    }
+
+    // -- DetectedIssueBuilder --
+
+    @Test
+    void detectedIssueBuilderR4() {
+        var code = new CodeableConceptSettings().add("sys", "code", "display");
+        var issue = new DetectedIssueBuilder<>(org.hl7.fhir.r4.model.DetectedIssue.class, "test-id", "FINAL", "detail")
+                .withCode(code)
+                .withPatient("Patient/123")
+                .withEvidenceDetail("extra-detail")
+                .build();
+        assertNotNull(issue);
+        assertEquals(org.hl7.fhir.r4.model.DetectedIssue.DetectedIssueStatus.FINAL, issue.getStatus());
+    }
+
+    @Test
+    void detectedIssueBuilderDstu3() {
+        var code = new CodeableConceptSettings().add("sys", "code", "display");
+        var issue = new DetectedIssueBuilder<>(org.hl7.fhir.dstu3.model.DetectedIssue.class)
+                .withStatus("FINAL")
+                .withCode(code)
+                .withPatient("123")
+                .withEvidenceDetail("detail")
+                .build();
+        assertNotNull(issue);
+    }
+
+    @Test
+    void detectedIssueBuilderR5() {
+        var code = new CodeableConceptSettings().add("sys", "code", "display");
+        var issue = new DetectedIssueBuilder<>(org.hl7.fhir.r5.model.DetectedIssue.class)
+                .withStatus("FINAL")
+                .withCode(code)
+                .withEvidenceDetail("detail")
+                .build();
+        assertNotNull(issue);
+    }
+
+    // -- CompositionBuilder --
+
+    @Test
+    void compositionBuilderR4() {
+        var type = new CodeableConceptSettings().add("sys", "code", "display");
+        var comp = new CompositionBuilder<>(
+                        org.hl7.fhir.r4.model.Composition.class, "test-id", type, "FINAL", "Practitioner/1", "Title")
+                .withDate(new Date())
+                .withSubject("Patient/123")
+                .withCustodian("Organization/456")
+                .build();
+        assertNotNull(comp);
+        assertEquals("Title", comp.getTitle());
+    }
+
+    @Test
+    void compositionBuilderDstu3() {
+        var type = new CodeableConceptSettings().add("sys", "code", "display");
+        var comp = new CompositionBuilder<>(org.hl7.fhir.dstu3.model.Composition.class)
+                .withType(type)
+                .withStatus("FINAL")
+                .withAuthor("Practitioner/1")
+                .withTitle("Title")
+                .withSubject("123")
+                .withCustodian("456")
+                .build();
+        assertNotNull(comp);
+    }
+
+    @Test
+    void compositionBuilderR5() {
+        var type = new CodeableConceptSettings().add("sys", "code", "display");
+        var comp = new CompositionBuilder<>(org.hl7.fhir.r5.model.Composition.class)
+                .withType(type)
+                .withStatus("FINAL")
+                .withAuthor("Device/1")
+                .withTitle("Title")
+                .build();
+        assertNotNull(comp);
+    }
+
+    // -- CompositionSectionComponentBuilder --
+
+    @Test
+    void compositionSectionBuilderR4() {
+        var section = new CompositionSectionComponentBuilder<>(
+                        org.hl7.fhir.r4.model.Composition.SectionComponent.class,
+                        "sec-id",
+                        "MeasureReport/1",
+                        "entry-1")
+                .withTitle("Section Title")
+                .withText(new NarrativeSettings("<div>text</div>"))
+                .withEntry("entry-2")
+                .build();
+        assertNotNull(section);
+        assertEquals("Section Title", section.getTitle());
+    }
+
+    @Test
+    void compositionSectionBuilderDstu3() {
+        var section = new CompositionSectionComponentBuilder<>(
+                        org.hl7.fhir.dstu3.model.Composition.SectionComponent.class)
+                .withFocus("MeasureReport/1")
+                .withEntry("entry-1")
+                .withTitle("Title")
+                .withText(new NarrativeSettings("<div>hi</div>"))
+                .build();
+        assertNotNull(section);
+    }
+
+    @Test
+    void compositionSectionBuilderR5() {
+        var section = new CompositionSectionComponentBuilder<>(org.hl7.fhir.r5.model.Composition.SectionComponent.class)
+                .withFocus("MeasureReport/1")
+                .withEntry("entry-1")
+                .withTitle("Title")
+                .withText(new NarrativeSettings("<div>hi</div>"))
+                .build();
+        assertNotNull(section);
+    }
+
+    // -- Extensions on builders --
+
+    @Test
+    void domainResourceBuilderWithExtension() {
+        var extCc = new CodeableConceptSettings().add("ext-sys", "ext-code", "ext-display");
+        var code = new CodeableConceptSettings().add("sys", "code", "display");
+        var issue = new DetectedIssueBuilder<>(org.hl7.fhir.r4.model.DetectedIssue.class)
+                .withStatus("FINAL")
+                .withCode(code)
+                .withEvidenceDetail("detail")
+                .withExtension(new ImmutablePair<>("http://example.org/ext", extCc))
+                .withModifierExtension(new ImmutablePair<>("http://example.org/mod-ext", extCc))
+                .build();
+        assertNotNull(issue);
+        assertTrue(issue.hasExtension());
+        assertTrue(issue.hasModifierExtension());
+    }
+
+    @Test
+    void domainResourceBuilderWithExtensionDstu3() {
+        var extCc = new CodeableConceptSettings().add("ext-sys", "ext-code", "ext-display");
+        var code = new CodeableConceptSettings().add("sys", "code", "display");
+        var issue = new DetectedIssueBuilder<>(org.hl7.fhir.dstu3.model.DetectedIssue.class)
+                .withStatus("FINAL")
+                .withCode(code)
+                .withEvidenceDetail("detail")
+                .withExtension(new ImmutablePair<>("http://example.org/ext", extCc))
+                .withModifierExtension(new ImmutablePair<>("http://example.org/mod-ext", extCc))
+                .build();
+        assertNotNull(issue);
+    }
+
+    @Test
+    void domainResourceBuilderWithExtensionR5() {
+        var extCc = new CodeableConceptSettings().add("ext-sys", "ext-code", "ext-display");
+        var code = new CodeableConceptSettings().add("sys", "code", "display");
+        var issue = new DetectedIssueBuilder<>(org.hl7.fhir.r5.model.DetectedIssue.class)
+                .withStatus("FINAL")
+                .withCode(code)
+                .withEvidenceDetail("detail")
+                .withExtension(new ImmutablePair<>("http://example.org/ext", extCc))
+                .withModifierExtension(new ImmutablePair<>("http://example.org/mod-ext", extCc))
+                .build();
+        assertNotNull(issue);
+    }
+
+    @Test
+    void backboneElementBuilderWithExtension() {
+        var extCc = new CodeableConceptSettings().add("ext-sys", "ext-code", "ext-display");
+        var section = new CompositionSectionComponentBuilder<>(org.hl7.fhir.r4.model.Composition.SectionComponent.class)
+                .withFocus("MeasureReport/1")
+                .withEntry("entry-1")
+                .withExtension(new ImmutablePair<>("http://example.org/ext", extCc))
+                .withModifierExtension(new ImmutablePair<>("http://example.org/mod-ext", extCc))
+                .build();
+        assertNotNull(section);
+    }
+
+    @Test
+    void backboneElementBuilderWithExtensionDstu3() {
+        var extCc = new CodeableConceptSettings().add("ext-sys", "ext-code", "ext-display");
+        var section = new CompositionSectionComponentBuilder<>(
+                        org.hl7.fhir.dstu3.model.Composition.SectionComponent.class)
+                .withFocus("MeasureReport/1")
+                .withEntry("entry-1")
+                .withExtension(new ImmutablePair<>("http://example.org/ext", extCc))
+                .withModifierExtension(new ImmutablePair<>("http://example.org/mod-ext", extCc))
+                .build();
+        assertNotNull(section);
+    }
+
+    @Test
+    void backboneElementBuilderWithExtensionR5() {
+        var extCc = new CodeableConceptSettings().add("ext-sys", "ext-code", "ext-display");
+        var section = new CompositionSectionComponentBuilder<>(org.hl7.fhir.r5.model.Composition.SectionComponent.class)
+                .withFocus("MeasureReport/1")
+                .withEntry("entry-1")
+                .withExtension(new ImmutablePair<>("http://example.org/ext", extCc))
+                .withModifierExtension(new ImmutablePair<>("http://example.org/mod-ext", extCc))
+                .build();
+        assertNotNull(section);
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/client/InterceptorTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/client/InterceptorTest.java
@@ -1,0 +1,76 @@
+package org.opencds.cqf.fhir.utility.client;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import ca.uhn.fhir.rest.client.api.IHttpRequest;
+import ca.uhn.fhir.rest.client.api.IHttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class InterceptorTest {
+
+    @Test
+    void headerInjectionSingleHeader() {
+        var interceptor = new HeaderInjectionInterceptor("Authorization", "Bearer token");
+        var request = mock(IHttpRequest.class);
+        interceptor.interceptRequest(request);
+        verify(request).addHeader("Authorization", "Bearer token");
+    }
+
+    @Test
+    void headerInjectionMapHeaders() {
+        var headers = Map.of("X-Custom", "val1", "Accept", "application/json");
+        var interceptor = new HeaderInjectionInterceptor(headers);
+        var request = mock(IHttpRequest.class);
+        interceptor.interceptRequest(request);
+        verify(request).addHeader("X-Custom", "val1");
+        verify(request).addHeader("Accept", "application/json");
+    }
+
+    @Test
+    void headerInjectionResponseNoOp() throws Exception {
+        var interceptor = new HeaderInjectionInterceptor("key", "val");
+        var response = mock(IHttpResponse.class);
+        interceptor.interceptResponse(response);
+        // no exception = pass
+    }
+
+    @Test
+    void additionalRequestHeadersDefault() {
+        var interceptor = new AdditionalRequestHeadersInterceptor();
+        interceptor.addHeaderValue("X-Test", "value1");
+        var request = mock(IHttpRequest.class);
+        interceptor.interceptRequest(request);
+        verify(request).addHeader("X-Test", "value1");
+    }
+
+    @Test
+    void additionalRequestHeadersFromMap() {
+        var headers = Map.of("X-Foo", List.of("bar", "baz"));
+        var interceptor = new AdditionalRequestHeadersInterceptor(headers);
+        var request = mock(IHttpRequest.class);
+        interceptor.interceptRequest(request);
+        verify(request).addHeader("X-Foo", "bar");
+        verify(request).addHeader("X-Foo", "baz");
+    }
+
+    @Test
+    void additionalRequestHeadersNullMap() {
+        var interceptor = new AdditionalRequestHeadersInterceptor(null);
+        var request = mock(IHttpRequest.class);
+        interceptor.interceptRequest(request);
+        // no headers added, no exception
+    }
+
+    @Test
+    void additionalRequestHeadersAddAll() {
+        var interceptor = new AdditionalRequestHeadersInterceptor();
+        interceptor.addAllHeaderValues("X-Multi", List.of("a", "b"));
+        var request = mock(IHttpRequest.class);
+        interceptor.interceptRequest(request);
+        verify(request).addHeader("X-Multi", "a");
+        verify(request).addHeader("X-Multi", "b");
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/dstu3/ContainedHelperTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/dstu3/ContainedHelperTest.java
@@ -1,0 +1,48 @@
+package org.opencds.cqf.fhir.utility.dstu3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hl7.fhir.dstu3.model.Encounter;
+import org.hl7.fhir.dstu3.model.Observation;
+import org.hl7.fhir.dstu3.model.Patient;
+import org.junit.jupiter.api.Test;
+
+class ContainedHelperTest {
+
+    @Test
+    void liftContainedResourcesToParent() {
+        var parent = new Patient();
+        parent.setId("parent");
+        var contained = new Observation();
+        contained.setId("obs1");
+        var nestedContained = new Encounter();
+        nestedContained.setId("enc1");
+        contained.addContained(nestedContained);
+        parent.addContained(contained);
+
+        ContainedHelper.liftContainedResourcesToParent(parent);
+        assertTrue(parent.getContained().size() >= 2);
+    }
+
+    @Test
+    void getAllContainedResourcesNested() {
+        var parent = new Patient();
+        var child = new Observation();
+        child.setId("obs1");
+        var grandchild = new Encounter();
+        grandchild.setId("enc1");
+        child.addContained(grandchild);
+        parent.addContained(child);
+
+        var all = ContainedHelper.getAllContainedResources(parent);
+        assertEquals(2, all.size());
+    }
+
+    @Test
+    void getAllContainedResourcesNonDomainResource() {
+        var bundle = new org.hl7.fhir.dstu3.model.Bundle();
+        var result = ContainedHelper.getAllContainedResources(bundle);
+        assertTrue(result.isEmpty());
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/iterable/BundleIterableTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/iterable/BundleIterableTest.java
@@ -1,0 +1,138 @@
+package org.opencds.cqf.fhir.utility.iterable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.repository.IRepository;
+import java.util.ArrayList;
+import java.util.NoSuchElementException;
+import java.util.stream.Stream;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.jupiter.api.Test;
+
+class BundleIterableTest {
+
+    private IRepository mockRepo() {
+        var repo = mock(IRepository.class);
+        when(repo.fhirContext()).thenReturn(FhirContext.forR4Cached());
+        return repo;
+    }
+
+    @Test
+    void emptyBundleIterator() {
+        var repo = mockRepo();
+        var bundle = new Bundle();
+        var iter = new BundleIterator<>(repo, bundle);
+        assertFalse(iter.hasNext());
+        assertThrows(NoSuchElementException.class, iter::next);
+    }
+
+    @Test
+    void singleEntryIterator() {
+        var repo = mockRepo();
+        var bundle = new Bundle();
+        bundle.addEntry().setResource(new Patient().setId("p1"));
+        var iter = new BundleIterator<>(repo, bundle);
+        assertTrue(iter.hasNext());
+        var entry = iter.next();
+        assertEquals("p1", entry.getResource().getIdElement().getIdPart());
+        assertFalse(iter.hasNext());
+    }
+
+    @Test
+    void iteratorWithPaging() {
+        var repo = mockRepo();
+        var bundle1 = new Bundle();
+        bundle1.addEntry().setResource(new Patient().setId("p1"));
+        bundle1.addLink().setRelation("next").setUrl("http://example.com/next");
+
+        var bundle2 = new Bundle();
+        bundle2.addEntry().setResource(new Patient().setId("p2"));
+        when(repo.link(eq(Bundle.class), any(String.class))).thenReturn(bundle2);
+
+        var iter = new BundleIterator<>(repo, bundle1);
+        var results = new ArrayList<>();
+        while (iter.hasNext()) {
+            results.add(iter.next().getResource().getIdElement().getIdPart());
+        }
+        assertEquals(2, results.size());
+    }
+
+    @Test
+    void iteratorWithNullNextBundle() {
+        var repo = mockRepo();
+        var bundle = new Bundle();
+        bundle.addEntry().setResource(new Patient().setId("p1"));
+        bundle.addLink().setRelation("next").setUrl("http://example.com/next");
+        when(repo.link(eq(Bundle.class), any(String.class))).thenReturn(null);
+
+        var iter = new BundleIterator<>(repo, bundle);
+        assertTrue(iter.hasNext());
+        iter.next();
+        assertFalse(iter.hasNext());
+    }
+
+    @Test
+    void bundleIterableForEach() {
+        var repo = mockRepo();
+        var bundle = new Bundle();
+        bundle.addEntry().setResource(new Patient().setId("p1"));
+        bundle.addEntry().setResource(new Patient().setId("p2"));
+
+        var iterable = new BundleIterable<>(repo, bundle);
+        var ids = new ArrayList<String>();
+        for (var entry : iterable) {
+            ids.add(entry.getResource().getIdElement().getIdPart());
+        }
+        assertEquals(2, ids.size());
+    }
+
+    @Test
+    void bundleIterableToStream() {
+        var repo = mockRepo();
+        var bundle = new Bundle();
+        bundle.addEntry().setResource(new Patient().setId("p1"));
+        var iterable = new BundleIterable<>(repo, bundle);
+        assertEquals(1, iterable.toStream().count());
+    }
+
+    @Test
+    void bundleMappingIterator() {
+        var repo = mockRepo();
+        var bundle = new Bundle();
+        bundle.addEntry().setResource(new Patient().setId("p1"));
+        var mappingIter = new BundleMappingIterator<>(
+                repo, bundle, e -> e.getResource().getIdElement().getIdPart());
+        assertTrue(mappingIter.hasNext());
+        assertEquals("p1", mappingIter.next());
+        assertFalse(mappingIter.hasNext());
+        assertThrows(NoSuchElementException.class, mappingIter::next);
+    }
+
+    @Test
+    void bundleMappingIterableToStream() {
+        var repo = mockRepo();
+        var bundle = new Bundle();
+        bundle.addEntry().setResource(new Patient().setId("p1"));
+        var iterable = new BundleMappingIterable<>(
+                repo, bundle, e -> e.getResource().getIdElement().getIdPart());
+        assertEquals(1, iterable.toStream().count());
+    }
+
+    @Test
+    void streamIterable() {
+        var stream = Stream.of("a", "b", "c");
+        var iterable = new StreamIterable<>(stream);
+        var results = new ArrayList<String>();
+        iterable.iterator().forEachRemaining(results::add);
+        assertEquals(3, results.size());
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/matcher/ResourceMatcherTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/matcher/ResourceMatcherTest.java
@@ -1,8 +1,12 @@
 package org.opencds.cqf.fhir.utility.matcher;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.RuntimeSearchParam;
 import ca.uhn.fhir.model.api.IQueryParameterType;
 import ca.uhn.fhir.rest.param.CompositeParam;
 import ca.uhn.fhir.rest.param.DateParam;
@@ -16,6 +20,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.Encounter;
@@ -27,6 +32,7 @@ import org.hl7.fhir.r4.model.Observation.ObservationStatus;
 import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.Period;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -37,7 +43,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * But it's been broken up (largely) by parameter type for simpler
  * debugging and fixing
  */
-public class ResourceMatcherTest {
+class ResourceMatcherTest {
 
     private static final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
     private static final SimpleDateFormat dateTimeFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
@@ -47,27 +53,27 @@ public class ResourceMatcherTest {
     private ResourceMatcherR4 resourceMatcher;
 
     @BeforeEach
-    public void before() {
+    void before() {
         resourceMatcher = new ResourceMatcherR4();
     }
 
     // NB: the list of parameters are always OR'd
     // internal compositeparams are always AND'd
     static List<Arguments> coverageParameters() {
-        List<Arguments> args = new ArrayList<>();
+        var args = new ArrayList<Arguments>();
 
         // 1 encounter with date range entirely within search bounds
         {
-            Encounter encounter = new Encounter();
+            var encounter = new Encounter();
             encounter
                     .addLocation()
                     .setPeriod(new Period()
                             .setStart(createDate("2000-01-01 00:00:00"))
                             .setEnd(createDate("2000-12-31 23:59:59")));
 
-            Date start = createDate("2000-02-01");
-            Date end = createDate("2000-11-11");
-            List<IQueryParameterType> params = new ArrayList<>();
+            var start = createDate("2000-02-01");
+            var end = createDate("2000-11-11");
+            var params = new ArrayList<IQueryParameterType>();
             // start <= v <= end || start <= v <= end
             params.add(new CompositeParam<>(
                     new DateParam(ParamPrefixEnum.LESSTHAN_OR_EQUALS, end),
@@ -77,16 +83,16 @@ public class ResourceMatcherTest {
         }
         // 2 encounter with date range overlapping and after
         {
-            Encounter encounter = new Encounter();
+            var encounter = new Encounter();
             encounter
                     .addLocation()
                     .setPeriod(new Period()
                             .setStart(createDate("2000-01-01 00:00:00"))
                             .setEnd(createDate("2000-12-31 23:59:59")));
 
-            Date start = createDate("2000-11-11");
-            Date end = createDate("2001-11-11");
-            List<IQueryParameterType> params = new ArrayList<>();
+            var start = createDate("2000-11-11");
+            var end = createDate("2001-11-11");
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new CompositeParam<>(
                     new DateParam(ParamPrefixEnum.LESSTHAN_OR_EQUALS, end),
                     new DateParam(ParamPrefixEnum.GREATERTHAN_OR_EQUALS, start)));
@@ -95,16 +101,16 @@ public class ResourceMatcherTest {
         }
         // 3 encounter with date range overlapping and before
         {
-            Encounter encounter = new Encounter();
+            var encounter = new Encounter();
             encounter
                     .addLocation()
                     .setPeriod(new Period()
                             .setStart(createDate("2000-01-01 00:00:00"))
                             .setEnd(createDate("2000-12-31 23:59:59")));
 
-            Date start = createDate("1999-11-11");
-            Date end = createDate("2000-11-11");
-            List<IQueryParameterType> params = new ArrayList<>();
+            var start = createDate("1999-11-11");
+            var end = createDate("2000-11-11");
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new CompositeParam<>(
                     new DateParam(ParamPrefixEnum.LESSTHAN_OR_EQUALS, end),
                     new DateParam(ParamPrefixEnum.GREATERTHAN_OR_EQUALS, start)));
@@ -113,16 +119,16 @@ public class ResourceMatcherTest {
         }
         // 4 encounter with date range entirely overlapping (and extending on both sides)
         {
-            Encounter encounter = new Encounter();
+            var encounter = new Encounter();
             encounter
                     .addLocation()
                     .setPeriod(new Period()
                             .setStart(createDate("2000-01-01 00:00:00"))
                             .setEnd(createDate("2000-12-31 23:59:59")));
 
-            Date start = createDate("1999-11-11");
-            Date end = createDate("2001-01-01");
-            List<IQueryParameterType> params = new ArrayList<>();
+            var start = createDate("1999-11-11");
+            var end = createDate("2001-01-01");
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new CompositeParam<>(
                     new DateParam(ParamPrefixEnum.LESSTHAN_OR_EQUALS, end),
                     new DateParam(ParamPrefixEnum.GREATERTHAN_OR_EQUALS, start)));
@@ -131,16 +137,16 @@ public class ResourceMatcherTest {
         }
         // 5 encounter with date range entirely before
         {
-            Encounter encounter = new Encounter();
+            var encounter = new Encounter();
             encounter
                     .addLocation()
                     .setPeriod(new Period()
                             .setStart(createDate("2000-01-01 00:00:00"))
                             .setEnd(createDate("2000-12-31 23:59:59")));
 
-            Date start = createDate("1999-01-01");
-            Date end = createDate("1999-11-11");
-            List<IQueryParameterType> params = new ArrayList<>();
+            var start = createDate("1999-01-01");
+            var end = createDate("1999-11-11");
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new CompositeParam<>(
                     new DateParam(ParamPrefixEnum.LESSTHAN_OR_EQUALS, end),
                     new DateParam(ParamPrefixEnum.GREATERTHAN_OR_EQUALS, start)));
@@ -149,16 +155,16 @@ public class ResourceMatcherTest {
         }
         // 6 encounter with date range entirely after
         {
-            Encounter encounter = new Encounter();
+            var encounter = new Encounter();
             encounter
                     .addLocation()
                     .setPeriod(new Period()
                             .setStart(createDate("2000-01-01 00:00:00"))
                             .setEnd(createDate("2000-12-31 23:59:59")));
 
-            Date start = createDate("2001-01-01");
-            Date end = createDate("2001-11-11");
-            List<IQueryParameterType> params = new ArrayList<>();
+            var start = createDate("2001-01-01");
+            var end = createDate("2001-11-11");
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new CompositeParam<>(
                     new DateParam(ParamPrefixEnum.GREATERTHAN_OR_EQUALS, start),
                     new DateParam(ParamPrefixEnum.LESSTHAN_OR_EQUALS, end)));
@@ -167,12 +173,12 @@ public class ResourceMatcherTest {
         }
         // 7 encounter with date range exactly matching
         {
-            Date start = createDate("2000-01-01 00:00:00");
-            Date end = createDate("2000-12-31 23:59:59");
-            Encounter encounter = new Encounter();
+            var start = createDate("2000-01-01 00:00:00");
+            var end = createDate("2000-12-31 23:59:59");
+            var encounter = new Encounter();
             encounter.addLocation().setPeriod(new Period().setStart(start).setEnd(end));
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new CompositeParam<>(
                     new DateParam(ParamPrefixEnum.GREATERTHAN_OR_EQUALS, start),
                     new DateParam(ParamPrefixEnum.LESSTHAN_OR_EQUALS, end)));
@@ -181,14 +187,14 @@ public class ResourceMatcherTest {
         }
         // 8 encounter with date range starting at endpoint (not in range)
         {
-            Date start = createDate(dateTimeFormatter, "2000-01-01 00:00:00");
-            Date end = createDate(dateTimeFormatter, "2000-12-31 23:59:59");
-            Encounter encounter = new Encounter();
+            var start = createDate(dateTimeFormatter, "2000-01-01 00:00:00");
+            var end = createDate(dateTimeFormatter, "2000-12-31 23:59:59");
+            var encounter = new Encounter();
             encounter
                     .addLocation()
                     .setPeriod(new Period().setStart(end).setEnd(createDate(dateTimeFormatter, "2001-02-02 00:00:00")));
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new CompositeParam<>(
                     new DateParam(ParamPrefixEnum.GREATERTHAN_OR_EQUALS, start),
                     new DateParam(ParamPrefixEnum.LESSTHAN, end)));
@@ -197,14 +203,14 @@ public class ResourceMatcherTest {
         }
         // 9 encounter with date range ending at startpoint (not in range)
         {
-            Date start = createDate("2000-01-01 00:00:00");
-            Date end = createDate("2000-12-31 23:59:59");
-            Encounter encounter = new Encounter();
+            var start = createDate("2000-01-01 00:00:00");
+            var end = createDate("2000-12-31 23:59:59");
+            var encounter = new Encounter();
             encounter
                     .addLocation()
                     .setPeriod(new Period().setStart(createDate("1999-02-02")).setEnd(start));
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new CompositeParam<>(
                     new DateParam(ParamPrefixEnum.GREATERTHAN, start),
                     new DateParam(ParamPrefixEnum.LESSTHAN_OR_EQUALS, end)));
@@ -214,16 +220,16 @@ public class ResourceMatcherTest {
         // 10 same as case 1 (encounter with date range entirely within search bounds)
         //      but with the composite params flipped for robust-ness
         {
-            Encounter encounter = new Encounter();
+            var encounter = new Encounter();
             encounter
                     .addLocation()
                     .setPeriod(new Period()
                             .setStart(createDate("2000-01-01 00:00:00"))
                             .setEnd(createDate("2000-12-31 23:59:59")));
 
-            Date start = createDate("2000-02-01");
-            Date end = createDate("2000-11-11");
-            List<IQueryParameterType> params = new ArrayList<>();
+            var start = createDate("2000-02-01");
+            var end = createDate("2000-11-11");
+            var params = new ArrayList<IQueryParameterType>();
             // start <= v <= end || start <= v <= end
             params.add(new CompositeParam<>(
                     new DateParam(ParamPrefixEnum.GREATERTHAN_OR_EQUALS, start),
@@ -233,13 +239,13 @@ public class ResourceMatcherTest {
         }
         // 11 Observation with valueDateTime after range
         {
-            Observation obs = new Observation();
+            var obs = new Observation();
             obs.setValue(new DateTimeType().setValue(createDate(dateTimeFormatter, "2001-03-14 02:59:00")));
             obs.setStatus(ObservationStatus.CORRECTED);
 
-            Date start = createDate("2000-02-01");
-            Date end = createDate("2000-11-11");
-            List<IQueryParameterType> params = new ArrayList<>();
+            var start = createDate("2000-02-01");
+            var end = createDate("2000-11-11");
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new CompositeParam<>(
                     new DateParam(ParamPrefixEnum.GREATERTHAN_OR_EQUALS, start),
                     new DateParam(ParamPrefixEnum.LESSTHAN_OR_EQUALS, end)));
@@ -248,13 +254,13 @@ public class ResourceMatcherTest {
         }
         // 12 Observation with valueDateTime before range
         {
-            Observation obs = new Observation();
+            var obs = new Observation();
             obs.setValue(new DateTimeType().setValue(createDate(dateTimeFormatter, "1999-03-14 02:59:00")));
             obs.setStatus(ObservationStatus.CORRECTED);
 
-            Date start = createDate("2000-02-01");
-            Date end = createDate("2000-11-11");
-            List<IQueryParameterType> params = new ArrayList<>();
+            var start = createDate("2000-02-01");
+            var end = createDate("2000-11-11");
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new CompositeParam<>(
                     new DateParam(ParamPrefixEnum.GREATERTHAN_OR_EQUALS, start),
                     new DateParam(ParamPrefixEnum.LESSTHAN_OR_EQUALS, end)));
@@ -263,13 +269,13 @@ public class ResourceMatcherTest {
         }
         // 13 Observation with valueDateTime within range
         {
-            Observation obs = new Observation();
+            var obs = new Observation();
             obs.setValue(new DateTimeType().setValue(createDate(dateTimeFormatter, "2000-03-14 02:59:00")));
             obs.setStatus(ObservationStatus.CORRECTED);
 
-            Date start = createDate("2000-02-01");
-            Date end = createDate("2000-11-11");
-            List<IQueryParameterType> params = new ArrayList<>();
+            var start = createDate("2000-02-01");
+            var end = createDate("2000-11-11");
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new CompositeParam<>(
                     new DateParam(ParamPrefixEnum.GREATERTHAN_OR_EQUALS, start),
                     new DateParam(ParamPrefixEnum.LESSTHAN_OR_EQUALS, end)));
@@ -278,13 +284,13 @@ public class ResourceMatcherTest {
         }
         // 14 Observation with valueDateTime exactly on startpoint of range
         {
-            Date start = createDate("2000-02-01");
-            Date end = createDate("2000-11-11");
-            Observation obs = new Observation();
+            var start = createDate("2000-02-01");
+            var end = createDate("2000-11-11");
+            var obs = new Observation();
             obs.setValue(new DateTimeType().setValue(start));
             obs.setStatus(ObservationStatus.CORRECTED);
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new CompositeParam<>(
                     new DateParam(ParamPrefixEnum.GREATERTHAN_OR_EQUALS, start),
                     new DateParam(ParamPrefixEnum.LESSTHAN_OR_EQUALS, end)));
@@ -293,13 +299,13 @@ public class ResourceMatcherTest {
         }
         // 15 Observation with valueDateTime exactly on starting point of range (with more specificity)
         {
-            Date start = createDate("2000-01-01 00:00:00");
-            Date end = createDate("2000-12-31 23:59:59");
-            Observation obs = new Observation();
+            var start = createDate("2000-01-01 00:00:00");
+            var end = createDate("2000-12-31 23:59:59");
+            var obs = new Observation();
             obs.setValue(new DateTimeType().setValue(end));
             obs.setStatus(ObservationStatus.CORRECTED);
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new CompositeParam<>(
                     new DateParam(ParamPrefixEnum.GREATERTHAN_OR_EQUALS, start),
                     new DateParam(ParamPrefixEnum.LESSTHAN_OR_EQUALS, end)));
@@ -308,24 +314,24 @@ public class ResourceMatcherTest {
         }
         // 16 Observation with valueDateTime that doesn't equal an exact match
         {
-            Date date = createDate(dateTimeFormatter, "2000-03-14 01:59:00");
-            Observation obs = new Observation();
+            var date = createDate(dateTimeFormatter, "2000-03-14 01:59:00");
+            var obs = new Observation();
             obs.setValue(new DateTimeType().setValue(date));
             obs.setStatus(ObservationStatus.CORRECTED);
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new DateParam(ParamPrefixEnum.NOT_EQUAL, date));
 
             args.add(Arguments.of("value-date", params, obs, false));
         }
         // 17 Observation with valueDateTime that doesn't match
         {
-            Date date = createDate(dateTimeFormatter, "2000-03-14 01:59:00");
-            Observation obs = new Observation();
+            var date = createDate(dateTimeFormatter, "2000-03-14 01:59:00");
+            var obs = new Observation();
             obs.setValue(new DateTimeType().setValue(date));
             obs.setStatus(ObservationStatus.CORRECTED);
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new DateParam(ParamPrefixEnum.NOT_EQUAL, createDate(dateTimeFormatter, "2000-01-01 00:00:01")));
 
             args.add(Arguments.of("value-date", params, obs, true));
@@ -336,98 +342,98 @@ public class ResourceMatcherTest {
 
     @ParameterizedTest
     @MethodSource("coverageParameters")
-    public void matches_dateParamCoverage_worksAsExpected(
+    void matches_dateParamCoverage_worksAsExpected(
             String spName, List<IQueryParameterType> params, IBaseResource resource, boolean expectedMatch) {
         // test
-        boolean matches = resourceMatcher.matches(spName, params, resource);
+        var matches = resourceMatcher.matches(spName, params, resource);
 
         // verify
         assertEquals(expectedMatch, matches);
     }
 
     static List<Arguments> stringLikeMatchParameters() {
-        List<Arguments> args = new ArrayList<>();
+        var args = new ArrayList<Arguments>();
 
         // 1 Measure with exactly matching uri
         {
-            Measure measure = new Measure();
+            var measure = new Measure();
             measure.setUrl("http://example.com");
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new UriParam().setValue("http://example.com"));
 
             args.add(Arguments.of("url", params, measure, true));
         }
         // 2 Measure with a non-matching uri
         {
-            Measure measure = new Measure();
+            var measure = new Measure();
             measure.setUrl("http://example.net");
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new UriParam().setValue("http://example.com"));
 
             args.add(Arguments.of("url", params, measure, false));
         }
         // 3 Measure with matching name
         {
-            Measure measure = new Measure();
+            var measure = new Measure();
             measure.setName("measure-1");
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new StringParam("measure-1"));
 
             args.add(Arguments.of("name", params, measure, true));
         }
         // 4 Measure with matching name
         {
-            Measure measure = new Measure();
+            var measure = new Measure();
             measure.setName("measure-1");
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new StringParam("measure-2"));
 
             args.add(Arguments.of("name", params, measure, false));
         }
         // 5 Organization with single matching endpoint reference only
         {
-            Organization organization = new Organization();
+            var organization = new Organization();
             organization.addEndpoint().setReference("Endpoint/123");
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new ReferenceParam("Endpoint/123"));
 
             args.add(Arguments.of("endpoint", params, organization, true));
         }
         // 6 Organization with an attached matching endpoint
         {
-            Endpoint ep = new Endpoint();
+            var ep = new Endpoint();
             ep.setId("Endpoint/123");
-            Organization organization = new Organization();
+            var organization = new Organization();
             organization.addEndpoint().setResource(ep);
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new ReferenceParam("Endpoint/123"));
 
             args.add(Arguments.of("endpoint", params, organization, true));
         }
         // 7 Organization with one of many endpoints matching
         {
-            Organization organization = new Organization();
+            var organization = new Organization();
             for (int i = 0; i < 4; i++) {
                 organization.addEndpoint().setReference("Endpoint/12" + i);
             }
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new ReferenceParam("Endpoint/123"));
 
             args.add(Arguments.of("endpoint", params, organization, true));
         }
         // 8 Organization without a matching endpoint
         {
-            Organization organization = new Organization();
+            var organization = new Organization();
             organization.addEndpoint().setReference("Endpoint/234");
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new ReferenceParam("Endpoint/123"));
 
             args.add(Arguments.of("endpoint", params, organization, false));
@@ -437,84 +443,84 @@ public class ResourceMatcherTest {
 
     @ParameterizedTest
     @MethodSource("stringLikeMatchParameters")
-    public void matches_stringParamsCoverage_works(
+    void matches_stringParamsCoverage_works(
             String spName, List<IQueryParameterType> params, IBaseResource resource, boolean expectedMatch) {
         // test
-        boolean matches = resourceMatcher.matches(spName, params, resource);
+        var matches = resourceMatcher.matches(spName, params, resource);
 
         // verify
         assertEquals(expectedMatch, matches);
     }
 
     static List<Arguments> tokenMatchingParameters() {
-        List<Arguments> args = new ArrayList<>();
+        var args = new ArrayList<Arguments>();
 
         // 1 Measure with status matching
         {
-            Measure measure = new Measure();
+            var measure = new Measure();
             measure.setStatus(PublicationStatus.ACTIVE);
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new TokenParam().setValue("active"));
 
             args.add(Arguments.of("status", params, measure, true));
         }
         // 2 Measure id matching
         {
-            Measure measure = new Measure();
+            var measure = new Measure();
             measure.setId("Measure/abc");
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new TokenParam("abc"));
 
             args.add(Arguments.of("_id", params, measure, true));
         }
         // 3 Measure matching on version
         {
-            Measure measure = new Measure();
+            var measure = new Measure();
             measure.setVersion("1.2.3");
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new TokenParam("1.2.3"));
 
             args.add(Arguments.of("version", params, measure, true));
         }
         // 4 Measure no match
         {
-            Measure measure = new Measure();
+            var measure = new Measure();
             measure.setStatus(PublicationStatus.ACTIVE);
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new TokenParam().setValue("INACTIVE"));
 
             args.add(Arguments.of("status", params, measure, false));
         }
         // 5 Measure with identifier matching system and value
         {
-            Measure measure = new Measure();
+            var measure = new Measure();
             measure.addIdentifier().setSystem("http://system.com").setValue("value1");
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new TokenParam().setSystem("http://system.com").setValue("value1"));
 
             args.add(Arguments.of("identifier", params, measure, true));
         }
         // 6 Measure with identifier matching on system only
         {
-            Measure measure = new Measure();
+            var measure = new Measure();
             measure.addIdentifier().setSystem("http://system.com");
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new TokenParam().setSystem("http://system.com").setValue("value1"));
 
             args.add(Arguments.of("identifier", params, measure, true));
         }
         // 7 Measure with identifier matching on value only
         {
-            Measure measure = new Measure();
+            var measure = new Measure();
             measure.addIdentifier().setValue("value1");
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new TokenParam().setSystem("http://system.com").setValue("value1"));
 
             args.add(Arguments.of("identifier", params, measure, true));
@@ -522,10 +528,10 @@ public class ResourceMatcherTest {
         // TODO - should this even be a valid test or should it return false?
         // 8 Measure matching on empty
         {
-            Measure measure = new Measure();
+            var measure = new Measure();
             measure.addIdentifier().setSystem("http://system.com").setValue("value1");
 
-            List<IQueryParameterType> params = new ArrayList<>();
+            var params = new ArrayList<IQueryParameterType>();
             params.add(new TokenParam());
 
             args.add(Arguments.of("identifier", params, measure, true));
@@ -536,10 +542,10 @@ public class ResourceMatcherTest {
 
     @ParameterizedTest
     @MethodSource("tokenMatchingParameters")
-    public void matches_tokenParamsCoverage_worksAsExpected(
+    void matches_tokenParamsCoverage_worksAsExpected(
             String spName, List<IQueryParameterType> params, IBaseResource resource, boolean expectedMatch) {
         // test
-        boolean matches = resourceMatcher.matches(spName, params, resource);
+        var matches = resourceMatcher.matches(spName, params, resource);
 
         // verify
         assertEquals(expectedMatch, matches);
@@ -561,5 +567,125 @@ public class ResourceMatcherTest {
             fail(ex);
             return null;
         }
+    }
+
+    // -- DSTU3 matcher tests --
+
+    @Test
+    void dstu3GetEngineAndContext() {
+        var matcher = new ResourceMatcherDSTU3();
+        assertNotNull(matcher.getEngine());
+        assertEquals(FhirContext.forDstu3Cached(), matcher.getContext());
+    }
+
+    @Test
+    void dstu3GetDateRangeFromPeriod() {
+        var matcher = new ResourceMatcherDSTU3();
+        var period = new org.hl7.fhir.dstu3.model.Period();
+        period.setStart(new Date());
+        period.setEnd(new Date());
+        assertNotNull(matcher.getDateRange(period));
+    }
+
+    @Test
+    void dstu3GetDateRangeFromTimingThrows() {
+        var matcher = new ResourceMatcherDSTU3();
+        assertThrows(NotImplementedException.class, () -> matcher.getDateRange(new org.hl7.fhir.dstu3.model.Timing()));
+    }
+
+    @Test
+    void dstu3GetDateRangeFromUnsupportedThrows() {
+        var matcher = new ResourceMatcherDSTU3();
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> matcher.getDateRange(new org.hl7.fhir.dstu3.model.Address()));
+    }
+
+    @Test
+    void dstu3GetCodesFromCoding() {
+        var matcher = new ResourceMatcherDSTU3();
+        var coding = new org.hl7.fhir.dstu3.model.Coding("http://sys", "code1", null);
+        assertEquals(1, matcher.getCodes(coding).size());
+    }
+
+    @Test
+    void dstu3GetCodesFromCodeType() {
+        var matcher = new ResourceMatcherDSTU3();
+        assertEquals(
+                1,
+                matcher.getCodes(new org.hl7.fhir.dstu3.model.CodeType("abc")).size());
+    }
+
+    @Test
+    void dstu3GetCodesFromCodeableConcept() {
+        var matcher = new ResourceMatcherDSTU3();
+        var cc = new org.hl7.fhir.dstu3.model.CodeableConcept();
+        cc.addCoding().setSystem("sys").setCode("c1");
+        cc.addCoding().setSystem("sys").setCode("c2");
+        assertEquals(2, matcher.getCodes(cc).size());
+    }
+
+    @Test
+    void dstu3CustomParameters() {
+        var matcher = new ResourceMatcherDSTU3();
+        assertNotNull(matcher.getPathCache());
+        assertNotNull(matcher.getCustomParameters());
+        var sp = new RuntimeSearchParam(null, null, "test", null, null, null, null, null, null, null);
+        matcher.addCustomParameter(sp);
+        assertEquals(1, matcher.getCustomParameters().size());
+    }
+
+    // -- R5 matcher tests --
+
+    @Test
+    void r5GetEngineAndContext() {
+        var matcher = new ResourceMatcherR5();
+        assertNotNull(matcher.getEngine());
+        assertEquals(FhirContext.forR5Cached(), matcher.getContext());
+    }
+
+    @Test
+    void r5GetDateRangeFromPeriod() {
+        var matcher = new ResourceMatcherR5();
+        var period = new org.hl7.fhir.r5.model.Period();
+        period.setStart(new Date());
+        assertNotNull(matcher.getDateRange(period));
+    }
+
+    @Test
+    void r5GetDateRangeFromTimingThrows() {
+        var matcher = new ResourceMatcherR5();
+        assertThrows(NotImplementedException.class, () -> matcher.getDateRange(new org.hl7.fhir.r5.model.Timing()));
+    }
+
+    @Test
+    void r5GetCodesFromCoding() {
+        var matcher = new ResourceMatcherR5();
+        var r5Coding = new org.hl7.fhir.r5.model.Coding();
+        r5Coding.setSystem("http://sys").setCode("c1");
+        assertEquals(1, matcher.getCodes(r5Coding).size());
+    }
+
+    @Test
+    void r5GetCodesFromCodeType() {
+        var matcher = new ResourceMatcherR5();
+        assertEquals(
+                1, matcher.getCodes(new org.hl7.fhir.r5.model.CodeType("xyz")).size());
+    }
+
+    @Test
+    void r5GetCodesFromCodeableConcept() {
+        var matcher = new ResourceMatcherR5();
+        var cc = new org.hl7.fhir.r5.model.CodeableConcept();
+        cc.addCoding().setSystem("sys").setCode("c1");
+        assertEquals(1, matcher.getCodes(cc).size());
+    }
+
+    @Test
+    void r5CustomParameters() {
+        var matcher = new ResourceMatcherR5();
+        var sp = new RuntimeSearchParam(null, null, "test", null, null, null, null, null, null, null);
+        matcher.addCustomParameter(sp);
+        assertEquals(1, matcher.getCustomParameters().size());
     }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/monad/EithersTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/monad/EithersTest.java
@@ -1,0 +1,101 @@
+package org.opencds.cqf.fhir.utility.monad;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class EithersTest {
+
+    @Test
+    void for2WithLeft() {
+        Either<String, Integer> e = Eithers.for2("hello", null);
+        assertTrue(e.isLeft());
+        assertEquals("hello", e.leftOrThrow());
+    }
+
+    @Test
+    void for2WithRight() {
+        Either<String, Integer> e = Eithers.for2(null, 42);
+        assertTrue(e.isRight());
+        assertEquals(42, e.rightOrThrow());
+    }
+
+    @Test
+    void for3WithLeft() {
+        Either3<String, Integer, Double> e = Eithers.for3("hello", null, null);
+        assertTrue(e.isLeft());
+    }
+
+    @Test
+    void for3WithMiddle() {
+        Either3<String, Integer, Double> e = Eithers.for3(null, 42, null);
+        assertTrue(e.isMiddle());
+    }
+
+    @Test
+    void for3WithRight() {
+        Either3<String, Integer, Double> e = Eithers.for3(null, null, 3.14);
+        assertTrue(e.isRight());
+    }
+
+    @Test
+    void forLeft3() {
+        Either3<String, Integer, Double> e = Eithers.forLeft3("hello");
+        assertTrue(e.isLeft());
+        assertFalse(e.isMiddle());
+        assertFalse(e.isRight());
+    }
+
+    @Test
+    void forMiddle3() {
+        Either3<String, Integer, Double> e = Eithers.forMiddle3(42);
+        assertTrue(e.isMiddle());
+    }
+
+    @Test
+    void forRight3() {
+        Either3<String, Integer, Double> e = Eithers.forRight3(3.14);
+        assertTrue(e.isRight());
+    }
+
+    @Test
+    void eitherOrElse() {
+        var right = Eithers.<String, Integer>forRight(42);
+        assertEquals(42, right.orElse(0));
+
+        var left = Eithers.<String, Integer>forLeft("error");
+        assertEquals(0, left.orElse(0));
+    }
+
+    @Test
+    void eitherOrElseGet() {
+        var right = Eithers.<String, Integer>forRight(42);
+        assertEquals(42, right.orElseGet(() -> 0));
+
+        var left = Eithers.<String, Integer>forLeft("error");
+        assertEquals(0, left.orElseGet(() -> 0));
+    }
+
+    @Test
+    void eitherPeek() {
+        var called = new boolean[] {false};
+        var right = Eithers.<String, Integer>forRight(42);
+        var result = right.peek(v -> called[0] = true);
+        assertTrue(called[0]);
+        assertEquals(right, result);
+
+        var notCalled = new boolean[] {false};
+        var left = Eithers.<String, Integer>forLeft("error");
+        left.peek(v -> notCalled[0] = true);
+        assertFalse(notCalled[0]);
+    }
+
+    @Test
+    void eitherTransform() {
+        var right = Eithers.<String, Integer>forRight(42);
+        var result = right.transform(e -> e.isRight() ? "right" : "left");
+        assertEquals("right", result);
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/monad/TriesTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/monad/TriesTest.java
@@ -1,0 +1,49 @@
+package org.opencds.cqf.fhir.utility.monad;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class TriesTest {
+
+    @Test
+    void ofWithError() {
+        var t = Tries.of(new RuntimeException("error"), null);
+        assertTrue(t.hasException());
+    }
+
+    @Test
+    void ofWithValue() {
+        var t = Tries.of(null, 42);
+        assertTrue(t.hasResult());
+        assertEquals(42, t.getOrThrow());
+    }
+
+    @Test
+    void ofSupplierSuccess() {
+        var t = Tries.of(() -> "hello");
+        assertTrue(t.hasResult());
+        assertEquals("hello", t.getOrThrow());
+    }
+
+    @Test
+    void ofSupplierFailure() {
+        var t = Tries.of(() -> {
+            throw new RuntimeException("fail");
+        });
+        assertTrue(t.hasException());
+    }
+
+    @Test
+    void ofExceptionDirectly() {
+        var t = Tries.<String>ofException(new RuntimeException("fail"));
+        assertTrue(t.hasException());
+    }
+
+    @Test
+    void ofValueDirectly() {
+        var t = Tries.of("hello");
+        assertTrue(t.hasResult());
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/r4/ContainedHelperTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/r4/ContainedHelperTest.java
@@ -1,0 +1,56 @@
+package org.opencds.cqf.fhir.utility.r4;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.jupiter.api.Test;
+
+class ContainedHelperTest {
+
+    @Test
+    void liftContainedResourcesToParent() {
+        var parent = new Patient();
+        parent.setId("parent");
+        var contained = new Observation();
+        contained.setId("obs1");
+        var nestedContained = new Encounter();
+        nestedContained.setId("enc1");
+        contained.addContained(nestedContained);
+        parent.addContained(contained);
+
+        ContainedHelper.liftContainedResourcesToParent(parent);
+        // Should now have both the original contained and the nested one
+        assertTrue(parent.getContained().size() >= 2);
+    }
+
+    @Test
+    void getAllContainedResourcesEmpty() {
+        var patient = new Patient();
+        var result = ContainedHelper.getAllContainedResources(patient);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getAllContainedResourcesNested() {
+        var parent = new Patient();
+        var child = new Observation();
+        child.setId("obs1");
+        var grandchild = new Encounter();
+        grandchild.setId("enc1");
+        child.addContained(grandchild);
+        parent.addContained(child);
+
+        var all = ContainedHelper.getAllContainedResources(parent);
+        assertEquals(2, all.size());
+    }
+
+    @Test
+    void getAllContainedResourcesNonDomainResource() {
+        var bundle = new org.hl7.fhir.r4.model.Bundle();
+        var result = ContainedHelper.getAllContainedResources(bundle);
+        assertTrue(result.isEmpty());
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/r4/VersionSpecificHelperTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/r4/VersionSpecificHelperTest.java
@@ -1,0 +1,130 @@
+package org.opencds.cqf.fhir.utility.r4;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.repository.IRepository;
+import java.util.Collections;
+import java.util.Map;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.junit.jupiter.api.Test;
+
+class VersionSpecificHelperTest {
+
+    private IRepository mockR4Repo() {
+        var repo = mock(IRepository.class);
+        when(repo.fhirContext()).thenReturn(FhirContext.forR4Cached());
+        return repo;
+    }
+
+    // -- R4 SearchHelper --
+
+    @Test
+    void searchRepositoryByCanonicalR4() {
+        var repo = mockR4Repo();
+        var vs = new ValueSet().setId("test-vs");
+        var bundle = new Bundle();
+        bundle.addEntry().setResource(vs);
+        when(repo.search(any(), any(), any(Map.class))).thenReturn(bundle);
+        var result = SearchHelper.searchRepositoryByCanonical(
+                repo, new org.hl7.fhir.r4.model.CanonicalType("http://example.org/ValueSet/test"));
+        assertEquals("test-vs", result.getIdElement().getIdPart());
+    }
+
+    @Test
+    void searchRepositoryByCanonicalWithVersionR4() {
+        var repo = mockR4Repo();
+        var vs = new ValueSet().setId("test-vs");
+        var bundle = new Bundle();
+        bundle.addEntry().setResource(vs);
+        when(repo.search(any(), any(), any(Map.class))).thenReturn(bundle);
+        var result = SearchHelper.searchRepositoryByCanonical(
+                repo, new org.hl7.fhir.r4.model.CanonicalType("http://example.org/ValueSet/test|1.0"));
+        assertNotNull(result);
+    }
+
+    @Test
+    void searchRepositoryByCanonicalNotFoundThrows() {
+        var repo = mockR4Repo();
+        when(repo.search(any(), any(), any(Map.class))).thenReturn(new Bundle());
+        assertThrows(
+                FHIRException.class,
+                () -> SearchHelper.searchRepositoryByCanonical(
+                        repo, new org.hl7.fhir.r4.model.CanonicalType("http://example.org/ValueSet/missing")));
+    }
+
+    @Test
+    void searchRepositoryWithPagingR4() {
+        var repo = mockR4Repo();
+        var bundle = new Bundle();
+        bundle.addEntry().setResource(new ValueSet().setId("vs1"));
+        when(repo.search(any(), any(), any(Map.class), any())).thenReturn(bundle);
+        var result = SearchHelper.searchRepositoryWithPaging(
+                repo, ValueSet.class, Collections.emptyMap(), Collections.emptyMap());
+        assertEquals(1, result.getEntry().size());
+    }
+
+    @Test
+    void searchRepositoryWithPagingAndNextLink() {
+        var repo = mockR4Repo();
+        var bundle1 = new Bundle();
+        bundle1.addEntry().setResource(new ValueSet().setId("vs1"));
+        bundle1.addLink().setRelation("next").setUrl("http://example.com/next");
+        when(repo.search(any(), any(), any(Map.class), any())).thenReturn(bundle1);
+
+        var bundle2 = new Bundle();
+        bundle2.addEntry().setResource(new ValueSet().setId("vs2"));
+        when(repo.link(any(), any(String.class))).thenReturn(bundle2);
+
+        var result = SearchHelper.searchRepositoryWithPaging(
+                repo, ValueSet.class, Collections.emptyMap(), Collections.emptyMap());
+        assertEquals(2, result.getEntry().size());
+    }
+
+    // -- R4 MetadataResourceHelper --
+
+    @Test
+    void forEachMetadataResourceR4() {
+        var repo = mockR4Repo();
+        var library = new org.hl7.fhir.r4.model.Library();
+        library.setId("lib1");
+        when(repo.read(any(), any())).thenReturn(library);
+
+        var entry = new org.hl7.fhir.r4.model.Bundle.BundleEntryComponent();
+        entry.getResponse().setLocation("Library/lib1");
+
+        var results = new java.util.ArrayList<>();
+        MetadataResourceHelper.forEachMetadataResource(java.util.List.of(entry), results::add, repo);
+        assertEquals(1, results.size());
+    }
+
+    @Test
+    void forEachMetadataResourceMultipleTypes() {
+        var repo = mockR4Repo();
+        when(repo.read(any(), any())).thenReturn(new org.hl7.fhir.r4.model.ValueSet());
+
+        var entries = java.util.List.of(
+                entryWithLocation("ValueSet/vs1"),
+                entryWithLocation("Measure/m1"),
+                entryWithLocation("PlanDefinition/pd1"),
+                entryWithLocation("ActivityDefinition/ad1"),
+                entryWithLocation("UnknownType/x1"));
+
+        var results = new java.util.ArrayList<>();
+        MetadataResourceHelper.forEachMetadataResource(entries, results::add, repo);
+        assertEquals(5, results.size());
+    }
+
+    private org.hl7.fhir.r4.model.Bundle.BundleEntryComponent entryWithLocation(String location) {
+        var entry = new org.hl7.fhir.r4.model.Bundle.BundleEntryComponent();
+        entry.getResponse().setLocation(location);
+        return entry;
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/r5/ContainedHelperTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/r5/ContainedHelperTest.java
@@ -1,0 +1,48 @@
+package org.opencds.cqf.fhir.utility.r5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hl7.fhir.r5.model.Encounter;
+import org.hl7.fhir.r5.model.Observation;
+import org.hl7.fhir.r5.model.Patient;
+import org.junit.jupiter.api.Test;
+
+class ContainedHelperTest {
+
+    @Test
+    void liftContainedResourcesToParent() {
+        var parent = new Patient();
+        parent.setId("parent");
+        var contained = new Observation();
+        contained.setId("obs1");
+        var nestedContained = new Encounter();
+        nestedContained.setId("enc1");
+        contained.addContained(nestedContained);
+        parent.addContained(contained);
+
+        ContainedHelper.liftContainedResourcesToParent(parent);
+        assertTrue(parent.getContained().size() >= 2);
+    }
+
+    @Test
+    void getAllContainedResourcesNested() {
+        var parent = new Patient();
+        var child = new Observation();
+        child.setId("obs1");
+        var grandchild = new Encounter();
+        grandchild.setId("enc1");
+        child.addContained(grandchild);
+        parent.addContained(child);
+
+        var all = ContainedHelper.getAllContainedResources(parent);
+        assertEquals(2, all.size());
+    }
+
+    @Test
+    void getAllContainedResourcesNonDomainResource() {
+        var bundle = new org.hl7.fhir.r5.model.Bundle();
+        var result = ContainedHelper.getAllContainedResources(bundle);
+        assertTrue(result.isEmpty());
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/search/SearchesTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/search/SearchesTest.java
@@ -1,0 +1,164 @@
+package org.opencds.cqf.fhir.utility.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import ca.uhn.fhir.rest.param.StringParam;
+import ca.uhn.fhir.rest.param.TokenParam;
+import ca.uhn.fhir.rest.param.TokenParamModifier;
+import ca.uhn.fhir.rest.param.UriParam;
+import org.junit.jupiter.api.Test;
+
+class SearchesTest {
+
+    @Test
+    void allIsEmptyMap() {
+        assertTrue(Searches.ALL.isEmpty());
+    }
+
+    @Test
+    void byIdSingle() {
+        var result = Searches.byId("123");
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey("_id"));
+        assertEquals(1, result.get("_id").size());
+        assertTrue(result.get("_id").get(0) instanceof TokenParam);
+    }
+
+    @Test
+    void byIdMultiple() {
+        var result = Searches.byId("1", "2", "3");
+        assertEquals(1, result.size());
+        assertEquals(3, result.get("_id").size());
+    }
+
+    @Test
+    void byProfile() {
+        var result = Searches.byProfile("http://example.org/profile");
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey("_profile"));
+        assertTrue(result.get("_profile").get(0) instanceof UriParam);
+    }
+
+    @Test
+    void byCanonicalWithVersion() {
+        var result = Searches.byCanonical("http://example.org/Library/test|1.0");
+        assertTrue(result.containsKey("url"));
+        assertTrue(result.containsKey("version"));
+    }
+
+    @Test
+    void byCanonicalWithoutVersion() {
+        var result = Searches.byCanonical("http://example.org/Library/test");
+        assertTrue(result.containsKey("url"));
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void byCodeAndSystem() {
+        var result = Searches.byCodeAndSystem("test-code", "http://example.org");
+        assertTrue(result.containsKey("code"));
+        var param = (TokenParam) result.get("code").get(0);
+        assertEquals("test-code", param.getValue());
+        assertEquals("http://example.org", param.getSystem());
+    }
+
+    @Test
+    void byUrl() {
+        var result = Searches.byUrl("http://example.org/Library/test");
+        assertTrue(result.containsKey("url"));
+        assertTrue(result.get("url").get(0) instanceof UriParam);
+    }
+
+    @Test
+    void byUrlAndVersion() {
+        var result = Searches.byUrlAndVersion("http://example.org/Library/test", "1.0");
+        assertTrue(result.containsKey("url"));
+        assertTrue(result.containsKey("version"));
+    }
+
+    @Test
+    void byName() {
+        var result = Searches.byName("TestLibrary");
+        assertTrue(result.containsKey("name"));
+        assertTrue(result.get("name").get(0) instanceof StringParam);
+    }
+
+    @Test
+    void byStatus() {
+        var result = Searches.byStatus("active");
+        assertTrue(result.containsKey("status"));
+        var param = (TokenParam) result.get("status").get(0);
+        assertEquals("active", param.getValue());
+    }
+
+    @Test
+    void exceptStatus() {
+        var result = Searches.exceptStatus("retired");
+        assertTrue(result.containsKey("status"));
+        var param = (TokenParam) result.get("status").get(0);
+        assertEquals("retired", param.getValue());
+        assertEquals(TokenParamModifier.NOT, param.getModifier());
+    }
+
+    @Test
+    void byNameAndVersion() {
+        var result = Searches.byNameAndVersion("TestLib", "2.0");
+        assertTrue(result.containsKey("name"));
+        assertTrue(result.containsKey("version"));
+    }
+
+    @Test
+    void byNameAndVersionNullVersion() {
+        var result = Searches.byNameAndVersion("TestLib", null);
+        assertTrue(result.containsKey("name"));
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void byNameAndVersionEmptyVersion() {
+        var result = Searches.byNameAndVersion("TestLib", "");
+        assertTrue(result.containsKey("name"));
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void builderWithReferenceParam() {
+        var result =
+                Searches.builder().withReferenceParam("patient", "Patient/123").build();
+        assertNotNull(result);
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void getPatientSearchParamDstu3() {
+        assertEquals("_id", Searches.getPatientSearchParam(FhirVersionEnum.DSTU3, "Patient"));
+        assertEquals("member", Searches.getPatientSearchParam(FhirVersionEnum.DSTU3, "Group"));
+        assertEquals("individual", Searches.getPatientSearchParam(FhirVersionEnum.DSTU3, "ResearchSubject"));
+        assertEquals("actor", Searches.getPatientSearchParam(FhirVersionEnum.DSTU3, "Appointment"));
+        assertEquals("subject", Searches.getPatientSearchParam(FhirVersionEnum.DSTU3, "Observation"));
+        assertEquals("patient", Searches.getPatientSearchParam(FhirVersionEnum.DSTU3, "Encounter"));
+        assertNull(Searches.getPatientSearchParam(FhirVersionEnum.DSTU3, "Organization"));
+    }
+
+    @Test
+    void getPatientSearchParamR4() {
+        assertEquals("_id", Searches.getPatientSearchParam(FhirVersionEnum.R4, "Patient"));
+        assertEquals("member", Searches.getPatientSearchParam(FhirVersionEnum.R4, "Group"));
+        assertEquals("individual", Searches.getPatientSearchParam(FhirVersionEnum.R4, "ResearchSubject"));
+        assertEquals("actor", Searches.getPatientSearchParam(FhirVersionEnum.R4, "Appointment"));
+        assertEquals("subject", Searches.getPatientSearchParam(FhirVersionEnum.R4, "Observation"));
+        assertEquals("patient", Searches.getPatientSearchParam(FhirVersionEnum.R4, "Encounter"));
+        assertEquals("policy-holder", Searches.getPatientSearchParam(FhirVersionEnum.R4, "Coverage"));
+        assertNull(Searches.getPatientSearchParam(FhirVersionEnum.R4, "Organization"));
+    }
+
+    @Test
+    void getPatientSearchParamR5() {
+        assertEquals("_id", Searches.getPatientSearchParam(FhirVersionEnum.R5, "Patient"));
+        assertEquals("subject", Searches.getPatientSearchParam(FhirVersionEnum.R5, "RequestOrchestration"));
+    }
+}


### PR DESCRIPTION
Add unit tests across the module targeting uncovered classes: search helpers, bundle helpers, builders, adapters, iterables, monads, matchers, interceptors, and package helpers.