### PR TITLE
Fix continuous variable aggregate method codes to match spec

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/ContinuousVariableObservationAggregateMethod.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/ContinuousVariableObservationAggregateMethod.java
@@ -6,11 +6,11 @@ import jakarta.annotation.Nullable;
  * All continuous variable scoring aggregation methods.
  */
 public enum ContinuousVariableObservationAggregateMethod {
-    AVG("avg"),
+    AVG("average"),
     COUNT("count"),
-    MAX("max"),
+    MAX("maximum"),
     MEDIAN("median"),
-    MIN("min"),
+    MIN("minimum"),
     SUM("sum"),
     N_A(null);
 

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/utils/R4MeasureReportUtilsTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/utils/R4MeasureReportUtilsTest.java
@@ -59,7 +59,7 @@ class R4MeasureReportUtilsTest {
         Extension methodExt = population.getExtensionByUrl(EXT_CQFM_AGGREGATE_METHOD_URL);
         assertNotNull(methodExt);
         assertInstanceOf(StringType.class, methodExt.getValue());
-        assertEquals("avg", ((StringType) methodExt.getValue()).getValue());
+        assertEquals("average", ((StringType) methodExt.getValue()).getValue());
     }
 
     @Test
@@ -114,7 +114,7 @@ class R4MeasureReportUtilsTest {
         Extension methodExt = population.getExtensionByUrl(EXT_CQFM_AGGREGATE_METHOD_URL);
         assertNotNull(methodExt);
         assertInstanceOf(StringType.class, methodExt.getValue());
-        assertEquals("avg", ((StringType) methodExt.getValue()).getValue());
+        assertEquals("average", ((StringType) methodExt.getValue()).getValue());
     }
 
     @Test
@@ -200,7 +200,7 @@ class R4MeasureReportUtilsTest {
 
         Extension methodExt = population.getExtensionByUrl(EXT_CQFM_AGGREGATE_METHOD_URL);
         assertNotNull(methodExt);
-        assertEquals("min", ((StringType) methodExt.getValue()).getValue());
+        assertEquals("minimum", ((StringType) methodExt.getValue()).getValue());
     }
 
     @Test
@@ -242,7 +242,7 @@ class R4MeasureReportUtilsTest {
 
         Extension methodExt = population.getExtensionByUrl(EXT_CQFM_AGGREGATE_METHOD_URL);
         assertNotNull(methodExt);
-        assertEquals("max", ((StringType) methodExt.getValue()).getValue());
+        assertEquals("maximum", ((StringType) methodExt.getValue()).getValue());
     }
 
     // ========================================
@@ -329,7 +329,7 @@ class R4MeasureReportUtilsTest {
 
         Extension methodExt = stratumPopulation.getExtensionByUrl(EXT_CQFM_AGGREGATE_METHOD_URL);
         assertNotNull(methodExt);
-        assertEquals("avg", ((StringType) methodExt.getValue()).getValue());
+        assertEquals("average", ((StringType) methodExt.getValue()).getValue());
 
         Extension criteriaRefExt = stratumPopulation.getExtensionByUrl(MeasureConstants.EXT_CQFM_CRITERIA_REFERENCE);
         assertNotNull(criteriaRefExt);
@@ -435,8 +435,8 @@ class R4MeasureReportUtilsTest {
     @Test
     void testAddAggregationResultAndMethod_FromEnum_WithAllAggregationMethodsAndCriteriaReference() {
         // Test multiple aggregate methods in a single test to reduce duplication
-        testAggregationMethodAndResult(ContinuousVariableObservationAggregateMethod.MIN, 1.2, "min");
-        testAggregationMethodAndResult(ContinuousVariableObservationAggregateMethod.MAX, 1.3, "max");
+        testAggregationMethodAndResult(ContinuousVariableObservationAggregateMethod.MIN, 1.2, "minimum");
+        testAggregationMethodAndResult(ContinuousVariableObservationAggregateMethod.MAX, 1.3, "maximum");
         testAggregationMethodAndResult(ContinuousVariableObservationAggregateMethod.MEDIAN, 1.4, "median");
         testAggregationMethodAndResult(ContinuousVariableObservationAggregateMethod.SUM, 1.5, "sum");
     }
@@ -578,7 +578,7 @@ class R4MeasureReportUtilsTest {
 
         Extension methodExt = population.getExtensionByUrl(EXT_CQFM_AGGREGATE_METHOD_URL);
         assertNotNull(methodExt);
-        assertEquals("avg", ((StringType) methodExt.getValue()).getValue());
+        assertEquals("average", ((StringType) methodExt.getValue()).getValue());
 
         Extension resultExt = population.getExtensionByUrl(MeasureConstants.EXT_AGGREGATION_METHOD_RESULT);
         assertNotNull(resultExt);
@@ -636,7 +636,7 @@ class R4MeasureReportUtilsTest {
         // Assert all three extensions are set
         Extension methodExt = population.getExtensionByUrl(EXT_CQFM_AGGREGATE_METHOD_URL);
         assertNotNull(methodExt);
-        assertEquals("min", ((StringType) methodExt.getValue()).getValue());
+        assertEquals("minimum", ((StringType) methodExt.getValue()).getValue());
 
         Extension resultExt = population.getExtensionByUrl(MeasureConstants.EXT_AGGREGATION_METHOD_RESULT);
         assertNotNull(resultExt);

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/utils/R4MeasureUtilsTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/utils/R4MeasureUtilsTest.java
@@ -499,7 +499,7 @@ class R4MeasureUtilsTest {
     void testGetAggregateMethod_WithAvgExtension() {
         String measureUrl = "http://example.com/Measure/test";
         MeasureGroupPopulationComponent population = new MeasureGroupPopulationComponent();
-        population.addExtension(EXT_CQFM_AGGREGATE_METHOD_URL, new StringType("avg"));
+        population.addExtension(EXT_CQFM_AGGREGATE_METHOD_URL, new StringType("average"));
 
         ContinuousVariableObservationAggregateMethod result = R4MeasureUtils.getAggregateMethod(measureUrl, population);
 
@@ -521,7 +521,7 @@ class R4MeasureUtilsTest {
     void testGetAggregateMethod_WithMinExtension() {
         String measureUrl = "http://example.com/Measure/test";
         MeasureGroupPopulationComponent population = new MeasureGroupPopulationComponent();
-        population.addExtension(EXT_CQFM_AGGREGATE_METHOD_URL, new StringType("min"));
+        population.addExtension(EXT_CQFM_AGGREGATE_METHOD_URL, new StringType("minimum"));
 
         ContinuousVariableObservationAggregateMethod result = R4MeasureUtils.getAggregateMethod(measureUrl, population);
 
@@ -532,7 +532,7 @@ class R4MeasureUtilsTest {
     void testGetAggregateMethod_WithMaxExtension() {
         String measureUrl = "http://example.com/Measure/test";
         MeasureGroupPopulationComponent population = new MeasureGroupPopulationComponent();
-        population.addExtension(EXT_CQFM_AGGREGATE_METHOD_URL, new StringType("max"));
+        population.addExtension(EXT_CQFM_AGGREGATE_METHOD_URL, new StringType("maximum"));
 
         ContinuousVariableObservationAggregateMethod result = R4MeasureUtils.getAggregateMethod(measureUrl, population);
 
@@ -588,7 +588,7 @@ class R4MeasureUtilsTest {
 
         MeasureGroupComponent group = new MeasureGroupComponent();
         MeasureGroupPopulationComponent measureObs = createPopulation(MeasurePopulationType.MEASUREOBSERVATION);
-        addAggregateMethodExtension(measureObs, "avg");
+        addAggregateMethodExtension(measureObs, "average");
         group.addPopulation(measureObs);
 
         boolean result = R4MeasureUtils.isRatioContinuousVariable(scoring, group);

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/ContinuousVariableObservationBooleanBasis/input/resources/measure/ContinuousVariableResourceMeasureObservationBooleanBasisAvg.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/ContinuousVariableObservationBooleanBasis/input/resources/measure/ContinuousVariableResourceMeasureObservationBooleanBasisAvg.json
@@ -81,7 +81,7 @@
             },
             {
               "url" : "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",
-              "valueCode" : "avg"
+              "valueCode": "average"
             }
           ],
           "code" : {

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/ContinuousVariableObservationBooleanBasis/input/resources/measure/ContinuousVariableResourceMeasureObservationBooleanBasisMax.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/ContinuousVariableObservationBooleanBasis/input/resources/measure/ContinuousVariableResourceMeasureObservationBooleanBasisMax.json
@@ -81,7 +81,7 @@
             },
             {
               "url" : "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",
-              "valueCode" : "max"
+              "valueCode": "maximum"
             }
           ],
           "code" : {

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/ContinuousVariableObservationBooleanBasis/input/resources/measure/ContinuousVariableResourceMeasureObservationBooleanBasisMin.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/ContinuousVariableObservationBooleanBasis/input/resources/measure/ContinuousVariableResourceMeasureObservationBooleanBasisMin.json
@@ -81,7 +81,7 @@
             },
             {
               "url" : "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",
-              "valueCode" : "min"
+              "valueCode": "minimum"
             }
           ],
           "code" : {

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/ContinuousVariableObservationEncounterBasis/input/resources/measure/ContinuousVariableResourceMeasureObservationEncounterBasisAvg.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/ContinuousVariableObservationEncounterBasis/input/resources/measure/ContinuousVariableResourceMeasureObservationEncounterBasisAvg.json
@@ -81,7 +81,7 @@
             },
             {
               "url" : "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",
-              "valueCode" : "avg"
+              "valueCode": "average"
             }
           ],
           "code" : {

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/ContinuousVariableObservationEncounterBasis/input/resources/measure/ContinuousVariableResourceMeasureObservationEncounterBasisMax.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/ContinuousVariableObservationEncounterBasis/input/resources/measure/ContinuousVariableResourceMeasureObservationEncounterBasisMax.json
@@ -81,7 +81,7 @@
             },
             {
               "url" : "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",
-              "valueCode" : "max"
+              "valueCode": "maximum"
             }
           ],
           "code" : {

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/ContinuousVariableObservationEncounterBasis/input/resources/measure/ContinuousVariableResourceMeasureObservationEncounterBasisMin.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/ContinuousVariableObservationEncounterBasis/input/resources/measure/ContinuousVariableResourceMeasureObservationEncounterBasisMin.json
@@ -81,7 +81,7 @@
             },
             {
               "url" : "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",
-              "valueCode" : "min"
+              "valueCode": "minimum"
             }
           ],
           "code" : {

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/RatioContVarResourceAvg.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/RatioContVarResourceAvg.json
@@ -107,7 +107,7 @@
           "id": "observation-num",
           "extension": [ {
             "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",
-            "valueCode": "avg"
+            "valueCode": "average"
           }, {
             "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference",
             "valueString": "numerator"
@@ -128,7 +128,7 @@
           "id": "observation-den",
           "extension": [ {
             "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",
-            "valueCode": "avg"
+            "valueCode": "average"
           }, {
             "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference",
             "valueString": "denominator"

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/RatioContVarResourceMax.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/RatioContVarResourceMax.json
@@ -107,7 +107,7 @@
           "id": "observation-num",
           "extension": [ {
             "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",
-            "valueCode": "max"
+            "valueCode": "maximum"
           }, {
             "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference",
             "valueString": "numerator"
@@ -128,7 +128,7 @@
           "id": "observation-den",
           "extension": [ {
             "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",
-            "valueCode": "max"
+            "valueCode": "maximum"
           }, {
             "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference",
             "valueString": "denominator"

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/RatioContVarResourceMin.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/RatioContVarResourceMin.json
@@ -107,7 +107,7 @@
           "id": "observation-num",
           "extension": [ {
             "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",
-            "valueCode": "min"
+            "valueCode": "minimum"
           }, {
             "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference",
             "valueString": "numerator"
@@ -128,7 +128,7 @@
           "id": "observation-den",
           "extension": [ {
             "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",
-            "valueCode": "min"
+            "valueCode": "minimum"
           }, {
             "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference",
             "valueString": "denominator"

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/RatioContVarResourceMix.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/RatioContVarResourceMix.json
@@ -107,7 +107,7 @@
           "id": "observation-num",
           "extension": [ {
             "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",
-            "valueCode": "avg"
+            "valueCode": "average"
           }, {
             "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference",
             "valueString": "numerator"


### PR DESCRIPTION
## Summary
- Update `ContinuousVariableObservationAggregateMethod` enum codes for AVG/MIN/MAX from `avg`/`min`/`max` to `average`/`minimum`/`maximum` to match the cqfm-aggregateMethod extension value set.
- Update affected unit tests and Measure JSON fixtures to use the spec-conformant codes.

## Test plan
- [x] `./gradlew build` passes
- [x] Targeted tests pass (`R4MeasureUtilsTest`, `R4MeasureReportUtilsTest`, continuous variable observation tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)