### PR TITLE
Better support for extension values in dynamicValues

### DIFF
--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/model/DynamicModelResolver.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/model/DynamicModelResolver.java
@@ -5,10 +5,10 @@ import ca.uhn.fhir.context.BaseRuntimeElementCompositeDefinition;
 import ca.uhn.fhir.context.BaseRuntimeElementDefinition;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeChildPrimitiveEnumerationDatatypeDefinition;
+import ca.uhn.fhir.context.RuntimePrimitiveDatatypeDefinition;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
-import ca.uhn.fhir.context.RuntimePrimitiveDatatypeDefinition;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IAnyResource;
 import org.hl7.fhir.instance.model.api.IBase;
@@ -37,8 +37,7 @@ public class DynamicModelResolver extends CachingModelResolverDecorator {
     private static final String PRIMITIVE = "IPrimitiveType";
     private static final String URI = "UriType";
 
-    private static final Pattern EXTENSION_PATTERN =
-        Pattern.compile("extension\\('([^']+)'\\)(\\[(\\d+)\\])?");
+    private static final Pattern EXTENSION_PATTERN = Pattern.compile("extension\\('([^']+)'\\)(\\[(\\d+)\\])?");
 
     private record ExtensionInfo(String url, int index) {}
 
@@ -214,18 +213,16 @@ public class DynamicModelResolver extends CachingModelResolverDecorator {
                 if (targetDef != null) {
                     var targetValues = targetDef.getAccessor().getValues(target);
                     var targetValue = (targetValues.size() >= index + 1 && !isLast)
-                        ? getTargetValueFromList(sliceName, index, targetValues)
-                        : getTargetValue(target, value, isLast, targetPath, targetDef);
+                            ? getTargetValueFromList(sliceName, index, targetValues)
+                            : getTargetValue(target, value, isLast, targetPath, targetDef);
                     target = targetValue == null ? target : targetValue;
                     if (!isLast) {
                         var nextDef = fhirContext.getElementDefinition(target.getClass());
-                        if(nextDef instanceof BaseRuntimeElementCompositeDefinition<?>)
-                            def = nextDef;
-                        else if (nextDef instanceof RuntimePrimitiveDatatypeDefinition)
-                            def = nextDef;
+                        if (nextDef instanceof BaseRuntimeElementCompositeDefinition<?>) def = nextDef;
+                        else if (nextDef instanceof RuntimePrimitiveDatatypeDefinition) def = nextDef;
                         else
                             throw new UnknownType("Unable to resolve the runtime definition for %s"
-                                .formatted(target.getClass().getName()));
+                                    .formatted(target.getClass().getName()));
                     }
                 }
             }
@@ -248,7 +245,7 @@ public class DynamicModelResolver extends CachingModelResolverDecorator {
                 current.append(c);
             }
         }
