### PR TITLE
Implement a solid and reusable RepositoryProxyFactory pattern for Repository proxies.

### DIFF
--- a/cqf-fhir-benchmark/src/test/java/org/opencds/cqf/fhir/benchmark/ActivityDefinitionProcessorFactory.java
+++ b/cqf-fhir-benchmark/src/test/java/org/opencds/cqf/fhir/benchmark/ActivityDefinitionProcessorFactory.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.fhir.benchmark;
 
 import ca.uhn.fhir.repository.IRepository;
+import org.opencds.cqf.fhir.cr.CrSettings;
 import org.opencds.cqf.fhir.cr.activitydefinition.ActivityDefinitionProcessor;
 import org.opencds.cqf.fhir.utility.repository.operations.IActivityDefinitionProcessor;
 import org.opencds.cqf.fhir.utility.repository.operations.IActivityDefinitionProcessorFactory;
@@ -9,6 +10,7 @@ public class ActivityDefinitionProcessorFactory implements IActivityDefinitionPr
 
     @Override
     public IActivityDefinitionProcessor create(IRepository repository) {
-        return new ActivityDefinitionProcessor(repository);
+        return new ActivityDefinitionProcessor(
+                repository, CrSettings.getDefault(), null, null, new NoOpRepositoryProxyFactory());
     }
 }

--- a/cqf-fhir-benchmark/src/test/java/org/opencds/cqf/fhir/benchmark/NoOpRepositoryProxyFactory.java
+++ b/cqf-fhir-benchmark/src/test/java/org/opencds/cqf/fhir/benchmark/NoOpRepositoryProxyFactory.java
@@ -1,0 +1,21 @@
+package org.opencds.cqf.fhir.benchmark;
+
+import ca.uhn.fhir.repository.IRepository;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
+
+/**
+ * A RepositoryProxyFactory that always returns the local Repository for tests only.
+ */
+public class NoOpRepositoryProxyFactory implements RepositoryProxyFactory {
+
+    @Override
+    public IRepository proxy(
+            IRepository localRepository,
+            Boolean useServerData,
+            IBaseResource dataEndpoint,
+            IBaseResource contentEndpoint,
+            IBaseResource terminologyEndpoint) {
+        return localRepository;
+    }
+}

--- a/cqf-fhir-benchmark/src/test/java/org/opencds/cqf/fhir/benchmark/measure/r4/Measure.java
+++ b/cqf-fhir-benchmark/src/test/java/org/opencds/cqf/fhir/benchmark/measure/r4/Measure.java
@@ -10,6 +10,7 @@ import java.util.function.Supplier;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.MeasureReport;
+import org.opencds.cqf.fhir.benchmark.NoOpRepositoryProxyFactory;
 import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.SEARCH_FILTER_MODE;
 import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.TERMINOLOGY_FILTER_MODE;
 import org.opencds.cqf.fhir.cql.engine.terminology.TerminologySettings.VALUESET_EXPANSION_MODE;
