### PR TITLE
Source dependencies from local maven repository only when local.properties exists

### DIFF
--- a/build-logic/src/main/kotlin/cqf.java-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cqf.java-conventions.gradle.kts
@@ -16,6 +16,9 @@ java {
 }
 
 repositories {
+    if (file("${rootProject.projectDir}/local.properties").exists()) {
+        mavenLocal()
+    }
     mavenCentral()
     maven {
         name = "central-snapshots"


### PR DESCRIPTION
- Enables resolution of locally-published SNAPSHOT artifacts during development. 
- Heuristic to detect local development:  Gated behind the presence of local.properties (which is gitignored) so CI and other developers are unaffected.