-        if (!current.isEmpty()) {
+        if (current.length() > 0) {
             segments.add(current.toString());
         }
         return segments;
@@ -272,11 +269,11 @@ public class DynamicModelResolver extends CachingModelResolverDecorator {
     private IBase resolveOrCreateExtension(IBase target, ExtensionInfo info) {
         if (!(target instanceof IBaseHasExtensions hasExtensions)) {
             throw new IllegalArgumentException(
-                "Target does not support extensions: " + target.getClass().getName());
+                    "Target does not support extensions: " + target.getClass().getName());
         }
         var matching = hasExtensions.getExtension().stream()
-            .filter(ext -> info.url().equals(ext.getUrl()))
-            .toList();
+                .filter(ext -> info.url().equals(ext.getUrl()))
+                .toList();
         if (matching.size() > info.index()) {
             return (IBase) matching.get(info.index());
         }
@@ -295,7 +292,7 @@ public class DynamicModelResolver extends CachingModelResolverDecorator {
             case R4 -> new org.hl7.fhir.r4.model.Extension(url);
             case R5 -> new org.hl7.fhir.r5.model.Extension(url);
             default -> throw new IllegalStateException(
-                "Unsupported FHIR version: " + fhirContext.getVersion().getVersion());
+                    "Unsupported FHIR version: " + fhirContext.getVersion().getVersion());
         };
     }
 

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/model/DynamicModelResolverTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/model/DynamicModelResolverTest.java
@@ -30,7 +30,8 @@ class DynamicModelResolverTest {
         var communicationRequest = new CommunicationRequest();
         RuntimeResourceDefinition def = fhirContext.getResourceDefinition(communicationRequest);
 
-        var path = "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[0].extension('lang').valueCode";
+        var path =
+                "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[0].extension('lang').valueCode";
         var value = new StringType("en");
 
         resolver.setNestedValue(communicationRequest, path, value, def);
@@ -55,12 +56,14 @@ class DynamicModelResolverTest {
 
         RuntimeResourceDefinition def = fhirContext.getResourceDefinition(communicationRequest);
 
-        var path = "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[0].extension('lang').valueCode";
+        var path =
+                "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[0].extension('lang').valueCode";
         var value = new StringType("en");
 
         resolver.setNestedValue(communicationRequest, path, value, def);
 
-        var contentString = (StringType) communicationRequest.getPayloadFirstRep().getContent();
+        var contentString =
+                (StringType) communicationRequest.getPayloadFirstRep().getContent();
         assertNotNull(contentString);
         assertEquals("Hello", contentString.getValue());
 
@@ -83,7 +86,8 @@ class DynamicModelResolverTest {
 
         RuntimeResourceDefinition def = fhirContext.getResourceDefinition(communicationRequest);
 
-        var path = "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[0].extension('lang').valueCode";
+        var path =
+                "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[0].extension('lang').valueCode";
         var value = new StringType("en");
 
         resolver.setNestedValue(communicationRequest, path, value, def);
@@ -104,12 +108,14 @@ class DynamicModelResolverTest {
 
         RuntimeResourceDefinition def = fhirContext.getResourceDefinition(communicationRequest);
 
-        var path = "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[0].extension('content').valueString";
+        var path =
+                "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[0].extension('content').valueString";
         var value = new StringType("Hej");
 
         resolver.setNestedValue(communicationRequest, path, value, def);
 
-        var contentString = (StringType) communicationRequest.getPayloadFirstRep().getContent();
+        var contentString =
+                (StringType) communicationRequest.getPayloadFirstRep().getContent();
         var translationExt = contentString.getExtensionByUrl(TRANSLATION_EXT_URL);
         assertNotNull(translationExt);
 
@@ -128,19 +134,20 @@ class DynamicModelResolverTest {
 
         // Set lang
         resolver.setNestedValue(
-            communicationRequest,
-            "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[0].extension('lang').valueCode",
-            new StringType("da"),
-            def);
+                communicationRequest,
+                "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[0].extension('lang').valueCode",
+                new StringType("da"),
+                def);
 
         // Set content
         resolver.setNestedValue(
-            communicationRequest,
-            "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[0].extension('content').valueString",
-            new StringType("Hej"),
-            def);
+                communicationRequest,
+                "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[0].extension('content').valueString",
+                new StringType("Hej"),
+                def);
 
-        var contentString = (StringType) communicationRequest.getPayloadFirstRep().getContent();
+        var contentString =
+                (StringType) communicationRequest.getPayloadFirstRep().getContent();
         var translationExt = contentString.getExtensionByUrl(TRANSLATION_EXT_URL);
         assertNotNull(translationExt);
 
@@ -166,7 +173,8 @@ class DynamicModelResolverTest {
         RuntimeResourceDefinition def = fhirContext.getResourceDefinition(communicationRequest);
 
         // Add a second translation at index [1]
-        var path = "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[1].extension('lang').valueCode";
+        var path =
+                "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[1].extension('lang').valueCode";
         var value = new StringType("de");
 
         resolver.setNestedValue(communicationRequest, path, value, def);

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/model/DynamicModelResolverTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/model/DynamicModelResolverTest.java
@@ -1,0 +1,182 @@
+package org.opencds.cqf.fhir.utility.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.RuntimeResourceDefinition;
+import org.hl7.fhir.r4.model.CommunicationRequest;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.cql.engine.fhir.model.R4FhirModelResolver;
+
+class DynamicModelResolverTest {
+
+    private static final String TRANSLATION_EXT_URL = "http://hl7.org/fhir/StructureDefinition/translation";
+
+    private DynamicModelResolver resolver;
+    private FhirContext fhirContext;
+
+    @BeforeEach
+    void setUp() {
+        fhirContext = FhirContext.forR4Cached();
+        resolver = new DynamicModelResolver(new R4FhirModelResolver(), fhirContext);
+    }
+
+    @Test
+    void setNestedValue_setsValueCodeOnTranslationExtension_whenCommunicationRequestHasNoExistingPayload() {
+        var communicationRequest = new CommunicationRequest();
+        RuntimeResourceDefinition def = fhirContext.getResourceDefinition(communicationRequest);
+
+        var path = "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[0].extension('lang').valueCode";
+        var value = new StringType("en");
+
+        resolver.setNestedValue(communicationRequest, path, value, def);
+
+        assertNotNull(communicationRequest.getPayloadFirstRep());
+        var contentString = communicationRequest.getPayloadFirstRep().getContent();
+        assertNotNull(contentString, "contentString should have been created");
+
+        var translationExt = ((StringType) contentString).getExtensionByUrl(TRANSLATION_EXT_URL);
+        assertNotNull(translationExt, "translation extension should have been created");
+
+        var langExt = translationExt.getExtensionByUrl("lang");
+        assertNotNull(langExt, "lang extension should have been created");
+
+        assertEquals("en", langExt.getValue().primitiveValue());
+    }
+
+    @Test
+    void setNestedValue_setsValueCodeOnTranslationExtension_whenPayloadAlreadyExists() {
+        var communicationRequest = new CommunicationRequest();
+        communicationRequest.addPayload().setContent(new StringType("Hello"));
+
+        RuntimeResourceDefinition def = fhirContext.getResourceDefinition(communicationRequest);
+
+        var path = "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[0].extension('lang').valueCode";
+        var value = new StringType("en");
+
+        resolver.setNestedValue(communicationRequest, path, value, def);
+
+        var contentString = (StringType) communicationRequest.getPayloadFirstRep().getContent();
+        assertNotNull(contentString);
+        assertEquals("Hello", contentString.getValue());
+
+        var translationExt = contentString.getExtensionByUrl(TRANSLATION_EXT_URL);
+        assertNotNull(translationExt, "translation extension should have been created on existing contentString");
+
+        var langExt = translationExt.getExtensionByUrl("lang");
+        assertNotNull(langExt, "lang extension should have been created");
+
+        assertEquals("en", langExt.getValue().primitiveValue());
+    }
+
+    @Test
+    void setNestedValue_setsValueCodeOnTranslationExtension_whenTranslationExtensionAlreadyExists() {
+        var communicationRequest = new CommunicationRequest();
+        var contentString = new StringType("Hello");
+        var translationExt = new Extension(TRANSLATION_EXT_URL);
+        contentString.addExtension(translationExt);
+        communicationRequest.addPayload().setContent(contentString);
+
+        RuntimeResourceDefinition def = fhirContext.getResourceDefinition(communicationRequest);
+
+        var path = "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[0].extension('lang').valueCode";
+        var value = new StringType("en");
+
+        resolver.setNestedValue(communicationRequest, path, value, def);
+
+        var resultTranslationExt = contentString.getExtensionByUrl(TRANSLATION_EXT_URL);
+        assertNotNull(resultTranslationExt);
+
+        var langExt = resultTranslationExt.getExtensionByUrl("lang");
+        assertNotNull(langExt, "lang extension should have been created on existing translation extension");
+
+        assertEquals("en", langExt.getValue().primitiveValue());
+    }
+
+    @Test
+    void setNestedValue_setsValueStringOnTranslationExtension() {
+        var communicationRequest = new CommunicationRequest();
+        communicationRequest.addPayload().setContent(new StringType("Hello"));
+
+        RuntimeResourceDefinition def = fhirContext.getResourceDefinition(communicationRequest);
+
+        var path = "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[0].extension('content').valueString";
+        var value = new StringType("Hej");
+
+        resolver.setNestedValue(communicationRequest, path, value, def);
+
+        var contentString = (StringType) communicationRequest.getPayloadFirstRep().getContent();
+        var translationExt = contentString.getExtensionByUrl(TRANSLATION_EXT_URL);
+        assertNotNull(translationExt);
+
+        var contentExt = translationExt.getExtensionByUrl("content");
+        assertNotNull(contentExt, "content extension should have been created");
+
+        assertEquals("Hej", contentExt.getValue().primitiveValue());
+    }
+
+    @Test
+    void setNestedValue_setsMultipleTranslationProperties() {
+        var communicationRequest = new CommunicationRequest();
+        communicationRequest.addPayload().setContent(new StringType("Hello"));
+
+        RuntimeResourceDefinition def = fhirContext.getResourceDefinition(communicationRequest);
+
+        // Set lang
+        resolver.setNestedValue(
+            communicationRequest,
+            "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[0].extension('lang').valueCode",
+            new StringType("da"),
+            def);
+
+        // Set content
+        resolver.setNestedValue(
+            communicationRequest,
+            "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[0].extension('content').valueString",
+            new StringType("Hej"),
+            def);
+
+        var contentString = (StringType) communicationRequest.getPayloadFirstRep().getContent();
+        var translationExt = contentString.getExtensionByUrl(TRANSLATION_EXT_URL);
+        assertNotNull(translationExt);
+
+        var langExt = translationExt.getExtensionByUrl("lang");
+        assertNotNull(langExt);
+        assertEquals("da", langExt.getValue().primitiveValue());
+
+        var contentExt = translationExt.getExtensionByUrl("content");
+        assertNotNull(contentExt);
+        assertEquals("Hej", contentExt.getValue().primitiveValue());
+    }
+
+    @Test
+    void setNestedValue_setsSecondTranslation() {
+        var communicationRequest = new CommunicationRequest();
+        var contentString = new StringType("Hello");
+        var existingTranslation = new Extension(TRANSLATION_EXT_URL);
+        existingTranslation.addExtension("lang", new StringType("da"));
+        existingTranslation.addExtension("content", new StringType("Hej"));
+        contentString.addExtension(existingTranslation);
+        communicationRequest.addPayload().setContent(contentString);
+
+        RuntimeResourceDefinition def = fhirContext.getResourceDefinition(communicationRequest);
+
+        // Add a second translation at index [1]
+        var path = "payload[0].contentString.extension('http://hl7.org/fhir/StructureDefinition/translation')[1].extension('lang').valueCode";
+        var value = new StringType("de");
+
+        resolver.setNestedValue(communicationRequest, path, value, def);
+
+        var extensions = contentString.getExtensionsByUrl(TRANSLATION_EXT_URL);
+        assertEquals(2, extensions.size(), "Should have two translation extensions");
+
+        var secondTranslation = extensions.get(1);
+        var langExt = secondTranslation.getExtensionByUrl("lang");
+        assertNotNull(langExt);
+        assertEquals("de", langExt.getValue().primitiveValue());
+    }
+}


### PR DESCRIPTION
This pull request significantly enhances the `DynamicModelResolver` to support setting values on deeply nested FHIR elements, especially those involving extensions with complex path expressions. The main focus is on robust handling of FHIR extensions in resource paths, including proper creation and indexing of extensions as needed. Comprehensive unit tests have also been added to verify these behaviors.

**Enhancements to `DynamicModelResolver`:**

* Added support for parsing and handling extension path segments (e.g., `extension('url')[index]`) in the `setNestedValue` method, including correct creation and indexing of extensions when they do not exist.
* Refactored path parsing logic to handle quoted segments and nested extensions, ensuring accurate traversal and modification of FHIR resources.
* Improved runtime type resolution for FHIR elements, supporting both composite and primitive types when traversing paths.

**Testing improvements:**

* Introduced a comprehensive test suite in `DynamicModelResolverTest.java` to cover various scenarios of setting nested values involving FHIR extensions, including cases with no existing payload, existing payload, multiple extensions, and extension indexing.

**Imports and utility updates:**

* Added necessary imports for new FHIR types, collections, and regex utilities to support the new logic. [[1]](diffhunk://#diff-8a663b68d987b40f6976ad56269d85cfae62763722c0eaa4c17cfdaf54162be9R5-R20) [[2]](diffhunk://#diff-8a663b68d987b40f6976ad56269d85cfae62763722c0eaa4c17cfdaf54162be9R40-R44)