@@ -85,7 +86,12 @@ public class Measure {
         }
 
         private R4MultiMeasureService buildMultiMeasureService() {
-            return new R4MultiMeasureService(repository, evaluationOptions, serverBase, measurePeriodValidator);
+            return new R4MultiMeasureService(
+                    repository,
+                    evaluationOptions,
+                    serverBase,
+                    measurePeriodValidator,
+                    new NoOpRepositoryProxyFactory());
         }
 
         public When when() {

--- a/cqf-fhir-benchmark/src/test/java/org/opencds/cqf/fhir/benchmark/plandefinition/TestPlanDefinition.java
+++ b/cqf-fhir-benchmark/src/test/java/org/opencds/cqf/fhir/benchmark/plandefinition/TestPlanDefinition.java
@@ -38,10 +38,12 @@ import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.json.JSONException;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.benchmark.NoOpRepositoryProxyFactory;
 import org.opencds.cqf.fhir.benchmark.TestOperationProvider;
 import org.opencds.cqf.fhir.benchmark.helpers.DataRequirementsLibrary;
 import org.opencds.cqf.fhir.benchmark.helpers.GeneratedPackage;
 import org.opencds.cqf.fhir.cql.EvaluationSettings;
+import org.opencds.cqf.fhir.cql.LibraryEngine;
 import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.SEARCH_FILTER_MODE;
 import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.TERMINOLOGY_FILTER_MODE;
 import org.opencds.cqf.fhir.cql.engine.terminology.TerminologySettings.VALUESET_EXPANSION_MODE;
@@ -53,6 +55,7 @@ import org.opencds.cqf.fhir.utility.adapter.IParametersAdapter;
 import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 import org.opencds.cqf.fhir.utility.monad.Eithers;
 import org.opencds.cqf.fhir.utility.repository.InMemoryFhirRepository;
+import org.opencds.cqf.fhir.utility.repository.Repositories;
 import org.opencds.cqf.fhir.utility.repository.ig.IgRepository;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -138,16 +141,17 @@ public class TestPlanDefinition {
                         .setValuesetExpansionMode(VALUESET_EXPANSION_MODE.PERFORM_NAIVE_EXPANSION);
             }
             var crSettings = CrSettings.getDefault().withEvaluationSettings(evaluationSettings);
-            return new PlanDefinitionProcessor(repository, crSettings);
+            return new PlanDefinitionProcessor(repository, crSettings, null, null, new NoOpRepositoryProxyFactory());
         }
 
         public When when() {
-            return new When(repository, buildProcessor(repository));
+            return new When(this, repository);
         }
     }
 
     @SuppressWarnings("UnstableApiUsage")
     public static class When {
+        private final Given given;
         private final IRepository repository;
         private final PlanDefinitionProcessor processor;
         private final IParser jsonParser;
@@ -168,9 +172,10 @@ public class TestPlanDefinition {
         private IBaseParameters parameters;
         private boolean isPackagePut;
 
-        public When(IRepository repository, PlanDefinitionProcessor processor) {
+        public When(Given given, IRepository repository) {
+            this.given = given;
             this.repository = repository;
-            this.processor = processor;
+            this.processor = given.buildProcessor(repository);
             jsonParser = repository.fhirContext().newJsonParser();
         }
 
@@ -272,7 +277,10 @@ public class TestPlanDefinition {
             if (additionalDataId != null) {
                 loadAdditionalData(readRepository(repository, additionalDataId));
             }
-            var param = (IParametersAdapter) IAdapterFactory.createAdapterForResource(processor.applyR5(
+            var proxiedRepo = Repositories.proxy(
+                    repository, useServerData, dataRepository, contentRepository, terminologyRepository);
+            var applyProcessor = given.buildProcessor(proxiedRepo);
+            var param = (IParametersAdapter) IAdapterFactory.createAdapterForResource(applyProcessor.applyR5(
                     Eithers.forMiddle3(Ids.newId(repository.fhirContext(), PLAN_DEFINITION, planDefinitionId)),
                     List.of(subjectId),
                     encounterId,
@@ -284,12 +292,9 @@ public class TestPlanDefinition {
                     null,
                     null,
                     parameters,
-                    useServerData,
                     additionalData,
                     prefetchData,
-                    dataRepository,
-                    contentRepository,
-                    terminologyRepository));
+                    new LibraryEngine(proxiedRepo, applyProcessor.settings().getEvaluationSettings())));
             return (IBaseBundle) param.getParameter().get(0).getResource();
         }
 
@@ -301,9 +306,12 @@ public class TestPlanDefinition {
             if (additionalDataId != null) {
                 loadAdditionalData(readRepository(repository, additionalDataId));
             }
+            var proxiedRepo = Repositories.proxy(
+                    repository, useServerData, dataRepository, contentRepository, terminologyRepository);
+            var applyProcessor = given.buildProcessor(proxiedRepo);
             return new GeneratedCarePlan(
                     repository,
-                    processor.apply(
+                    applyProcessor.apply(
                             Eithers.forMiddle3(Ids.newId(repository.fhirContext(), PLAN_DEFINITION, planDefinitionId)),
                             subjectId,
                             encounterId,
@@ -315,12 +323,10 @@ public class TestPlanDefinition {
                             null,
                             null,
                             parameters,
-                            useServerData,
                             additionalData,
                             prefetchData,
-                            dataRepository,
-                            contentRepository,
-                            terminologyRepository));
+                            new LibraryEngine(
+                                    proxiedRepo, applyProcessor.settings().getEvaluationSettings())));
         }
 
         public GeneratedPackage thenPackage() {

--- a/cqf-fhir-benchmark/src/test/java/org/opencds/cqf/fhir/benchmark/questionnaire/TestQuestionnaire.java
+++ b/cqf-fhir-benchmark/src/test/java/org/opencds/cqf/fhir/benchmark/questionnaire/TestQuestionnaire.java
@@ -13,6 +13,7 @@ import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
+import org.opencds.cqf.fhir.benchmark.NoOpRepositoryProxyFactory;
 import org.opencds.cqf.fhir.cql.EvaluationSettings;
 import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.SEARCH_FILTER_MODE;
 import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.TERMINOLOGY_FILTER_MODE;
@@ -53,7 +54,7 @@ public class TestQuestionnaire {
                         .setValuesetExpansionMode(VALUESET_EXPANSION_MODE.PERFORM_NAIVE_EXPANSION);
             }
             var crSettings = CrSettings.getDefault().withEvaluationSettings(evaluationSettings);
-            return new QuestionnaireProcessor(repository, crSettings, null);
+            return new QuestionnaireProcessor(repository, crSettings, null, new NoOpRepositoryProxyFactory());
         }
 
         public When when() {

--- a/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/config/CrBaseConfig.java
+++ b/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/config/CrBaseConfig.java
@@ -6,11 +6,18 @@ import org.opencds.cqf.fhir.cr.CrSettings;
 import org.opencds.cqf.fhir.cr.hapi.common.StringTimePeriodHandler;
 import org.opencds.cqf.fhir.cr.measure.common.MeasurePeriodValidator;
 import org.opencds.cqf.fhir.utility.client.TerminologyServerClientSettings;
+import org.opencds.cqf.fhir.utility.repository.DefaultRepositoryProxyFactory;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class CrBaseConfig {
+    @Bean
+    RepositoryProxyFactory repositoryProxyFactory() {
+        return new DefaultRepositoryProxyFactory();
+    }
+
     @Bean
     CrSettings settings(
             EvaluationSettings evaluationSettings, TerminologyServerClientSettings terminologyServerClientSettings) {

--- a/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/config/CrProcessorConfig.java
+++ b/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/config/CrProcessorConfig.java
@@ -25,6 +25,7 @@ import org.opencds.cqf.fhir.cr.plandefinition.PlanDefinitionProcessor;
 import org.opencds.cqf.fhir.cr.questionnaire.QuestionnaireProcessor;
 import org.opencds.cqf.fhir.cr.questionnaireresponse.QuestionnaireResponseProcessor;
 import org.opencds.cqf.fhir.cr.valueset.ValueSetProcessor;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -34,14 +35,20 @@ import org.springframework.context.annotation.Import;
 @Import({CrBaseConfig.class})
 public class CrProcessorConfig {
     @Bean
-    ICqlProcessorFactory cqlProcessorFactory(IRepositoryFactory repositoryFactory, CrSettings crSettings) {
-        return rd -> new CqlProcessor(repositoryFactory.create(rd), crSettings);
+    ICqlProcessorFactory cqlProcessorFactory(
+            IRepositoryFactory repositoryFactory,
+            CrSettings crSettings,
+            RepositoryProxyFactory repositoryProxyFactory) {
+        return rd -> new CqlProcessor(repositoryFactory.create(rd), crSettings, null, repositoryProxyFactory);
     }
 
     @Bean
     IActivityDefinitionProcessorFactory activityDefinitionProcessorFactory(
-            IRepositoryFactory repositoryFactory, CrSettings crSettings) {
-        return rd -> new ActivityDefinitionProcessor(repositoryFactory.create(rd), crSettings);
+            IRepositoryFactory repositoryFactory,
+            CrSettings crSettings,
+            RepositoryProxyFactory repositoryProxyFactory) {
+        return rd -> new ActivityDefinitionProcessor(
+                repositoryFactory.create(rd), crSettings, null, null, repositoryProxyFactory);
     }
 
     @Bean
@@ -52,27 +59,39 @@ public class CrProcessorConfig {
 
     @Bean
     IPlanDefinitionProcessorFactory planDefinitionProcessorFactory(
-            IRepositoryFactory repositoryFactory, CrSettings crSettings) {
-        return rd -> new PlanDefinitionProcessor(repositoryFactory.create(rd), crSettings);
+            IRepositoryFactory repositoryFactory,
+            CrSettings crSettings,
+            RepositoryProxyFactory repositoryProxyFactory) {
+        return rd -> new PlanDefinitionProcessor(
+                repositoryFactory.create(rd), crSettings, null, null, repositoryProxyFactory);
     }
 
     @Bean
     IQuestionnaireProcessorFactory questionnaireProcessorFactory(
-            IRepositoryFactory repositoryFactory, CrSettings crSettings) {
-        return rd -> new QuestionnaireProcessor(repositoryFactory.create(rd), crSettings);
+            IRepositoryFactory repositoryFactory,
+            CrSettings crSettings,
+            RepositoryProxyFactory repositoryProxyFactory) {
+        return rd -> new QuestionnaireProcessor(repositoryFactory.create(rd), crSettings, null, repositoryProxyFactory);
     }
 
     @Bean
     IQuestionnaireResponseProcessorFactory questionnaireResponseProcessorFactory(
-            IRepositoryFactory repositoryFactory, CrSettings crSettings) {
-        return rd -> new QuestionnaireResponseProcessor(repositoryFactory.create(rd), crSettings);
+            IRepositoryFactory repositoryFactory,
+            CrSettings crSettings,
+            RepositoryProxyFactory repositoryProxyFactory) {
+        return rd -> new QuestionnaireResponseProcessor(
+                repositoryFactory.create(rd), crSettings, null, repositoryProxyFactory);
     }
 
     @Bean
-    ILibraryProcessorFactory libraryProcessorFactory(IRepositoryFactory repositoryFactory, CrSettings crSettings) {
+    ILibraryProcessorFactory libraryProcessorFactory(
+            IRepositoryFactory repositoryFactory,
+            CrSettings crSettings,
+            RepositoryProxyFactory repositoryProxyFactory) {
         return rd -> {
             var repository = repositoryFactory.create(rd);
-            return new LibraryProcessor(repository, crSettings, List.of(new HapiArtifactDiffProcessor(repository)));
+            return new LibraryProcessor(
+                    repository, crSettings, List.of(new HapiArtifactDiffProcessor(repository)), repositoryProxyFactory);
         };
     }
 
@@ -89,8 +108,10 @@ public class CrProcessorConfig {
 
     @Bean
     IGraphDefinitionApplyRequestBuilderFactory graphDefinitionApplyRequestBuilderFactory(
-            IRepositoryFactory repositoryFactory, EvaluationSettings evaluationSettings) {
+            IRepositoryFactory repositoryFactory,
+            EvaluationSettings evaluationSettings,
+            RepositoryProxyFactory repositoryProxyFactory) {
 
-        return rd -> new ApplyRequestBuilder(repositoryFactory.create(rd), evaluationSettings);
+        return rd -> new ApplyRequestBuilder(repositoryFactory.create(rd), evaluationSettings, repositoryProxyFactory);
     }
 }

--- a/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/config/r4/CrR4Config.java
+++ b/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/config/r4/CrR4Config.java
@@ -49,6 +49,7 @@ import org.opencds.cqf.fhir.cr.measure.r4.R4DataRequirementsService;
 import org.opencds.cqf.fhir.cr.measure.r4.R4MultiMeasureService;
 import org.opencds.cqf.fhir.cr.measure.r4.R4SubmitDataService;
 import org.opencds.cqf.fhir.cr.measure.r4.utils.R4MeasureServiceUtils;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -73,22 +74,29 @@ public class CrR4Config {
     R4MeasureEvaluatorSingleFactory r4MeasureServiceFactory(
             IRepositoryFactory repositoryFactory,
             MeasureEvaluationOptions evaluationOptions,
-            MeasurePeriodValidator measurePeriodValidator) {
+            MeasurePeriodValidator measurePeriodValidator,
+            RepositoryProxyFactory repositoryProxyFactory) {
         // We are effectively returning an R4MeasureEvaluatorSingle her
         return requestDetails -> new R4MultiMeasureService(
                 repositoryFactory.create(requestDetails),
                 evaluationOptions,
                 requestDetails.getFhirServerBase(),
-                measurePeriodValidator);
+                measurePeriodValidator,
+                repositoryProxyFactory);
     }
 
     @Bean
     R4MeasureEvaluatorMultipleFactory r4MeasureEvaluatorMultipleFactory(
             IRepositoryFactory repositoryFactory,
             MeasureEvaluationOptions evaluationOptions,
-            MeasurePeriodValidator measurePeriodValidator) {
+            MeasurePeriodValidator measurePeriodValidator,
+            RepositoryProxyFactory repositoryProxyFactory) {
         return rd -> new R4MultiMeasureService(
-                repositoryFactory.create(rd), evaluationOptions, rd.getFhirServerBase(), measurePeriodValidator);
+                repositoryFactory.create(rd),
+                evaluationOptions,
+                rd.getFhirServerBase(),
+                measurePeriodValidator,
+                repositoryProxyFactory);
     }
 
     @Bean
@@ -132,13 +140,15 @@ public class CrR4Config {
             IRepositoryFactory repositoryFactory,
             CareGapsProperties careGapsProperties,
             MeasureEvaluationOptions measureEvaluationOptions,
-            MeasurePeriodValidator measurePeriodValidator) {
+            MeasurePeriodValidator measurePeriodValidator,
+            RepositoryProxyFactory repositoryProxyFactory) {
         return rd -> new R4CareGapsService(
                 careGapsProperties,
                 repositoryFactory.create(rd),
                 measureEvaluationOptions,
                 rd.getFhirServerBase(),
-                measurePeriodValidator);
+                measurePeriodValidator,
+                repositoryProxyFactory);
     }
 
     @Bean

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/activitydefinition/ActivityDefinitionProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/activitydefinition/ActivityDefinitionProcessor.java
@@ -1,8 +1,6 @@
 package org.opencds.cqf.fhir.cr.activitydefinition;
 
 import static java.util.Objects.requireNonNull;
-import static org.opencds.cqf.fhir.utility.repository.Repositories.createRestRepository;
-import static org.opencds.cqf.fhir.utility.repository.Repositories.proxy;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
@@ -28,6 +26,7 @@ import org.opencds.cqf.fhir.cr.common.ResourceResolver;
 import org.opencds.cqf.fhir.utility.Ids;
 import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 import org.opencds.cqf.fhir.utility.monad.Either3;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
 import org.opencds.cqf.fhir.utility.repository.operations.IActivityDefinitionProcessor;
 
 @SuppressWarnings("UnstableApiUsage")
@@ -40,22 +39,17 @@ public class ActivityDefinitionProcessor implements IActivityDefinitionProcessor
     protected IRepository repository;
     protected CrSettings crSettings;
     protected ExtensionResolver extensionResolver;
-
-    public ActivityDefinitionProcessor(IRepository repository) {
-        this(repository, CrSettings.getDefault());
-    }
-
-    public ActivityDefinitionProcessor(IRepository repository, CrSettings crSettings) {
-        this(repository, crSettings, null, null);
-    }
+    protected final RepositoryProxyFactory repositoryProxyFactory;
 
     public ActivityDefinitionProcessor(
             IRepository repository,
             CrSettings crSettings,
             IRequestResolverFactory requestResolverFactory,
-            List<? extends IOperationProcessor> operationProcessors) {
+            List<? extends IOperationProcessor> operationProcessors,
+            RepositoryProxyFactory repositoryProxyFactory) {
         this.repository = requireNonNull(repository, "repository can not be null");
         this.crSettings = requireNonNull(crSettings, "crSettings can not be null");
+        this.repositoryProxyFactory = requireNonNull(repositoryProxyFactory, "repositoryProxyFactory can not be null");
         this.resourceResolver = new ResourceResolver("ActivityDefinition", this.repository);
         fhirVersion = repository.fhirContext().getVersion().getVersion();
         modelResolver = FhirModelResolverCache.resolverForVersion(fhirVersion);
@@ -118,43 +112,8 @@ public class ActivityDefinitionProcessor implements IActivityDefinitionProcessor
             IBaseResource dataEndpoint,
             IBaseResource contentEndpoint,
             IBaseResource terminologyEndpoint) {
-        return apply(
-                activityDefinition,
-                subjectId,
-                encounterId,
-                practitionerId,
-                organizationId,
-                userType,
-                userLanguage,
-                userTaskContext,
-                setting,
-                settingContext,
-                parameters,
-                useServerData,
-                data,
-                createRestRepository(repository.fhirContext(), dataEndpoint),
-                createRestRepository(repository.fhirContext(), contentEndpoint),
-                createRestRepository(repository.fhirContext(), terminologyEndpoint));
-    }
-
-    public <C extends IPrimitiveType<String>, R extends IBaseResource> IBaseResource apply(
-            Either3<C, IIdType, R> activityDefinition,
-            String subjectId,
-            String encounterId,
-            String practitionerId,
-            String organizationId,
-            IBaseDatatype userType,
-            IBaseDatatype userLanguage,
-            IBaseDatatype userTaskContext,
-            IBaseDatatype setting,
-            IBaseDatatype settingContext,
-            IBaseParameters parameters,
-            boolean useServerData,
-            IBaseBundle data,
-            IRepository dataRepository,
-            IRepository contentRepository,
-            IRepository terminologyRepository) {
-        repository = proxy(repository, useServerData, dataRepository, contentRepository, terminologyRepository);
+        repository = repositoryProxyFactory.proxy(
+                repository, useServerData, dataEndpoint, contentEndpoint, terminologyEndpoint);
         return apply(
                 activityDefinition,
                 subjectId,

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/cql/CqlProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/cql/CqlProcessor.java
@@ -1,8 +1,6 @@
 package org.opencds.cqf.fhir.cr.cql;
 
 import static java.util.Objects.requireNonNull;
-import static org.opencds.cqf.fhir.utility.repository.Repositories.createRestRepository;
-import static org.opencds.cqf.fhir.utility.repository.Repositories.proxy;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.repository.IRepository;
@@ -21,28 +19,26 @@ import org.opencds.cqf.fhir.cr.cql.evaluate.CqlEvaluationRequest;
 import org.opencds.cqf.fhir.cr.cql.evaluate.ICqlEvaluationProcessor;
 import org.opencds.cqf.fhir.utility.Ids;
 import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
 
 @SuppressWarnings("UnstableApiUsage")
 public class CqlProcessor {
 
     protected final ModelResolver modelResolver;
     protected final FhirVersionEnum fhirVersion;
+    protected final RepositoryProxyFactory repositoryProxyFactory;
     protected ICqlEvaluationProcessor cqlEvaluationProcessor;
     protected IRepository repository;
     protected CrSettings crSettings;
 
-    public CqlProcessor(IRepository repository) {
-        this(repository, CrSettings.getDefault());
-    }
-
-    public CqlProcessor(IRepository repository, CrSettings crSettings) {
-        this(repository, crSettings, null);
-    }
-
     public CqlProcessor(
-            IRepository repository, CrSettings crSettings, List<? extends IOperationProcessor> operationProcessors) {
+            IRepository repository,
+            CrSettings crSettings,
+            List<? extends IOperationProcessor> operationProcessors,
+            RepositoryProxyFactory repositoryProxyFactory) {
         this.repository = requireNonNull(repository, "repository can not be null");
         this.crSettings = requireNonNull(crSettings, "crSettings can not be null");
+        this.repositoryProxyFactory = requireNonNull(repositoryProxyFactory, "repositoryProxyFactory can not be null");
         fhirVersion = this.repository.fhirContext().getVersion().getVersion();
         modelResolver = FhirModelResolverCache.resolverForVersion(fhirVersion);
         if (operationProcessors != null && !operationProcessors.isEmpty()) {
@@ -70,33 +66,8 @@ public class CqlProcessor {
             IBaseResource dataEndpoint,
             IBaseResource contentEndpoint,
             IBaseResource terminologyEndpoint) {
-        return evaluate(
-                subject,
-                expression,
-                parameters,
-                library,
-                useServerData,
-                data,
-                prefetchData,
-                content,
-                createRestRepository(repository.fhirContext(), dataEndpoint),
-                createRestRepository(repository.fhirContext(), contentEndpoint),
-                createRestRepository(repository.fhirContext(), terminologyEndpoint));
-    }
-
-    public IBaseParameters evaluate(
-            String subject,
-            String expression,
-            IBaseParameters parameters,
-            List<? extends IBaseBackboneElement> library,
-            boolean useServerData,
-            IBaseBundle data,
-            List<? extends IBaseBackboneElement> prefetchData,
-            String content,
-            IRepository dataRepository,
-            IRepository contentRepository,
-            IRepository terminologyRepository) {
-        repository = proxy(repository, useServerData, dataRepository, contentRepository, terminologyRepository);
+        repository = repositoryProxyFactory.proxy(
+                repository, useServerData, dataEndpoint, contentEndpoint, terminologyEndpoint);
         return evaluate(
                 subject,
                 expression,

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/graphdefinition/apply/ApplyRequestBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/graphdefinition/apply/ApplyRequestBuilder.java
@@ -1,7 +1,6 @@
 package org.opencds.cqf.fhir.cr.graphdefinition.apply;
 
-import static org.opencds.cqf.fhir.utility.repository.Repositories.createRestRepository;
-import static org.opencds.cqf.fhir.utility.repository.Repositories.proxy;
+import static java.util.Objects.requireNonNull;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.repository.IRepository;
@@ -26,6 +25,7 @@ import org.opencds.cqf.fhir.utility.Ids;
 import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 import org.opencds.cqf.fhir.utility.monad.Either3;
 import org.opencds.cqf.fhir.utility.monad.Eithers;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
 
 @SuppressWarnings("UnstableApiUsage")
 public class ApplyRequestBuilder {
@@ -33,6 +33,7 @@ public class ApplyRequestBuilder {
     private IRepository repository;
     private final EvaluationSettings evaluationSettings;
     private final FhirVersionEnum fhirVersion;
+    private final RepositoryProxyFactory repositoryProxyFactory;
     private GraphDefinition graphDefinition;
     private String subject;
     private String encounter;
@@ -46,19 +47,23 @@ public class ApplyRequestBuilder {
     private boolean useServerData = true;
     private IBaseBundle data;
     private List<ParametersParameterComponent> prefetchData;
-    private IRepository dataRepository;
-    private IRepository contentRepository;
-    private IRepository terminologyRepository;
+    private IBaseResource dataEndpoint;
+    private IBaseResource contentEndpoint;
+    private IBaseResource terminologyEndpoint;
     private Parameters parameters;
     private IIdType id;
     private ZonedDateTime periodStartString;
     private ZonedDateTime periodEndString;
     private IPrimitiveType<String> canonicalType;
 
-    public ApplyRequestBuilder(IRepository repository, EvaluationSettings evaluationSettings) {
+    public ApplyRequestBuilder(
+            IRepository repository,
+            EvaluationSettings evaluationSettings,
+            RepositoryProxyFactory repositoryProxyFactory) {
         this.repository = repository;
         this.fhirVersion = repository.fhirContext().getVersion().getVersion();
         this.evaluationSettings = evaluationSettings;
+        this.repositoryProxyFactory = requireNonNull(repositoryProxyFactory, "repositoryProxyFactory can not be null");
     }
 
     public ApplyRequestBuilder withGraphDefinitionId(IdType id) {
@@ -141,36 +146,23 @@ public class ApplyRequestBuilder {
         return this;
     }
 
-    public ApplyRequestBuilder withDataEndpoint(ParametersParameterComponent dataEndpointParam) {
-        IBaseResource endpoint = EndpointHelper.getEndpoint(fhirVersion, dataEndpointParam);
-        this.dataRepository = createRestRepository(repository.fhirContext(), endpoint);
+    public ApplyRequestBuilder withRepository(IRepository repository) {
+        this.repository = repository;
         return this;
     }
 
-    public ApplyRequestBuilder withDataRepository(IRepository dataRepository) {
-        this.dataRepository = dataRepository;
+    public ApplyRequestBuilder withDataEndpoint(ParametersParameterComponent dataEndpointParam) {
+        this.dataEndpoint = EndpointHelper.getEndpoint(fhirVersion, dataEndpointParam);
         return this;
     }
 
     public ApplyRequestBuilder withContentEndpoint(ParametersParameterComponent contentEndpointParam) {
-        IBaseResource endpoint = EndpointHelper.getEndpoint(fhirVersion, contentEndpointParam);
-        this.contentRepository = createRestRepository(repository.fhirContext(), endpoint);
-        return this;
-    }
-
-    public ApplyRequestBuilder withContentRepository(IRepository contentRepository) {
-        this.contentRepository = contentRepository;
+        this.contentEndpoint = EndpointHelper.getEndpoint(fhirVersion, contentEndpointParam);
         return this;
     }
 
     public ApplyRequestBuilder withTerminologyEndpoint(ParametersParameterComponent terminologyEndpointParam) {
-        IBaseResource endpoint = EndpointHelper.getEndpoint(fhirVersion, terminologyEndpointParam);
-        this.terminologyRepository = createRestRepository(repository.fhirContext(), endpoint);
-        return this;
-    }
-
-    public ApplyRequestBuilder withTerminologyRepository(IRepository terminologyRepository) {
-        this.terminologyRepository = terminologyRepository;
+        this.terminologyEndpoint = EndpointHelper.getEndpoint(fhirVersion, terminologyEndpointParam);
         return this;
     }
 
@@ -193,12 +185,8 @@ public class ApplyRequestBuilder {
             throw new IllegalArgumentException("Missing required parameter: 'practitioner'");
         }
 
-        this.repository = proxy(
-                this.repository,
-                this.useServerData,
-                this.dataRepository,
-                this.contentRepository,
-                this.terminologyRepository);
+        this.repository = repositoryProxyFactory.proxy(
+                this.repository, this.useServerData, this.dataEndpoint, this.contentEndpoint, this.terminologyEndpoint);
 
         Either3<IPrimitiveType<String>, IIdType, IBaseResource> eitherGraphDefinition =
                 Eithers.for3(canonicalType, this.id, this.graphDefinition);

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/library/LibraryProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/library/LibraryProcessor.java
@@ -2,8 +2,6 @@ package org.opencds.cqf.fhir.cr.library;
 
 import static java.util.Objects.requireNonNull;
 import static org.opencds.cqf.fhir.utility.PackageHelper.packageParameters;
-import static org.opencds.cqf.fhir.utility.repository.Repositories.createRestRepository;
-import static org.opencds.cqf.fhir.utility.repository.Repositories.proxy;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.repository.IRepository;
@@ -42,6 +40,7 @@ import org.opencds.cqf.fhir.cr.library.evaluate.IEvaluateProcessor;
 import org.opencds.cqf.fhir.utility.Ids;
 import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 import org.opencds.cqf.fhir.utility.monad.Either3;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
 
 @SuppressWarnings("UnstableApiUsage")
 public class LibraryProcessor {
@@ -59,19 +58,16 @@ public class LibraryProcessor {
 
     protected IRepository repository;
     protected CrSettings crSettings;
-
-    public LibraryProcessor(IRepository repository) {
-        this(repository, CrSettings.getDefault());
-    }
-
-    public LibraryProcessor(IRepository repository, CrSettings crSettings) {
-        this(repository, crSettings, null);
-    }
+    protected final RepositoryProxyFactory repositoryProxyFactory;
 
     public LibraryProcessor(
-            IRepository repository, CrSettings crSettings, List<? extends IOperationProcessor> operationProcessors) {
+            IRepository repository,
+            CrSettings crSettings,
+            List<? extends IOperationProcessor> operationProcessors,
+            RepositoryProxyFactory repositoryProxyFactory) {
         this.repository = requireNonNull(repository, "repository can not be null");
         this.crSettings = requireNonNull(crSettings, "crSettings can not be null");
+        this.repositoryProxyFactory = requireNonNull(repositoryProxyFactory, "repositoryProxyFactory can not be null");
         fhirVersion = this.repository.fhirContext().getVersion().getVersion();
         modelResolver = FhirModelResolverCache.resolverForVersion(fhirVersion);
         if (operationProcessors != null && !operationProcessors.isEmpty()) {
@@ -197,31 +193,8 @@ public class LibraryProcessor {
             IBaseResource dataEndpoint,
             IBaseResource contentEndpoint,
             IBaseResource terminologyEndpoint) {
-        return evaluate(
-                library,
-                subject,
-                expression,
-                parameters,
-                useServerData,
-                data,
-                prefetchData,
-                createRestRepository(repository.fhirContext(), dataEndpoint),
-                createRestRepository(repository.fhirContext(), contentEndpoint),
-                createRestRepository(repository.fhirContext(), terminologyEndpoint));
-    }
-
-    public <C extends IPrimitiveType<String>, R extends IBaseResource> IBaseParameters evaluate(
-            Either3<C, IIdType, R> library,
-            String subject,
-            List<String> expression,
-            IBaseParameters parameters,
-            boolean useServerData,
-            IBaseBundle data,
-            List<? extends IBaseBackboneElement> prefetchData,
-            IRepository dataRepository,
-            IRepository contentRepository,
-            IRepository terminologyRepository) {
-        repository = proxy(repository, useServerData, dataRepository, contentRepository, terminologyRepository);
+        repository = repositoryProxyFactory.proxy(
+                repository, useServerData, dataEndpoint, contentEndpoint, terminologyEndpoint);
         return evaluate(
                 library,
                 subject,

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsBundleBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsBundleBuilder.java
@@ -57,6 +57,7 @@ import org.opencds.cqf.fhir.utility.builder.CompositionBuilder;
 import org.opencds.cqf.fhir.utility.builder.CompositionSectionComponentBuilder;
 import org.opencds.cqf.fhir.utility.builder.DetectedIssueBuilder;
 import org.opencds.cqf.fhir.utility.builder.NarrativeSettings;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
 
 /**
  * Care Gaps Bundle Builder houses the logic for constructing a Care-Gaps Document Bundle for a Patient per Measures requested
@@ -83,15 +84,16 @@ public class R4CareGapsBundleBuilder {
             MeasureEvaluationOptions measureEvaluationOptions,
             String serverBase,
             Map<String, Resource> configuredResources,
-            MeasurePeriodValidator measurePeriodValidator) {
+            MeasurePeriodValidator measurePeriodValidator,
+            RepositoryProxyFactory repositoryProxyFactory) {
         this.repository = repository;
         this.careGapsProperties = careGapsProperties;
         this.serverBase = serverBase;
         this.configuredResources = configuredResources;
 
         r4MeasureServiceUtils = new R4MeasureServiceUtils(repository);
-        r4MultiMeasureService =
-                new R4MultiMeasureService(repository, measureEvaluationOptions, serverBase, measurePeriodValidator);
+        r4MultiMeasureService = new R4MultiMeasureService(
+                repository, measureEvaluationOptions, serverBase, measurePeriodValidator, repositoryProxyFactory);
     }
 
     public List<Parameters.ParametersParameterComponent> makePatientBundles(

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsProcessor.java
@@ -31,6 +31,7 @@ import org.opencds.cqf.fhir.cr.measure.constant.CareGapsConstants;
 import org.opencds.cqf.fhir.cr.measure.enumeration.CareGapsStatusCode;
 import org.opencds.cqf.fhir.cr.measure.r4.utils.R4MeasureServiceUtils;
 import org.opencds.cqf.fhir.utility.monad.Either3;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +53,8 @@ public class R4CareGapsProcessor implements R4CareGapsProcessorInterface {
             IRepository repository,
             MeasureEvaluationOptions measureEvaluationOptions,
             String serverBase,
-            MeasurePeriodValidator measurePeriodValidator) {
+            MeasurePeriodValidator measurePeriodValidator,
+            RepositoryProxyFactory repositoryProxyFactory) {
         this.repository = repository;
         this.careGapsProperties = careGapsProperties;
 
@@ -63,7 +65,8 @@ public class R4CareGapsProcessor implements R4CareGapsProcessorInterface {
                 measureEvaluationOptions,
                 serverBase,
                 configuredResources,
-                measurePeriodValidator);
+                measurePeriodValidator,
+                repositoryProxyFactory);
         subjectProvider = new R4RepositorySubjectProvider(measureEvaluationOptions.getSubjectProviderOptions());
     }
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsService.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4CareGapsService.java
@@ -18,6 +18,7 @@ import org.opencds.cqf.fhir.cr.measure.MeasureEvaluationOptions;
 import org.opencds.cqf.fhir.cr.measure.common.MeasurePeriodValidator;
 import org.opencds.cqf.fhir.utility.monad.Either3;
 import org.opencds.cqf.fhir.utility.monad.Eithers;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
 
 /**
  * Care Gap service that processes and produces care-gaps report as a result
@@ -30,10 +31,16 @@ public class R4CareGapsService implements R4CareGapsServiceInterface {
             IRepository repository,
             MeasureEvaluationOptions measureEvaluationOptions,
             String serverBase,
-            MeasurePeriodValidator measurePeriodEvalutator) {
+            MeasurePeriodValidator measurePeriodEvalutator,
+            RepositoryProxyFactory repositoryProxyFactory) {
 
         r4CareGapsProcessor = new R4CareGapsProcessor(
-                careGapsProperties, repository, measureEvaluationOptions, serverBase, measurePeriodEvalutator);
+                careGapsProperties,
+                repository,
+                measureEvaluationOptions,
+                serverBase,
+                measurePeriodEvalutator,
+                repositoryProxyFactory);
     }
 
     /**

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureProcessor.java
@@ -508,6 +508,13 @@ public class R4MeasureProcessor {
         return parameterMap;
     }
 
+    public R4MeasureProcessor withRepository(IRepository repository) {
+        if (repository == this.repository) {
+            return this;
+        }
+        return new R4MeasureProcessor(repository, this.measureEvaluationOptions);
+    }
+
     public Interval buildMeasurementPeriod(ZonedDateTime periodStart, ZonedDateTime periodEnd) {
         Interval measurementPeriod = null;
         if (periodStart != null && periodEnd != null) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MultiMeasureService.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MultiMeasureService.java
@@ -40,7 +40,7 @@ import org.opencds.cqf.fhir.utility.builder.BundleBuilder;
 import org.opencds.cqf.fhir.utility.monad.Either3;
 import org.opencds.cqf.fhir.utility.repository.FederatedRepository;
 import org.opencds.cqf.fhir.utility.repository.InMemoryFhirRepository;
-import org.opencds.cqf.fhir.utility.repository.Repositories;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
 
 /**
  * Alternate MeasureService call to Process MeasureEvaluation for the selected population of subjects against n-number
@@ -58,6 +58,7 @@ public class R4MultiMeasureService implements R4MeasureEvaluatorSingle, R4Measur
     private final R4RepositorySubjectProvider subjectProvider;
     private final R4MeasureProcessor r4MeasureProcessorStandardRepository;
     private final R4MeasureServiceUtils r4MeasureServiceUtilsStandardRepository;
+    private final RepositoryProxyFactory repositoryProxyFactory;
 
     private enum SingleOrMultiple {
         SINGLE,
@@ -68,11 +69,13 @@ public class R4MultiMeasureService implements R4MeasureEvaluatorSingle, R4Measur
             IRepository repository,
             MeasureEvaluationOptions measureEvaluationOptions,
             String serverBase,
-            MeasurePeriodValidator measurePeriodValidator) {
+            MeasurePeriodValidator measurePeriodValidator,
+            RepositoryProxyFactory repositoryProxyFactory) {
         this.repository = repository;
         this.measureEvaluationOptions = measureEvaluationOptions;
         this.measurePeriodValidator = measurePeriodValidator;
         this.serverBase = serverBase;
+        this.repositoryProxyFactory = repositoryProxyFactory;
         this.subjectProvider = new R4RepositorySubjectProvider(measureEvaluationOptions.getSubjectProviderOptions());
         this.r4MeasureProcessorStandardRepository = new R4MeasureProcessor(repository, this.measureEvaluationOptions);
         this.r4MeasureServiceUtilsStandardRepository = new R4MeasureServiceUtils(repository);
@@ -288,19 +291,10 @@ public class R4MultiMeasureService implements R4MeasureEvaluatorSingle, R4Measur
 
         measurePeriodValidator.validatePeriodStartAndEnd(periodStart, periodEnd);
 
-        final R4MeasureProcessor r4ProcessorToUse;
-        final R4MeasureServiceUtils r4MeasureServiceUtilsToUse;
-        if (dataEndpoint != null && contentEndpoint != null && terminologyEndpoint != null) {
-            var repositoryToUse =
-                    Repositories.proxy(repository, true, dataEndpoint, contentEndpoint, terminologyEndpoint);
-
-            r4ProcessorToUse = new R4MeasureProcessor(repositoryToUse, this.measureEvaluationOptions);
-
-            r4MeasureServiceUtilsToUse = new R4MeasureServiceUtils(repositoryToUse);
-        } else {
-            r4ProcessorToUse = r4MeasureProcessorStandardRepository;
-            r4MeasureServiceUtilsToUse = r4MeasureServiceUtilsStandardRepository;
-        }
+        var repositoryToUse =
+                repositoryProxyFactory.proxy(repository, true, dataEndpoint, contentEndpoint, terminologyEndpoint);
+        var r4ProcessorToUse = r4MeasureProcessorStandardRepository.withRepository(repositoryToUse);
+        var r4MeasureServiceUtilsToUse = r4MeasureServiceUtilsStandardRepository.withRepository(repositoryToUse);
 
         r4MeasureServiceUtilsToUse.ensureSupplementalDataElementSearchParameter();
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/utils/R4MeasureServiceUtils.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/utils/R4MeasureServiceUtils.java
@@ -70,6 +70,13 @@ public class R4MeasureServiceUtils {
         this.repository = repository;
     }
 
+    public R4MeasureServiceUtils withRepository(IRepository repository) {
+        if (repository == this.repository) {
+            return this;
+        }
+        return new R4MeasureServiceUtils(repository);
+    }
+
     public MeasureReport addProductLineExtension(MeasureReport measureReport, String productLine) {
         if (productLine != null) {
             Extension ext = new Extension();

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/PlanDefinitionProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/PlanDefinitionProcessor.java
@@ -2,8 +2,6 @@ package org.opencds.cqf.fhir.cr.plandefinition;
 
 import static java.util.Objects.requireNonNull;
 import static org.opencds.cqf.fhir.utility.PackageHelper.packageParameters;
-import static org.opencds.cqf.fhir.utility.repository.Repositories.createRestRepository;
-import static org.opencds.cqf.fhir.utility.repository.Repositories.proxy;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.repository.IRepository;
@@ -35,6 +33,7 @@ import org.opencds.cqf.fhir.utility.Resources;
 import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
 import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 import org.opencds.cqf.fhir.utility.monad.Either3;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
 
 @SuppressWarnings({"squid:S107", "squid:S1172", "UnstableApiUsage"})
 public class PlanDefinitionProcessor {
@@ -47,22 +46,17 @@ public class PlanDefinitionProcessor {
     protected IRequestResolverFactory requestResolverFactory;
     protected IRepository repository;
     protected CrSettings crSettings;
-
-    public PlanDefinitionProcessor(IRepository repository) {
-        this(repository, CrSettings.getDefault());
-    }
-
-    public PlanDefinitionProcessor(IRepository repository, CrSettings crSettings) {
-        this(repository, crSettings, null, null);
-    }
+    protected final RepositoryProxyFactory repositoryProxyFactory;
 
     public PlanDefinitionProcessor(
             IRepository repository,
             CrSettings crSettings,
             IRequestResolverFactory requestResolverFactory,
-            List<? extends IOperationProcessor> operationProcessors) {
+            List<? extends IOperationProcessor> operationProcessors,
+            RepositoryProxyFactory repositoryProxyFactory) {
         this.repository = requireNonNull(repository, "repository can not be null");
         this.crSettings = requireNonNull(crSettings, "crSettings can not be null");
+        this.repositoryProxyFactory = requireNonNull(repositoryProxyFactory, "repositoryProxyFactory can not be null");
         this.requestResolverFactory = requestResolverFactory;
         fhirVersion = this.repository.fhirContext().getVersion().getVersion();
         modelResolver = FhirModelResolverCache.resolverForVersion(fhirVersion);
@@ -96,7 +90,9 @@ public class PlanDefinitionProcessor {
                             ? requestResolverFactory
                             : IRequestResolverFactory.getDefault(fhirVersion));
         }
-        applyProcessor = applyProcessor != null ? applyProcessor : new ApplyProcessor(repository, activityProcessor);
+        applyProcessor = applyProcessor != null
+                ? applyProcessor
+                : new ApplyProcessor(repository, activityProcessor, crSettings, repositoryProxyFactory);
     }
 
     protected <C extends IPrimitiveType<String>, R extends IBaseResource> R resolvePlanDefinition(
@@ -219,45 +215,8 @@ public class PlanDefinitionProcessor {
             IBaseResource dataEndpoint,
             IBaseResource contentEndpoint,
             IBaseResource terminologyEndpoint) {
-        return apply(
-                planDefinition,
-                subject,
-                encounter,
-                practitioner,
-                organization,
-                userType,
-                userLanguage,
-                userTaskContext,
-                setting,
-                settingContext,
-                parameters,
-                useServerData,
-                data,
-                prefetchData,
-                createRestRepository(repository.fhirContext(), dataEndpoint),
-                createRestRepository(repository.fhirContext(), contentEndpoint),
-                createRestRepository(repository.fhirContext(), terminologyEndpoint));
-    }
-
-    public <C extends IPrimitiveType<String>, R extends IBaseResource> IBaseResource apply(
-            Either3<C, IIdType, R> planDefinition,
-            String subject,
-            String encounter,
-            String practitioner,
-            String organization,
-            IBaseDatatype userType,
-            IBaseDatatype userLanguage,
-            IBaseDatatype userTaskContext,
-            IBaseDatatype setting,
-            IBaseDatatype settingContext,
-            IBaseParameters parameters,
-            boolean useServerData,
-            IBaseBundle data,
-            List<? extends IBaseBackboneElement> prefetchData,
-            IRepository dataRepository,
-            IRepository contentRepository,
-            IRepository terminologyRepository) {
-        repository = proxy(repository, useServerData, dataRepository, contentRepository, terminologyRepository);
+        repository = repositoryProxyFactory.proxy(
+                repository, useServerData, dataEndpoint, contentEndpoint, terminologyEndpoint);
         return apply(
                 planDefinition,
                 subject,
@@ -347,45 +306,8 @@ public class PlanDefinitionProcessor {
             IBaseResource dataEndpoint,
             IBaseResource contentEndpoint,
             IBaseResource terminologyEndpoint) {
-        return applyR5(
-                planDefinition,
-                subject,
-                encounter,
-                practitioner,
-                organization,
-                userType,
-                userLanguage,
-                userTaskContext,
-                setting,
-                settingContext,
-                parameters,
-                useServerData,
-                data,
-                prefetchData,
-                createRestRepository(repository.fhirContext(), dataEndpoint),
-                createRestRepository(repository.fhirContext(), contentEndpoint),
-                createRestRepository(repository.fhirContext(), terminologyEndpoint));
-    }
-
-    public <C extends IPrimitiveType<String>, R extends IBaseResource> IBaseParameters applyR5(
-            Either3<C, IIdType, R> planDefinition,
-            List<String> subject,
-            String encounter,
-            String practitioner,
-            String organization,
-            IBaseDatatype userType,
-            IBaseDatatype userLanguage,
-            IBaseDatatype userTaskContext,
-            IBaseDatatype setting,
-            IBaseDatatype settingContext,
-            IBaseParameters parameters,
-            boolean useServerData,
-            IBaseBundle data,
-            List<? extends IBaseBackboneElement> prefetchData,
-            IRepository dataRepository,
-            IRepository contentRepository,
-            IRepository terminologyRepository) {
-        repository = proxy(repository, useServerData, dataRepository, contentRepository, terminologyRepository);
+        repository = repositoryProxyFactory.proxy(
+                repository, useServerData, dataEndpoint, contentEndpoint, terminologyEndpoint);
         return applyR5(
                 planDefinition,
                 subject,

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ApplyProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/plandefinition/apply/ApplyProcessor.java
@@ -17,6 +17,7 @@ import java.util.Date;
 import java.util.List;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.opencds.cqf.fhir.cr.CrSettings;
 import org.opencds.cqf.fhir.cr.common.ExtensionProcessor;
 import org.opencds.cqf.fhir.cr.common.ICpgRequest;
 import org.opencds.cqf.fhir.cr.questionnaire.generate.GenerateProcessor;
@@ -25,6 +26,7 @@ import org.opencds.cqf.fhir.cr.questionnaireresponse.QuestionnaireResponseProces
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.Ids;
 import org.opencds.cqf.fhir.utility.monad.Eithers;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,13 +57,16 @@ public class ApplyProcessor implements IApplyProcessor {
 
     public ApplyProcessor(
             IRepository repository,
-            org.opencds.cqf.fhir.cr.activitydefinition.apply.IApplyProcessor activityProcessor) {
+            org.opencds.cqf.fhir.cr.activitydefinition.apply.IApplyProcessor activityProcessor,
+            CrSettings crSettings,
+            RepositoryProxyFactory repositoryProxyFactory) {
         this.repository = repository;
         this.activityProcessor = activityProcessor;
         extensionProcessor = new ExtensionProcessor();
         generateProcessor = new GenerateProcessor(this.repository);
         populateProcessor = new PopulateProcessor();
-        extractProcessor = new QuestionnaireResponseProcessor(this.repository);
+        extractProcessor =
+                new QuestionnaireResponseProcessor(this.repository, crSettings, null, repositoryProxyFactory);
         processRequest = new ResponseBuilder(populateProcessor);
         processGoal = new ProcessGoal();
         processAction = new ProcessAction(this.repository, this, generateProcessor);

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/QuestionnaireProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/QuestionnaireProcessor.java
@@ -2,8 +2,6 @@ package org.opencds.cqf.fhir.cr.questionnaire;
 
 import static java.util.Objects.requireNonNull;
 import static org.opencds.cqf.fhir.utility.PackageHelper.packageParameters;
-import static org.opencds.cqf.fhir.utility.repository.Repositories.createRestRepository;
-import static org.opencds.cqf.fhir.utility.repository.Repositories.proxy;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.repository.IRepository;
@@ -33,6 +31,7 @@ import org.opencds.cqf.fhir.cr.questionnaire.populate.PopulateRequest;
 import org.opencds.cqf.fhir.utility.Ids;
 import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 import org.opencds.cqf.fhir.utility.monad.Either3;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
 
 @SuppressWarnings("UnstableApiUsage")
 public class QuestionnaireProcessor {
@@ -48,19 +47,16 @@ public class QuestionnaireProcessor {
     protected IPackageProcessor packageProcessor;
     protected IDataRequirementsProcessor dataRequirementsProcessor;
     protected IPopulateProcessor populateProcessor;
-
-    public QuestionnaireProcessor(IRepository repository) {
-        this(repository, CrSettings.getDefault());
-    }
-
-    public QuestionnaireProcessor(IRepository repository, CrSettings crSettings) {
-        this(repository, crSettings, null);
-    }
+    protected final RepositoryProxyFactory repositoryProxyFactory;
 
     public QuestionnaireProcessor(
-            IRepository repository, CrSettings crSettings, List<? extends IOperationProcessor> operationProcessors) {
+            IRepository repository,
+            CrSettings crSettings,
+            List<? extends IOperationProcessor> operationProcessors,
+            RepositoryProxyFactory repositoryProxyFactory) {
         this.repository = requireNonNull(repository, "repository can not be null");
         this.crSettings = requireNonNull(crSettings, "evaluationSettings can not be null");
+        this.repositoryProxyFactory = requireNonNull(repositoryProxyFactory, "repositoryProxyFactory can not be null");
         this.questionnaireResolver = new ResourceResolver("Questionnaire", this.repository);
         this.structureDefResolver = new ResourceResolver("StructureDefinition", this.repository);
         fhirVersion = this.repository.fhirContext().getVersion().getVersion();
@@ -122,23 +118,7 @@ public class QuestionnaireProcessor {
             IBaseResource contentEndpoint,
             IBaseResource terminologyEndpoint,
             String id) {
-        return generateQuestionnaire(
-                profile,
-                supportedOnly,
-                requiredOnly,
-                createRestRepository(repository.fhirContext(), contentEndpoint),
-                createRestRepository(repository.fhirContext(), terminologyEndpoint),
-                id);
-    }
-
-    public <C extends IPrimitiveType<String>, R extends IBaseResource> IBaseResource generateQuestionnaire(
-            Either3<C, IIdType, R> profile,
-            boolean supportedOnly,
-            boolean requiredOnly,
-            IRepository contentRepository,
-            IRepository terminologyRepository,
-            String id) {
-        repository = proxy(repository, true, null, contentRepository, terminologyRepository);
+        repository = repositoryProxyFactory.proxy(repository, true, null, contentEndpoint, terminologyEndpoint);
         return generateQuestionnaire(profile, supportedOnly, requiredOnly, id);
     }
 
@@ -230,29 +210,8 @@ public class QuestionnaireProcessor {
             IBaseResource dataEndpoint,
             IBaseResource contentEndpoint,
             IBaseResource terminologyEndpoint) {
-        return populate(
-                questionnaire,
-                subjectId,
-                context,
-                launchContext,
-                data,
-                useServerData,
-                createRestRepository(repository.fhirContext(), dataEndpoint),
-                createRestRepository(repository.fhirContext(), contentEndpoint),
-                createRestRepository(repository.fhirContext(), terminologyEndpoint));
-    }
-
-    public <C extends IPrimitiveType<String>, R extends IBaseResource> IBaseResource populate(
-            Either3<C, IIdType, R> questionnaire,
-            String subjectId,
-            List<? extends IBaseBackboneElement> context,
-            IBaseExtension<?, ?> launchContext,
-            IBaseBundle data,
-            boolean useServerData,
-            IRepository dataRepository,
-            IRepository contentRepository,
-            IRepository terminologyRepository) {
-        repository = proxy(repository, useServerData, dataRepository, contentRepository, terminologyRepository);
+        repository = repositoryProxyFactory.proxy(
+                repository, useServerData, dataEndpoint, contentEndpoint, terminologyEndpoint);
         return populate(
                 questionnaire,
                 subjectId,

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/QuestionnaireResponseProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaireresponse/QuestionnaireResponseProcessor.java
@@ -1,7 +1,6 @@
 package org.opencds.cqf.fhir.cr.questionnaireresponse;
 
 import static java.util.Objects.requireNonNull;
-import static org.opencds.cqf.fhir.utility.repository.Repositories.proxy;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
@@ -24,6 +23,7 @@ import org.opencds.cqf.fhir.cr.questionnaireresponse.extract.IExtractProcessor;
 import org.opencds.cqf.fhir.utility.SearchHelper;
 import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 import org.opencds.cqf.fhir.utility.monad.Either;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,19 +38,16 @@ public class QuestionnaireResponseProcessor {
     protected IRepository repository;
     protected CrSettings crSettings;
     protected IExtractProcessor extractProcessor;
-
-    public QuestionnaireResponseProcessor(IRepository repository) {
-        this(repository, CrSettings.getDefault());
-    }
-
-    public QuestionnaireResponseProcessor(IRepository repository, CrSettings crSettings) {
-        this(repository, crSettings, null);
-    }
+    protected final RepositoryProxyFactory repositoryProxyFactory;
 
     public QuestionnaireResponseProcessor(
-            IRepository repository, CrSettings crSettings, List<? extends IOperationProcessor> operationProcessors) {
+            IRepository repository,
+            CrSettings crSettings,
+            List<? extends IOperationProcessor> operationProcessors,
+            RepositoryProxyFactory repositoryProxyFactory) {
         this.repository = requireNonNull(repository, "repository can not be null");
         this.crSettings = requireNonNull(crSettings, "crSettings can not be null");
+        this.repositoryProxyFactory = requireNonNull(repositoryProxyFactory, "repositoryProxyFactory can not be null");
         this.questionnaireResponseResolver = new ResourceResolver("QuestionnaireResponse", this.repository);
         this.questionnaireResolver = new ResourceResolver(QUESTIONNAIRE, this.repository);
         this.fhirVersion = this.repository.fhirContext().getVersion().getVersion();
@@ -139,7 +136,7 @@ public class QuestionnaireResponseProcessor {
             IBaseParameters parameters,
             IBaseBundle data,
             boolean useServerData) {
-        repository = proxy(repository, useServerData, (IRepository) null, null, null);
+        repository = repositoryProxyFactory.proxy(repository, useServerData, (IBaseResource) null, null, null);
         return extract(
                 questionnaireResponseId,
                 questionnaireId,

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/ActivityDefinitionProcessorFactory.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/ActivityDefinitionProcessorFactory.java
@@ -2,6 +2,7 @@ package org.opencds.cqf.fhir.cr;
 
 import ca.uhn.fhir.repository.IRepository;
 import org.opencds.cqf.fhir.cr.activitydefinition.ActivityDefinitionProcessor;
+import org.opencds.cqf.fhir.cr.measure.r4.NoOpRepositoryProxyFactory;
 import org.opencds.cqf.fhir.utility.repository.operations.IActivityDefinitionProcessor;
 import org.opencds.cqf.fhir.utility.repository.operations.IActivityDefinitionProcessorFactory;
 
@@ -9,6 +10,7 @@ public class ActivityDefinitionProcessorFactory implements IActivityDefinitionPr
 
     @Override
     public IActivityDefinitionProcessor create(IRepository repository) {
-        return new ActivityDefinitionProcessor(repository);
+        return new ActivityDefinitionProcessor(
+                repository, CrSettings.getDefault(), null, null, new NoOpRepositoryProxyFactory());
     }
 }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/activitydefinition/ActivityDefinitionProcessorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/activitydefinition/ActivityDefinitionProcessorTests.java
@@ -33,7 +33,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opencds.cqf.fhir.cql.LibraryEngine;
+import org.opencds.cqf.fhir.cr.CrSettings;
 import org.opencds.cqf.fhir.cr.activitydefinition.apply.IRequestResolverFactory;
+import org.opencds.cqf.fhir.cr.measure.r4.NoOpRepositoryProxyFactory;
 import org.opencds.cqf.fhir.utility.Ids;
 import org.opencds.cqf.fhir.utility.monad.Either3;
 import org.opencds.cqf.fhir.utility.monad.Eithers;
@@ -58,7 +60,8 @@ class ActivityDefinitionProcessorTests {
     }
 
     private ActivityDefinitionProcessor createProcessor(IRepository repository) {
-        return new ActivityDefinitionProcessor(repository);
+        return new ActivityDefinitionProcessor(
+                repository, CrSettings.getDefault(), null, null, new NoOpRepositoryProxyFactory());
     }
 
     @BeforeAll

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/cql/CqlProcessorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/cql/CqlProcessorTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.opencds.cqf.fhir.cql.EvaluationSettings;
 import org.opencds.cqf.fhir.cr.CrSettings;
 import org.opencds.cqf.fhir.cr.cql.evaluate.CqlEvaluationProcessor;
+import org.opencds.cqf.fhir.cr.measure.r4.NoOpRepositoryProxyFactory;
 import org.opencds.cqf.fhir.utility.repository.ig.IgRepository;
 
 class CqlProcessorTests {
@@ -54,7 +55,7 @@ class CqlProcessorTests {
     void defaultSettings() {
         var repository =
                 new IgRepository(fhirContextR4, Path.of(getResourcePath(this.getClass()) + "/" + CLASS_PATH + "/r4"));
-        var processor = new CqlProcessor(repository);
+        var processor = new CqlProcessor(repository, CrSettings.getDefault(), null, new NoOpRepositoryProxyFactory());
         assertNotNull(processor.settings());
     }
 
@@ -65,7 +66,8 @@ class CqlProcessorTests {
         var processor = new CqlProcessor(
                 repository,
                 CrSettings.getDefault(),
-                List.of(new CqlEvaluationProcessor(repository, EvaluationSettings.getDefault())));
+                List.of(new CqlEvaluationProcessor(repository, EvaluationSettings.getDefault())),
+                new NoOpRepositoryProxyFactory());
 
         assertNotNull(processor.settings());
     }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/cql/TestCql.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/cql/TestCql.java
@@ -31,15 +31,18 @@ import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.fhir.cql.EvaluationSettings;
+import org.opencds.cqf.fhir.cql.LibraryEngine;
 import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.SEARCH_FILTER_MODE;
 import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.TERMINOLOGY_FILTER_MODE;
 import org.opencds.cqf.fhir.cql.engine.terminology.TerminologySettings.VALUESET_EXPANSION_MODE;
 import org.opencds.cqf.fhir.cr.CrSettings;
 import org.opencds.cqf.fhir.cr.TestOperationProvider;
+import org.opencds.cqf.fhir.cr.measure.r4.NoOpRepositoryProxyFactory;
 import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
 import org.opencds.cqf.fhir.utility.adapter.IParametersParameterComponentAdapter;
 import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 import org.opencds.cqf.fhir.utility.repository.InMemoryFhirRepository;
+import org.opencds.cqf.fhir.utility.repository.Repositories;
 import org.opencds.cqf.fhir.utility.repository.ig.IgRepository;
 
 public class TestCql {
@@ -104,18 +107,18 @@ public class TestCql {
                         .setValuesetExpansionMode(VALUESET_EXPANSION_MODE.PERFORM_NAIVE_EXPANSION);
             }
             var crSettings = CrSettings.getDefault().withEvaluationSettings(evaluationSettings);
-            return new CqlProcessor(repository, crSettings);
+            return new CqlProcessor(repository, crSettings, null, new NoOpRepositoryProxyFactory());
         }
 
         public When when() {
-            return new When(repository, buildProcessor(repository));
+            return new When(this, repository);
         }
     }
 
     @SuppressWarnings("UnstableApiUsage")
     public static class When {
+        private final Given given;
         private final IRepository repository;
-        private final CqlProcessor processor;
         private final IParser jsonParser;
 
         private String subject;
@@ -131,9 +134,9 @@ public class TestCql {
         private List<? extends IBaseBackboneElement> library;
         private String cqlContent;
 
-        public When(IRepository repository, CqlProcessor processor) {
+        public When(Given given, IRepository repository) {
+            this.given = given;
             this.repository = repository;
-            this.processor = processor;
             useServerData = true;
             jsonParser = repository.fhirContext().newJsonParser();
         }
@@ -230,6 +233,9 @@ public class TestCql {
             if (additionalDataId != null) {
                 loadAdditionalData(readRepository(repository, additionalDataId));
             }
+            var proxiedRepo = Repositories.proxy(
+                    repository, useServerData, dataRepository, contentRepository, terminologyRepository);
+            var processor = given.buildProcessor(proxiedRepo);
             return new Evaluation(
                     repository,
                     processor.evaluate(
@@ -237,13 +243,10 @@ public class TestCql {
                             expression,
                             parameters,
                             library,
-                            useServerData,
                             additionalData,
                             prefetchData,
                             cqlContent,
-                            dataRepository,
-                            contentRepository,
-                            terminologyRepository));
+                            new LibraryEngine(proxiedRepo, processor.settings().getEvaluationSettings())));
         }
     }
 

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/graphdefinition/TestGraphDefinition.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/graphdefinition/TestGraphDefinition.java
@@ -28,8 +28,10 @@ import org.opencds.cqf.fhir.cql.engine.terminology.TerminologySettings.VALUESET_
 import org.opencds.cqf.fhir.cr.TestOperationProvider;
 import org.opencds.cqf.fhir.cr.graphdefinition.apply.ApplyRequest;
 import org.opencds.cqf.fhir.cr.graphdefinition.apply.ApplyRequestBuilder;
+import org.opencds.cqf.fhir.cr.measure.r4.NoOpRepositoryProxyFactory;
 import org.opencds.cqf.fhir.utility.BundleHelper;
 import org.opencds.cqf.fhir.utility.repository.InMemoryFhirRepository;
+import org.opencds.cqf.fhir.utility.repository.Repositories;
 import org.opencds.cqf.fhir.utility.repository.ig.IgRepository;
 
 @SuppressWarnings("UnstableApiUsage")
@@ -108,6 +110,9 @@ public class TestGraphDefinition {
         private GraphDefinitionProcessor processor;
         private ApplyRequestBuilder applyRequestBuilder;
         private IParser jsonParser;
+        private IRepository dataRepository;
+        private IRepository contentRepository;
+        private IRepository terminologyRepository;
 
         public When(
                 IRepository repository,
@@ -115,7 +120,8 @@ public class TestGraphDefinition {
                 EvaluationSettings evaluationSettings) {
             this.repository = repository;
             this.processor = graphDefinitionProcessor;
-            this.applyRequestBuilder = new ApplyRequestBuilder(this.repository, evaluationSettings);
+            this.applyRequestBuilder =
+                    new ApplyRequestBuilder(this.repository, evaluationSettings, new NoOpRepositoryProxyFactory());
             this.jsonParser = repository.fhirContext().newJsonParser();
         }
 
@@ -135,17 +141,17 @@ public class TestGraphDefinition {
         }
 
         public When data(String dataAssetName) {
-            applyRequestBuilder.withDataRepository(createRepository(dataAssetName));
+            this.dataRepository = createRepository(dataAssetName);
             return this;
         }
 
         public When content(String dataAssetName) {
-            applyRequestBuilder.withContentRepository(createRepository(dataAssetName));
+            this.contentRepository = createRepository(dataAssetName);
             return this;
         }
 
         public When terminology(String dataAssetName) {
-            applyRequestBuilder.withTerminologyRepository(createRepository(dataAssetName));
+            this.terminologyRepository = createRepository(dataAssetName);
             return this;
         }
 
@@ -161,7 +167,7 @@ public class TestGraphDefinition {
         }
 
         public When dataRepository(IgRepository theRepository) {
-            applyRequestBuilder.withDataRepository(theRepository);
+            this.dataRepository = theRepository;
             return this;
         }
 
@@ -171,6 +177,9 @@ public class TestGraphDefinition {
         }
 
         public GeneratedBundle thenApply() {
+            var proxiedRepo =
+                    Repositories.proxy(repository, true, dataRepository, contentRepository, terminologyRepository);
+            applyRequestBuilder.withRepository(proxiedRepo);
             ApplyRequest applyRequest = applyRequestBuilder.buildApplyRequest();
             IBaseResource generatedBundle = this.processor.apply(applyRequest);
 

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/graphdefinition/apply/ApplyProcessorTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/graphdefinition/apply/ApplyProcessorTest.java
@@ -43,6 +43,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.fhir.cql.EvaluationSettings;
+import org.opencds.cqf.fhir.cr.measure.r4.NoOpRepositoryProxyFactory;
 import org.opencds.cqf.fhir.utility.repository.ig.IgRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,7 +81,8 @@ public class ApplyProcessorTest {
         String id = "eras-postop";
         IdType graphDefinitionId = new IdType("GraphDefinition", id);
 
-        ApplyRequestBuilder applyRequestBuilder = new ApplyRequestBuilder(repository, EvaluationSettings.getDefault());
+        ApplyRequestBuilder applyRequestBuilder =
+                new ApplyRequestBuilder(repository, EvaluationSettings.getDefault(), new NoOpRepositoryProxyFactory());
         applyRequestBuilder.withSubject("Patient/time-zero");
         applyRequestBuilder.withPractitioner("Practitioner/ordering-md-1");
         applyRequestBuilder.withGraphDefinitionId(graphDefinitionId);
@@ -98,7 +100,8 @@ public class ApplyProcessorTest {
         String id = "eras-postop";
         IdType graphDefinitionId = new IdType("GraphDefinition", id);
 
-        ApplyRequestBuilder applyRequestBuilder = new ApplyRequestBuilder(repository, EvaluationSettings.getDefault());
+        ApplyRequestBuilder applyRequestBuilder =
+                new ApplyRequestBuilder(repository, EvaluationSettings.getDefault(), new NoOpRepositoryProxyFactory());
         applyRequestBuilder.withSubject("Patient/time-zero");
         applyRequestBuilder.withPractitioner("Practitioner/ordering-md-1");
         applyRequestBuilder.withGraphDefinitionId(graphDefinitionId);

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/graphdefinition/apply/ApplyRequestBuilderTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/graphdefinition/apply/ApplyRequestBuilderTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opencds.cqf.fhir.cql.EvaluationSettings;
 import org.opencds.cqf.fhir.cql.LibraryEngine;
+import org.opencds.cqf.fhir.cr.measure.r4.NoOpRepositoryProxyFactory;
 import org.opencds.cqf.fhir.utility.repository.InMemoryFhirRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,7 +32,8 @@ class ApplyRequestBuilderTest {
     void build_withoutSubject_throwsIllegalArgumentException() {
         when(repository.fhirContext()).thenReturn(fhirContext);
 
-        ApplyRequestBuilder builder = new ApplyRequestBuilder(repository, evaluationSettings);
+        ApplyRequestBuilder builder =
+                new ApplyRequestBuilder(repository, evaluationSettings, new NoOpRepositoryProxyFactory());
 
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, builder::buildApplyRequest);
         assertEquals("Missing required parameter: 'subject'", ex.getMessage());
@@ -41,8 +43,9 @@ class ApplyRequestBuilderTest {
     void build_withoutPractitioner_throwsIllegalArgumentException() {
         when(repository.fhirContext()).thenReturn(fhirContext);
 
-        ApplyRequestBuilder builder =
-                new ApplyRequestBuilder(repository, evaluationSettings).withSubject("Patient/123");
+        ApplyRequestBuilder builder = new ApplyRequestBuilder(
+                        repository, evaluationSettings, new NoOpRepositoryProxyFactory())
+                .withSubject("Patient/123");
 
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, builder::buildApplyRequest);
         assertEquals("Missing required parameter: 'practitioner'", ex.getMessage());
@@ -53,7 +56,8 @@ class ApplyRequestBuilderTest {
         IRepository localRepository = new InMemoryFhirRepository(fhirContext);
         IdType id = (IdType) localRepository.create(new GraphDefinition()).getId();
 
-        ApplyRequestBuilder builder = new ApplyRequestBuilder(localRepository, evaluationSettings)
+        ApplyRequestBuilder builder = new ApplyRequestBuilder(
+                        localRepository, evaluationSettings, new NoOpRepositoryProxyFactory())
                 .withGraphDefinitionId(id)
                 .withSubject("Patient/123")
                 .withPractitioner("Practitioner/456")

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/library/LibraryProcessorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/library/LibraryProcessorTests.java
@@ -29,6 +29,7 @@ import org.opencds.cqf.fhir.cr.common.ReviseProcessor;
 import org.opencds.cqf.fhir.cr.common.WithdrawProcessor;
 import org.opencds.cqf.fhir.cr.helpers.RequestHelpers;
 import org.opencds.cqf.fhir.cr.library.evaluate.EvaluateProcessor;
+import org.opencds.cqf.fhir.cr.measure.r4.NoOpRepositoryProxyFactory;
 import org.opencds.cqf.fhir.utility.Ids;
 import org.opencds.cqf.fhir.utility.monad.Eithers;
 import org.opencds.cqf.fhir.utility.repository.ig.IgRepository;
@@ -47,7 +48,8 @@ class LibraryProcessorTests {
     void defaultSettings() {
         var repository =
                 new IgRepository(fhirContextR4, Path.of(getResourcePath(this.getClass()) + "/" + CLASS_PATH + "/r4"));
-        var processor = new LibraryProcessor(repository);
+        var processor =
+                new LibraryProcessor(repository, CrSettings.getDefault(), null, new NoOpRepositoryProxyFactory());
         assertNotNull(processor.settings());
     }
 
@@ -76,7 +78,8 @@ class LibraryProcessorTests {
                         new RetireProcessor(repository),
                         new WithdrawProcessor(repository),
                         new ReviseProcessor(repository),
-                        new ArtifactDiffProcessor()));
+                        new ArtifactDiffProcessor()),
+                new NoOpRepositoryProxyFactory());
 
         assertNotNull(processor.settings());
         var result = processor.resolveLibrary(Eithers.forMiddle3(

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/library/TestLibrary.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/library/TestLibrary.java
@@ -30,6 +30,7 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.fhir.cql.EvaluationSettings;
+import org.opencds.cqf.fhir.cql.LibraryEngine;
 import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.SEARCH_FILTER_MODE;
 import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.TERMINOLOGY_FILTER_MODE;
 import org.opencds.cqf.fhir.cql.engine.terminology.TerminologySettings.VALUESET_EXPANSION_MODE;
@@ -37,10 +38,12 @@ import org.opencds.cqf.fhir.cr.CrSettings;
 import org.opencds.cqf.fhir.cr.TestOperationProvider;
 import org.opencds.cqf.fhir.cr.helpers.DataRequirementsLibrary;
 import org.opencds.cqf.fhir.cr.helpers.GeneratedPackage;
+import org.opencds.cqf.fhir.cr.measure.r4.NoOpRepositoryProxyFactory;
 import org.opencds.cqf.fhir.utility.Ids;
 import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 import org.opencds.cqf.fhir.utility.monad.Eithers;
 import org.opencds.cqf.fhir.utility.repository.InMemoryFhirRepository;
+import org.opencds.cqf.fhir.utility.repository.Repositories;
 import org.opencds.cqf.fhir.utility.repository.ig.IgRepository;
 
 public class TestLibrary {
@@ -105,18 +108,18 @@ public class TestLibrary {
                         .setValuesetExpansionMode(VALUESET_EXPANSION_MODE.PERFORM_NAIVE_EXPANSION);
             }
             var crSettings = CrSettings.getDefault().withEvaluationSettings(evaluationSettings);
-            return new LibraryProcessor(repository, crSettings);
+            return new LibraryProcessor(repository, crSettings, null, new NoOpRepositoryProxyFactory());
         }
 
         public When when() {
-            return new When(repository, buildProcessor(repository));
+            return new When(this, repository);
         }
     }
 
     @SuppressWarnings("UnstableApiUsage")
     public static class When {
+        private final Given given;
         private final IRepository repository;
-        private final LibraryProcessor processor;
         private final IParser jsonParser;
 
         private String libraryId;
@@ -134,9 +137,12 @@ public class TestLibrary {
         private IBaseParameters parameters;
         private Boolean isPackagePut;
 
-        public When(IRepository repository, LibraryProcessor processor) {
+        private final LibraryProcessor processor;
+
+        public When(Given given, IRepository repository) {
+            this.given = given;
             this.repository = repository;
-            this.processor = processor;
+            this.processor = given.buildProcessor(repository);
             useServerData = true;
             jsonParser = repository.fhirContext().newJsonParser();
         }
@@ -254,9 +260,12 @@ public class TestLibrary {
             if (additionalDataId != null) {
                 loadAdditionalData(readRepository(repository, additionalDataId));
             }
+            var proxiedRepo = Repositories.proxy(
+                    repository, useServerData, dataRepository, contentRepository, terminologyRepository);
+            var evalProcessor = given.buildProcessor(proxiedRepo);
             return new Evaluation(
                     repository,
-                    processor.evaluate(
+                    evalProcessor.evaluate(
                             Eithers.for3(
                                     libraryUrl == null
                                             ? null
@@ -273,12 +282,10 @@ public class TestLibrary {
                             subjectId,
                             expression,
                             parameters,
-                            useServerData,
                             additionalData,
                             prefetchData,
-                            dataRepository,
-                            contentRepository,
-                            terminologyRepository));
+                            new LibraryEngine(
+                                    proxiedRepo, evalProcessor.settings().getEvaluationSettings())));
         }
     }
 

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/CareGaps.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/CareGaps.java
@@ -139,7 +139,12 @@ public class CareGaps {
 
         private R4CareGapsService buildCareGapsService() {
             return new R4CareGapsService(
-                    careGapsProperties, repository, evaluationOptions, serverBase, measurePeriodEvaluator);
+                    careGapsProperties,
+                    repository,
+                    evaluationOptions,
+                    serverBase,
+                    measurePeriodEvaluator,
+                    new NoOpRepositoryProxyFactory());
         }
 
         public When when() {

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/Measure.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/Measure.java
@@ -31,6 +31,7 @@ import org.opencds.cqf.fhir.cr.measure.r4.selected.report.SelectedMeasureReportE
 import org.opencds.cqf.fhir.cr.measure.r4.selected.report.SelectedMeasureReportGroup;
 import org.opencds.cqf.fhir.cr.measure.r4.selected.report.SelectedMeasureReportReference;
 import org.opencds.cqf.fhir.utility.monad.Eithers;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
 import org.opencds.cqf.fhir.utility.repository.ig.IgRepository;
 
 // consider rolling this entire thing into MultiMeasure with "single measure" assertions
@@ -89,6 +90,7 @@ public class Measure {
         private MeasureEvaluationOptions evaluationOptions;
         private String serverBase;
         private final MeasurePeriodValidator measurePeriodValidator;
+        private RepositoryProxyFactory repositoryProxyFactory;
 
         public Given(@Nullable Boolean applyScoringSetMembership) {
             this.evaluationOptions = MeasureEvaluationOptions.defaultOptions();
@@ -138,8 +140,18 @@ public class Measure {
             return this;
         }
 
+        public Given repositoryProxyFactory(RepositoryProxyFactory repositoryProxyFactory) {
+            this.repositoryProxyFactory = repositoryProxyFactory;
+            return this;
+        }
+
         private R4MultiMeasureService buildMultiMeasureService() {
-            return new R4MultiMeasureService(repository, evaluationOptions, serverBase, measurePeriodValidator);
+            return new R4MultiMeasureService(
+                    repository,
+                    evaluationOptions,
+                    serverBase,
+                    measurePeriodValidator,
+                    repositoryProxyFactory != null ? repositoryProxyFactory : new NoOpRepositoryProxyFactory());
         }
 
         public When when() {

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasure.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasure.java
@@ -48,6 +48,7 @@ import org.opencds.cqf.fhir.cr.measure.common.MeasurePeriodValidator;
 import org.opencds.cqf.fhir.cr.measure.constant.MeasureConstants;
 import org.opencds.cqf.fhir.cr.measure.r4.selected.def.SelectedMeasureDefCollection;
 import org.opencds.cqf.fhir.utility.BundleHelper;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
 import org.opencds.cqf.fhir.utility.repository.ig.IgRepository;
 
 @SuppressWarnings("squid:S1135")
@@ -101,6 +102,7 @@ class MultiMeasure {
         private MeasureEvaluationOptions evaluationOptions;
         private String serverBase;
         private MeasurePeriodValidator measurePeriodValidator;
+        private RepositoryProxyFactory repositoryProxyFactory;
 
         public Given() {
             this.evaluationOptions = MeasureEvaluationOptions.defaultOptions();
@@ -142,6 +144,11 @@ class MultiMeasure {
             return this;
         }
 
+        public MultiMeasure.Given repositoryProxyFactory(RepositoryProxyFactory repositoryProxyFactory) {
+            this.repositoryProxyFactory = repositoryProxyFactory;
+            return this;
+        }
+
         // Exposed for unit tests that only want to use part of this framework when passing in
         // an IgRepository
         public IRepository getRepository() {
@@ -153,7 +160,12 @@ class MultiMeasure {
         }
 
         private R4MultiMeasureService buildMeasureService() {
-            return new R4MultiMeasureService(repository, evaluationOptions, serverBase, measurePeriodValidator);
+            return new R4MultiMeasureService(
+                    repository,
+                    evaluationOptions,
+                    serverBase,
+                    measurePeriodValidator,
+                    repositoryProxyFactory != null ? repositoryProxyFactory : new NoOpRepositoryProxyFactory());
         }
 
         public MultiMeasure.When when() {

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/NoOpRepositoryProxyFactory.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/NoOpRepositoryProxyFactory.java
@@ -1,0 +1,21 @@
+package org.opencds.cqf.fhir.cr.measure.r4;
+
+import ca.uhn.fhir.repository.IRepository;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
+
+/**
+ * A RepositoryProxyFactory that always returns the local Repository for tests only.
+ */
+public class NoOpRepositoryProxyFactory implements RepositoryProxyFactory {
+
+    @Override
+    public IRepository proxy(
+            IRepository localRepository,
+            Boolean useServerData,
+            IBaseResource dataEndpoint,
+            IBaseResource contentEndpoint,
+            IBaseResource terminologyEndpoint) {
+        return localRepository;
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/R4MultiMeasureServiceProxyTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/R4MultiMeasureServiceProxyTest.java
@@ -1,0 +1,273 @@
+package org.opencds.cqf.fhir.cr.measure.r4;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.opencds.cqf.fhir.test.Resources.getResourcePath;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.repository.IRepository;
+import java.nio.file.Path;
+import java.util.Collections;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Endpoint;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.Measure;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.SEARCH_FILTER_MODE;
+import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.TERMINOLOGY_FILTER_MODE;
+import org.opencds.cqf.fhir.cql.engine.terminology.TerminologySettings.VALUESET_EXPANSION_MODE;
+import org.opencds.cqf.fhir.cr.measure.MeasureEvaluationOptions;
+import org.opencds.cqf.fhir.cr.measure.common.MeasurePeriodValidator;
+import org.opencds.cqf.fhir.utility.BundleHelper;
+import org.opencds.cqf.fhir.utility.repository.InMemoryFhirRepository;
+import org.opencds.cqf.fhir.utility.repository.ig.IgRepository;
+
+/**
+ * Tests that verify the RepositoryProxyFactory correctly routes requests
+ * to different repositories based on endpoint configuration.
+ *
+ * <p>Each test splits resources across InMemoryFhirRepositories so that
+ * evaluation can only succeed if the proxy routes to the correct repository.
+ */
+class R4MultiMeasureServiceProxyTest {
+
+    private static final String CLASS_PATH = "org/opencds/cqf/fhir/cr/measure/r4";
+    private static final FhirContext FHIR_CONTEXT = FhirContext.forR4Cached();
+
+    private IgRepository fullRepository() {
+        return new IgRepository(
+                FHIR_CONTEXT,
+                Path.of(getResourcePath(this.getClass()) + "/" + CLASS_PATH + "/MinimalMeasureEvaluation"));
+    }
+
+    private MeasureEvaluationOptions defaultOptions() {
+        var options = MeasureEvaluationOptions.defaultOptions();
+        options.getEvaluationSettings()
+                .getRetrieveSettings()
+                .setSearchParameterMode(SEARCH_FILTER_MODE.FILTER_IN_MEMORY)
+                .setTerminologyParameterMode(TERMINOLOGY_FILTER_MODE.FILTER_IN_MEMORY);
+        options.getEvaluationSettings()
+                .getTerminologySettings()
+                .setValuesetExpansionMode(VALUESET_EXPANSION_MODE.PERFORM_NAIVE_EXPANSION);
+        return options;
+    }
+
+    /**
+     * Sentinel endpoint: a non-null Endpoint signals the TestRepositoryProxyFactory
+     * to substitute the corresponding InMemoryFhirRepository.
+     */
+    private Endpoint sentinel() {
+        return new Endpoint().setAddress("http://test");
+    }
+
+    /**
+     * Builds an InMemoryFhirRepository containing only content resources
+     * (Measure and Library) from the full repository.
+     */
+    private IRepository buildContentRepository(IgRepository source) {
+        var repo = new InMemoryFhirRepository(FHIR_CONTEXT);
+        // Copy all Measure resources
+        var measures = source.search(Bundle.class, Measure.class, Collections.emptyMap());
+        for (var resource : BundleHelper.getEntryResources(measures)) {
+            repo.update(resource);
+        }
+        // Copy all Library resources
+        var libraries = source.search(Bundle.class, Library.class, Collections.emptyMap());
+        for (var resource : BundleHelper.getEntryResources(libraries)) {
+            repo.update(resource);
+        }
+        return repo;
+    }
+
+    /**
+     * Builds an InMemoryFhirRepository containing only terminology resources
+     * (ValueSet) from the full repository.
+     */
+    private IRepository buildTerminologyRepository(IgRepository source) {
+        var repo = new InMemoryFhirRepository(FHIR_CONTEXT);
+        var valueSets = source.search(Bundle.class, ValueSet.class, Collections.emptyMap());
+        for (var resource : BundleHelper.getEntryResources(valueSets)) {
+            repo.update(resource);
+        }
+        return repo;
+    }
+
+    /**
+     * Builds an InMemoryFhirRepository containing only data resources
+     * (Patient, Encounter, etc.) from the full repository.
+     */
+    private IRepository buildDataRepository(IgRepository source) {
+        var repo = new InMemoryFhirRepository(FHIR_CONTEXT);
+        var patients = source.search(Bundle.class, Patient.class, Collections.emptyMap());
+        for (var resource : BundleHelper.getEntryResources(patients)) {
+            repo.update(resource);
+        }
+        // Also copy Encounter resources
+        var encounters = source.search(Bundle.class, org.hl7.fhir.r4.model.Encounter.class, Collections.emptyMap());
+        for (var resource : BundleHelper.getEntryResources(encounters)) {
+            repo.update(resource);
+        }
+        return repo;
+    }
+
+    @Test
+    void noEndpoints_usesStandardRepository() {
+        var repo = fullRepository();
+        var service = new R4MultiMeasureService(
+                repo,
+                defaultOptions(),
+                "http://localhost",
+                new MeasurePeriodValidator(),
+                new TestRepositoryProxyFactory(null, null, null));
+
+        // Evaluate with no endpoints - should use the standard repository
+        var report = service.evaluate(
+                org.opencds.cqf.fhir.utility.monad.Eithers.forMiddle3(
+                        new IdType("Measure", "MinimalProportionBooleanBasisSingleGroup")),
+                null,
+                null,
+                "subject",
+                "Patient/female-1988",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
+        assertNotNull(report);
+        assertNotNull(report.getId());
+    }
+
+    @Test
+    void onlyContentEndpoint_contentFromProxy() {
+        var source = fullRepository();
+        var contentRepo = buildContentRepository(source);
+
+        // Create a local repo WITHOUT content (Measures/Libraries)
+        // The content must come from the proxy's content repository
+        var service = new R4MultiMeasureService(
+                source,
+                defaultOptions(),
+                "http://localhost",
+                new MeasurePeriodValidator(),
+                new TestRepositoryProxyFactory(null, contentRepo, null));
+
+        // Passing only content endpoint sentinel - content should route to contentRepo
+        var report = service.evaluate(
+                org.opencds.cqf.fhir.utility.monad.Eithers.forMiddle3(
+                        new IdType("Measure", "MinimalProportionBooleanBasisSingleGroup")),
+                null,
+                null,
+                "subject",
+                "Patient/female-1988",
+                null,
+                sentinel(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
+        assertNotNull(report);
+    }
+
+    @Test
+    void onlyTerminologyEndpoint_terminologyFromProxy() {
+        var source = fullRepository();
+        var terminologyRepo = buildTerminologyRepository(source);
+
+        var service = new R4MultiMeasureService(
+                source,
+                defaultOptions(),
+                "http://localhost",
+                new MeasurePeriodValidator(),
+                new TestRepositoryProxyFactory(null, null, terminologyRepo));
+
+        // Passing only terminology endpoint sentinel
+        var report = service.evaluate(
+                org.opencds.cqf.fhir.utility.monad.Eithers.forMiddle3(
+                        new IdType("Measure", "MinimalProportionBooleanBasisSingleGroup")),
+                null,
+                null,
+                "subject",
+                "Patient/female-1988",
+                null,
+                null,
+                sentinel(),
+                null,
+                null,
+                null,
+                null,
+                null);
+        assertNotNull(report);
+    }
+
+    @Test
+    void allThreeEndpoints_eachTypeSeparatelyRouted() {
+        var source = fullRepository();
+        var dataRepo = buildDataRepository(source);
+        var contentRepo = buildContentRepository(source);
+        var terminologyRepo = buildTerminologyRepository(source);
+
+        var service = new R4MultiMeasureService(
+                source,
+                defaultOptions(),
+                "http://localhost",
+                new MeasurePeriodValidator(),
+                new TestRepositoryProxyFactory(dataRepo, contentRepo, terminologyRepo));
+
+        // All three endpoints specified - each type routed to its respective repo
+        var report = service.evaluate(
+                org.opencds.cqf.fhir.utility.monad.Eithers.forMiddle3(
+                        new IdType("Measure", "MinimalProportionBooleanBasisSingleGroup")),
+                null,
+                null,
+                "subject",
+                "Patient/female-1988",
+                null,
+                sentinel(),
+                sentinel(),
+                sentinel(),
+                null,
+                null,
+                null,
+                null);
+        assertNotNull(report);
+    }
+
+    @Test
+    void contentAndTerminologyEndpoints_dataFromLocal() {
+        var source = fullRepository();
+        var contentRepo = buildContentRepository(source);
+        var terminologyRepo = buildTerminologyRepository(source);
+
+        var service = new R4MultiMeasureService(
+                source,
+                defaultOptions(),
+                "http://localhost",
+                new MeasurePeriodValidator(),
+                new TestRepositoryProxyFactory(null, contentRepo, terminologyRepo));
+
+        // Content + terminology endpoints, data from local
+        var report = service.evaluate(
+                org.opencds.cqf.fhir.utility.monad.Eithers.forMiddle3(
+                        new IdType("Measure", "MinimalProportionBooleanBasisSingleGroup")),
+                null,
+                null,
+                "subject",
+                "Patient/female-1988",
+                null,
+                sentinel(),
+                sentinel(),
+                null,
+                null,
+                null,
+                null,
+                null);
+        assertNotNull(report);
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/TestRepositoryProxyFactory.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/TestRepositoryProxyFactory.java
@@ -1,0 +1,41 @@
+package org.opencds.cqf.fhir.cr.measure.r4;
+
+import ca.uhn.fhir.repository.IRepository;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.opencds.cqf.fhir.utility.repository.Repositories;
+import org.opencds.cqf.fhir.utility.repository.RepositoryProxyFactory;
+
+/**
+ * A test-only RepositoryProxyFactory that maps non-null endpoint sentinel objects
+ * to pre-built InMemoryFhirRepository instances, avoiding the need for live FHIR servers.
+ *
+ * <p>For the endpoint-based proxy method, any non-null endpoint is treated as a sentinel
+ * indicating that the corresponding pre-built repository should be used.
+ */
+class TestRepositoryProxyFactory implements RepositoryProxyFactory {
+    private final IRepository dataRepository;
+    private final IRepository contentRepository;
+    private final IRepository terminologyRepository;
+
+    TestRepositoryProxyFactory(
+            IRepository dataRepository, IRepository contentRepository, IRepository terminologyRepository) {
+        this.dataRepository = dataRepository;
+        this.contentRepository = contentRepository;
+        this.terminologyRepository = terminologyRepository;
+    }
+
+    @Override
+    public IRepository proxy(
+            IRepository localRepository,
+            Boolean useServerData,
+            IBaseResource dataEndpoint,
+            IBaseResource contentEndpoint,
+            IBaseResource terminologyEndpoint) {
+        return Repositories.proxy(
+                localRepository,
+                useServerData,
+                dataEndpoint != null ? dataRepository : null,
+                contentEndpoint != null ? contentRepository : null,
+                terminologyEndpoint != null ? terminologyRepository : null);
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/PlanDefinitionProcessorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/PlanDefinitionProcessorTests.java
@@ -26,6 +26,7 @@ import org.opencds.cqf.fhir.cr.CrSettings;
 import org.opencds.cqf.fhir.cr.activitydefinition.apply.IRequestResolverFactory;
 import org.opencds.cqf.fhir.cr.common.DataRequirementsProcessor;
 import org.opencds.cqf.fhir.cr.common.PackageProcessor;
+import org.opencds.cqf.fhir.cr.measure.r4.NoOpRepositoryProxyFactory;
 import org.opencds.cqf.fhir.cr.plandefinition.apply.ApplyProcessor;
 import org.opencds.cqf.fhir.utility.BundleHelper;
 import org.opencds.cqf.fhir.utility.Ids;
@@ -42,7 +43,8 @@ class PlanDefinitionProcessorTests {
     void defaultSettings() {
         var repository =
                 new IgRepository(fhirContextR4, Path.of(getResourcePath(this.getClass()) + "/" + CLASS_PATH + "/r4"));
-        var processor = new PlanDefinitionProcessor(repository);
+        var processor = new PlanDefinitionProcessor(
+                repository, CrSettings.getDefault(), null, null, new NoOpRepositoryProxyFactory());
         assertNotNull(processor.settings());
     }
 
@@ -60,10 +62,15 @@ class PlanDefinitionProcessorTests {
                 CrSettings.getDefault(),
                 requestResolverFactory,
                 List.of(
-                        new ApplyProcessor(repository, activityProcessor),
+                        new ApplyProcessor(
+                                repository,
+                                activityProcessor,
+                                CrSettings.getDefault(),
+                                new NoOpRepositoryProxyFactory()),
                         packageProcessor,
                         dataRequirementsProcessor,
-                        activityProcessor));
+                        activityProcessor),
+                new NoOpRepositoryProxyFactory());
         assertNotNull(processor.settings());
         var result = processor.apply(
                 Eithers.forMiddle3(Ids.newId(repository.fhirContext(), "PlanDefinition", "DischargeInstructionsPlan")),

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/TestPlanDefinition.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/TestPlanDefinition.java
@@ -40,6 +40,7 @@ import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.json.JSONException;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.fhir.cql.EvaluationSettings;
+import org.opencds.cqf.fhir.cql.LibraryEngine;
 import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.SEARCH_FILTER_MODE;
 import org.opencds.cqf.fhir.cql.engine.retrieve.RetrieveSettings.TERMINOLOGY_FILTER_MODE;
 import org.opencds.cqf.fhir.cql.engine.terminology.TerminologySettings.VALUESET_EXPANSION_MODE;
@@ -48,12 +49,14 @@ import org.opencds.cqf.fhir.cr.TestOperationProvider;
 import org.opencds.cqf.fhir.cr.common.IOperationProcessor;
 import org.opencds.cqf.fhir.cr.helpers.DataRequirementsLibrary;
 import org.opencds.cqf.fhir.cr.helpers.GeneratedPackage;
+import org.opencds.cqf.fhir.cr.measure.r4.NoOpRepositoryProxyFactory;
 import org.opencds.cqf.fhir.utility.Ids;
 import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
 import org.opencds.cqf.fhir.utility.adapter.IParametersAdapter;
 import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 import org.opencds.cqf.fhir.utility.monad.Eithers;
 import org.opencds.cqf.fhir.utility.repository.InMemoryFhirRepository;
+import org.opencds.cqf.fhir.utility.repository.Repositories;
 import org.opencds.cqf.fhir.utility.repository.ig.IgRepository;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -120,16 +123,18 @@ public class TestPlanDefinition {
                         .setValuesetExpansionMode(VALUESET_EXPANSION_MODE.PERFORM_NAIVE_EXPANSION);
             }
             var crSettings = CrSettings.getDefault().withEvaluationSettings(evaluationSettings);
-            return new PlanDefinitionProcessor(repository, crSettings, null, operationProcessors);
+            return new PlanDefinitionProcessor(
+                    repository, crSettings, null, operationProcessors, new NoOpRepositoryProxyFactory());
         }
 
         public When when() {
-            return new When(repository, buildProcessor(repository));
+            return new When(this, repository);
         }
     }
 
     @SuppressWarnings("UnstableApiUsage")
     public static class When {
+        private final Given given;
         private final IRepository repository;
         private final PlanDefinitionProcessor processor;
         private final IParser jsonParser;
@@ -150,9 +155,10 @@ public class TestPlanDefinition {
         private IBaseParameters parameters;
         private boolean isPackagePut;
 
-        public When(IRepository repository, PlanDefinitionProcessor processor) {
+        public When(Given given, IRepository repository) {
+            this.given = given;
             this.repository = repository;
-            this.processor = processor;
+            this.processor = given.buildProcessor(repository);
             useServerData = true;
             jsonParser = repository.fhirContext().newJsonParser();
         }
@@ -255,7 +261,10 @@ public class TestPlanDefinition {
             if (additionalDataId != null) {
                 additionalData(readRepository(repository, additionalDataId));
             }
-            var param = (IParametersAdapter) IAdapterFactory.createAdapterForResource(processor.applyR5(
+            var proxiedRepo = Repositories.proxy(
+                    repository, useServerData, dataRepository, contentRepository, terminologyRepository);
+            var applyProcessor = given.buildProcessor(proxiedRepo);
+            var param = (IParametersAdapter) IAdapterFactory.createAdapterForResource(applyProcessor.applyR5(
                     Eithers.forMiddle3(Ids.newId(repository.fhirContext(), "PlanDefinition", planDefinitionId)),
                     List.of(subjectId),
                     encounterId,
@@ -267,12 +276,9 @@ public class TestPlanDefinition {
                     null,
                     null,
                     parameters,
-                    useServerData,
                     additionalData,
                     prefetchData,
-                    dataRepository,
-                    contentRepository,
-                    terminologyRepository));
+                    new LibraryEngine(proxiedRepo, applyProcessor.settings().getEvaluationSettings())));
             return (IBaseBundle) param.getParameter().get(0).getResource();
         }
 
@@ -284,9 +290,12 @@ public class TestPlanDefinition {
             if (additionalDataId != null) {
                 additionalData(readRepository(repository, additionalDataId));
             }
+            var proxiedRepo = Repositories.proxy(
+                    repository, useServerData, dataRepository, contentRepository, terminologyRepository);
+            var applyProcessor = given.buildProcessor(proxiedRepo);
             return new GeneratedCarePlan(
                     repository,
-                    processor.apply(
+                    applyProcessor.apply(
                             Eithers.forMiddle3(Ids.newId(repository.fhirContext(), "PlanDefinition", planDefinitionId)),
                             subjectId,
                             encounterId,
@@ -298,12 +307,10 @@ public class TestPlanDefinition {
                             null,
                             null,
                             parameters,
-                            useServerData,
                             additionalData,
                             prefetchData,
-                            dataRepository,
-                            contentRepository,
-                            terminologyRepository));
+                            new LibraryEngine(
+                                    proxiedRepo, applyProcessor.settings().getEvaluationSettings())));
         }
 
         public GeneratedPackage thenPackage() {

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/TestItemGenerator.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/TestItemGenerator.java
@@ -26,6 +26,8 @@ import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.json.JSONException;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.fhir.cr.CrSettings;
+import org.opencds.cqf.fhir.cr.measure.r4.NoOpRepositoryProxyFactory;
 import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 import org.opencds.cqf.fhir.utility.monad.Eithers;
@@ -66,7 +68,8 @@ public class TestItemGenerator {
         }
 
         public static QuestionnaireProcessor buildProcessor(IRepository repository) {
-            return new QuestionnaireProcessor(repository);
+            return new QuestionnaireProcessor(
+                    repository, CrSettings.getDefault(), null, new NoOpRepositoryProxyFactory());
         }
 
         public When when() {

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/TestQuestionnaire.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/TestQuestionnaire.java
@@ -36,6 +36,7 @@ import org.opencds.cqf.fhir.cr.common.IOperationProcessor;
 import org.opencds.cqf.fhir.cr.common.IPackageProcessor;
 import org.opencds.cqf.fhir.cr.helpers.DataRequirementsLibrary;
 import org.opencds.cqf.fhir.cr.helpers.GeneratedPackage;
+import org.opencds.cqf.fhir.cr.measure.r4.NoOpRepositoryProxyFactory;
 import org.opencds.cqf.fhir.cr.questionnaire.generate.GenerateRequest;
 import org.opencds.cqf.fhir.cr.questionnaire.generate.IGenerateProcessor;
 import org.opencds.cqf.fhir.cr.questionnaire.populate.IPopulateProcessor;
@@ -116,7 +117,8 @@ public class TestQuestionnaire {
                         .setValuesetExpansionMode(VALUESET_EXPANSION_MODE.PERFORM_NAIVE_EXPANSION);
             }
             var crSettings = CrSettings.getDefault().withEvaluationSettings(evaluationSettings);
-            return new QuestionnaireProcessor(repository, crSettings, operationProcessors);
+            return new QuestionnaireProcessor(
+                    repository, crSettings, operationProcessors, new NoOpRepositoryProxyFactory());
         }
 
         public When when() {

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaireresponse/TestQuestionnaireResponse.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaireresponse/TestQuestionnaireResponse.java
@@ -21,6 +21,7 @@ import org.hl7.fhir.instance.model.api.IIdType;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.fhir.cr.CrSettings;
 import org.opencds.cqf.fhir.cr.common.IOperationProcessor;
+import org.opencds.cqf.fhir.cr.measure.r4.NoOpRepositoryProxyFactory;
 import org.opencds.cqf.fhir.cr.questionnaireresponse.extract.IExtractProcessor;
 import org.opencds.cqf.fhir.utility.Ids;
 import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
@@ -75,7 +76,8 @@ public class TestQuestionnaireResponse {
         }
 
         private QuestionnaireResponseProcessor buildProcessor() {
-            return new QuestionnaireResponseProcessor(repository, CrSettings.getDefault(), operationProcessors);
+            return new QuestionnaireResponseProcessor(
+                    repository, CrSettings.getDefault(), operationProcessors, new NoOpRepositoryProxyFactory());
         }
 
         public When when() {

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/repository/DefaultRepositoryProxyFactory.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/repository/DefaultRepositoryProxyFactory.java
@@ -1,0 +1,20 @@
+package org.opencds.cqf.fhir.utility.repository;
+
+import ca.uhn.fhir.repository.IRepository;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+/**
+ * Default implementation that delegates to the static methods in {@link Repositories}.
+ */
+public class DefaultRepositoryProxyFactory implements RepositoryProxyFactory {
+
+    @Override
+    public IRepository proxy(
+            IRepository localRepository,
+            Boolean useServerData,
+            IBaseResource dataEndpoint,
+            IBaseResource contentEndpoint,
+            IBaseResource terminologyEndpoint) {
+        return Repositories.proxy(localRepository, useServerData, dataEndpoint, contentEndpoint, terminologyEndpoint);
+    }
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/repository/RepositoryProxyFactory.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/repository/RepositoryProxyFactory.java
@@ -1,0 +1,24 @@
+package org.opencds.cqf.fhir.utility.repository;
+
+import ca.uhn.fhir.repository.IRepository;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+/**
+ * Factory for creating proxy repositories that route data, content, and terminology
+ * requests to different endpoints. This abstraction allows tests to substitute
+ * in-memory repositories instead of requiring live FHIR servers.
+ */
+public interface RepositoryProxyFactory {
+
+    /**
+     * Creates a proxy repository from endpoint resources (e.g., FHIR Endpoint).
+     * Each non-null endpoint is converted to a repository via
+     * {@link Repositories#createRestRepository}.
+     */
+    IRepository proxy(
+            IRepository localRepository,
+            Boolean useServerData,
+            IBaseResource dataEndpoint,
+            IBaseResource contentEndpoint,
+            IBaseResource terminologyEndpoint);
+}


### PR DESCRIPTION
## Summary

This MR introduces a `RepositoryProxyFactory` abstraction to decouple all clinical reasoning processors from the static `Repositories.proxy()` / `Repositories.createRestRepository()` helpers. Previously, processors (ActivityDefinition, PlanDefinition, Library, CQL, Questionnaire, QuestionnaireResponse, GraphDefinition, Measure, CareGaps) hard-coded calls to these static methods, making it impossible to substitute proxy behaviour in tests without standing up live FHIR servers. The factory is injected via constructors throughout the processor hierarchy and wired as a Spring bean in the HAPI config layer.

1. **New `RepositoryProxyFactory` interface and `DefaultRepositoryProxyFactory`** in `cqf-fhir-utility` — the interface accepts raw endpoint resources (`IBaseResource`) rather than pre-resolved `IRepository` instances, so processors no longer need to call `createRestRepository()` themselves.
2. **Processor constructor consolidation** — telescope constructors (e.g. `new Processor(repo)` -> `new Processor(repo, settings)` -> `new Processor(repo, settings, ops)`) are removed in favour of a single constructor that requires the factory, enforced with `requireNonNull`.
3. **R4MultiMeasureService proxy simplification** — the duplicated null-check-then-proxy pattern is replaced by unconditionally calling `proxy()` + `withRepository()` on cached processor/utils instances. `withRepository()` returns `this` when the repository is the same instance, avoiding unnecessary object creation.
4. **Test infrastructure** — `NoOpRepositoryProxyFactory` (always returns the local repo) replaces `DefaultRepositoryProxyFactory` in all tests that don't exercise proxy routing. `R4MultiMeasureServiceProxyTest` with `TestRepositoryProxyFactory` validates that endpoint-based routing actually works by splitting resources across `InMemoryFhirRepository` instances.

## Code Review Suggestions

- [ ] **Breaking API change**: All processor constructors now require `RepositoryProxyFactory` as a mandatory parameter, and the 1-arg and 2-arg telescope constructors are removed. Verify that no downstream consumers (HAPI FHIR starter, Android SDK, other integrators) rely on the removed constructors — the compiler will catch direct callers, but reflection-based or Spring XML-based instantiation will fail silently at runtime.
- [ ] **`ApplyRequestBuilder` removed `withDataRepository()`, `withContentRepository()`, `withTerminologyRepository()` setters** — these accepted `IRepository` directly and are replaced by endpoint-based wiring. Check whether any HAPI provider or external code calls these removed methods.
- [ ] **`R4MultiMeasureService` original proxy condition used `&&` (all three non-null)** while the new code calls `proxy()` unconditionally — verify this is the intended semantic change. The old code only proxied when *all* endpoints were non-null; the new code delegates to the factory regardless, which handles partial endpoints correctly via `Repositories.proxy()`.
- [ ] **`QuestionnaireResponseProcessor` is now constructed inside `ApplyProcessor`** with `new QuestionnaireResponseProcessor(repo, crSettings, null, repositoryProxyFactory)` — previously it used a no-arg-ish constructor. Confirm `CrSettings` propagation here is correct (it receives the PlanDefinition processor's settings, not QuestionnaireResponse-specific settings).
- [ ] **Spring bean `repositoryProxyFactory()` in `CrBaseConfig`** is not annotated with `@ConditionalOnMissingBean` — if a downstream project (like Smile CDR) defines its own `RepositoryProxyFactory` bean, it will conflict. Verify whether this should be conditional.

## QA Test Suggestions

### Setup
- Deploy a HAPI FHIR server (or Smile CDR) with the `cqf-fhir-cr-hapi` module loaded
- Ensure clinical reasoning operations are enabled (Measure, PlanDefinition, ActivityDefinition, Questionnaire, Library, CareGaps, CQL, GraphDefinition)
- Load a test IG with at least one Measure, PlanDefinition, Library, and Questionnaire resource

### Test Cases

- [ ] **$evaluate-measure without endpoints**: Call `Measure/$evaluate-measure` with no `dataEndpoint`, `contentEndpoint`, or `terminologyEndpoint` parameters. Verify the measure evaluates successfully using the local server's data — this exercises the default `RepositoryProxyFactory` path.
- [ ] **$evaluate-measure with endpoint parameters**: If a remote FHIR terminology server is available, call `$evaluate-measure` with a `terminologyEndpoint` pointing to it. Verify that ValueSet expansion comes from the remote server.
- [ ] **$apply (PlanDefinition)**: Call `PlanDefinition/$apply` with and without endpoint parameters. Verify the CarePlan/RequestGroup is returned correctly in both cases.
- [ ] **$apply (ActivityDefinition)**: Call `ActivityDefinition/$apply` with and without endpoint parameters. Verify the generated resource (e.g. MedicationRequest, ServiceRequest) is correct.
- [ ] **$populate (Questionnaire)**: Call `Questionnaire/$populate` with a subject. Verify pre-population works against local data.
- [ ] **$extract (QuestionnaireResponse)**: Submit a QuestionnaireResponse for `$extract`. Verify the extracted resources are correct — this validates the `ApplyProcessor` -> `QuestionnaireResponseProcessor` construction chain.
- [ ] **$care-gaps**: Call `Measure/$care-gaps` with required parameters. Verify the care gaps bundle is returned with correct composition and detected issues.
- [ ] **Multi-measure evaluation**: Call the multi-measure endpoint with multiple measure IDs. Verify all MeasureReports are returned in the Parameters response.
- [ ] **Spring context startup**: Verify the application context starts cleanly with no bean definition conflicts or missing dependencies related to `RepositoryProxyFactory`.
