### PR TITLE
Fix CLI module to publish unclassified fat JAR as primary artifact

### DIFF
--- a/cqf-fhir-cr-cli/build.gradle.kts
+++ b/cqf-fhir-cr-cli/build.gradle.kts
@@ -13,6 +13,15 @@ application { mainClass = "org.opencds.cqf.fhir.cr.cli.Main" }
 
 tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
     mainClass = "org.opencds.cqf.fhir.cr.cli.Main"
+    // Publish the fat JAR as the primary (unclassified) artifact so consumers
+    // can resolve it without specifying a classifier
+    archiveClassifier.set("")
+}
+
+tasks.named<Jar>("jar") {
+    // The standard library JAR gets the "plain" classifier to avoid conflicting
+    // with the bootJar output
+    archiveClassifier.set("plain")
 }
 
 dependencies {


### PR DESCRIPTION
Since the Spring Boot Gradle plugin was applied to cqf-fhir-cr-cli, the standard jar task was disabled by default and only classified JARs (-plain, -javadoc, -module) were published to Maven Central. Downstream projects depending on cqf-fhir-cr-cli:jar (without a classifier) got 404s from Maven Central, breaking builds that unpack the CLI fat JAR.