### PR TITLE
Fix CLI module to publish unclassified fat JAR

### DIFF
--- a/cqf-fhir-cr-cli/build.gradle.kts
+++ b/cqf-fhir-cr-cli/build.gradle.kts
@@ -15,6 +15,19 @@ tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
     mainClass = "org.opencds.cqf.fhir.cr.cli.Main"
 }
 
+// Disable the thin "plain" JAR so the bootJar fat JAR is published as the
+// primary unclassified artifact, matching the Maven-era artifact layout.
+tasks.named<Jar>("jar") { enabled = false }
+
+// The vanniktech publish plugin derives its publication from components["java"],
+// which is wired to the (now-disabled) jar task. Explicitly add the bootJar
+// output so the fat JAR is published as the unclassified primary artifact.
+afterEvaluate {
+    extensions.configure<PublishingExtension> {
+        publications.named<MavenPublication>("maven") { artifact(tasks.named("bootJar")) }
+    }
+}
+
 dependencies {
     implementation(project(":cqf-fhir-utility"))
     implementation(project(":cqf-fhir-cql"))


### PR DESCRIPTION
## Summary
- Since 4.4.1 (the Gradle migration), the CLI module only published a `-plain` thin JAR to Maven Central. The unclassified fat JAR that consumers expect was missing.
- Disables the `jar` task and wires `bootJar` into the vanniktech maven publication so the fat JAR is published as the primary unclassified artifact, matching the pre-4.4.1 layout.
- Already applied to `release-4.5.1` for a 4.5.2 patch release.

## Test plan
- [x] `publishToMavenLocal` produces unclassified fat JAR (~206MB), `-javadoc`, `-sources` — matches Maven-era artifact names
- [x] `:cqf-fhir-cr-cli:build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)