### PR TITLE
Ensure stratifier validation mandates "string" population basis correctly

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/PopulationBasisValidator.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/PopulationBasisValidator.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.opencds.cqf.cql.engine.execution.EvaluationResult;
+import org.opencds.cqf.fhir.cr.measure.MeasureStratifierType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -193,15 +194,38 @@ public interface PopulationBasisValidator {
                 .toList();
 
         if (resultMatchingClasses.size() != resultClasses.size()) {
-            throw new InvalidRequestException(
-                    "stratifier expression criteria results for expression: [%s] must fall within accepted types for population-basis: [%s] for Measure: [%s] due to mismatch between total eval result classes: %s and matching result classes: %s"
-                            .formatted(
-                                    expression,
-                                    groupPopulationBasisCode,
-                                    url,
-                                    prettyClassNames(resultClasses),
-                                    prettyClassNames(resultMatchingClasses)));
+            var invalidTypes = resultClasses.stream()
+                    .filter(c -> !resultMatchingClasses.contains(c))
+                    .toList();
+            throw new InvalidRequestException(buildValueStratifierErrorMessage(
+                    stratifierDef, expression, groupPopulationBasisCode, url, resultClasses, invalidTypes));
         }
+    }
+
+    private String buildValueStratifierErrorMessage(
+            StratifierDef stratifierDef,
+            String expression,
+            String groupPopulationBasisCode,
+            String url,
+            List<Class<?>> resultClasses,
+            List<Class<?>> invalidTypes) {
+
+        var allowedTypes = prettyClassNames(List.copyOf(allowedStratifierValueTypes()));
+        var invalidTypeNames = prettyClassNames(invalidTypes);
+
+        if (stratifierDef.getStratifierType() == MeasureStratifierType.NON_SUBJECT_VALUE) {
+            return "Non Subject Value stratifier expression for [%s] returned invalid result type(s): %s for Measure: [%s] with population basis: [%s]. Non Subject Value stratifier expressions must return categorical types, such as: %s. Resource types like %s cannot be used as stratifier values. Consider using a CRITERIA-based stratifier for resource membership stratification."
+                    .formatted(
+                            expression,
+                            prettyClassNames(resultClasses),
+                            url,
+                            groupPopulationBasisCode,
+                            allowedTypes,
+                            invalidTypeNames);
+        }
+
+        return "Value stratifier expression for [%s] returned invalid result type(s): %s for Measure: [%s]. Value stratifier expressions must return categorical types for stratification, such as: %s. Resource types like %s are not valid for Value stratifiers. If you intend to stratify by resource membership, use a CRITERIA-based stratifier instead."
+                .formatted(expression, prettyClassNames(resultClasses), url, allowedTypes, invalidTypeNames);
     }
 
     private boolean doesBasisMatchResource(Class<?> resultClass, String groupPopulationBasisCode) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/PopulationBasisValidator.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/PopulationBasisValidator.java
@@ -1,13 +1,224 @@
 package org.opencds.cqf.fhir.cr.measure.common;
 
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import org.opencds.cqf.cql.engine.execution.EvaluationResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Validates group populations and stratifiers against population basis-es.
+ * <p/>
+ * Default implementations provide the full validation logic used by R4 and later FHIR versions.
+ * FHIR-version-specific behavior is supplied by overriding {@link #allowedStratifierValueTypes()}
+ * and {@link #extractResourceType(String)}. Versions that do not support population basis
+ * (e.g. DSTU3) can override the public methods to no-op.
  */
 public interface PopulationBasisValidator {
 
-    void validateGroupPopulations(MeasureDef measureDef, GroupDef groupDef, EvaluationResult evaluationResult);
+    Logger log = LoggerFactory.getLogger(PopulationBasisValidator.class);
 
-    void validateStratifiers(MeasureDef measureDef, GroupDef groupDef, EvaluationResult evaluationResult);
+    String BOOLEAN_BASIS = "boolean";
+    String STRING_BASIS = "string";
+
+    /**
+     * Returns the set of Java classes that are allowed as value stratifier result types.
+     * Typically includes FHIR types like CodeableConcept, Coding, Quantity, etc., plus
+     * Java/CQL primitives like Boolean, Integer, String, and Code.
+     * <p/>
+     * Default returns an empty set. Implementations that enable validation must override this.
+     */
+    default Set<Class<?>> allowedStratifierValueTypes() {
+        return Set.of();
+    }
+
+    /**
+     * Maps a population basis code (e.g. "Encounter", "boolean") to the corresponding Java class
+     * for group population validation. Handles primitive FHIR type codes ("boolean") that are
+     * common across all FHIR versions, then delegates to {@link #extractFhirResourceType(String)}
+     * for version-specific resource type resolution. Returns {@link Optional#empty()} if the code
+     * does not map to a known type (e.g. for primitive types like "string").
+     */
+    default Optional<Class<?>> extractResourceType(String groupPopulationBasisCode) {
+        if (BOOLEAN_BASIS.equals(groupPopulationBasisCode)) {
+            return Optional.of(Boolean.class);
+        }
+        return extractFhirResourceType(groupPopulationBasisCode);
+    }
+
+    /**
+     * Maps a population basis code to a FHIR-version-specific resource class
+     * (e.g. "Encounter" to {@code org.hl7.fhir.r4.model.Encounter}).
+     * <p/>
+     * Default returns empty. Implementations must override this to enable resource type validation.
+     */
+    default Optional<Class<?>> extractFhirResourceType(String groupPopulationBasisCode) {
+        return Optional.empty();
+    }
+
+    /**
+     * Resolves a population basis code to a Java class by matching against the provided resource
+     * type names and loading the class from the given FHIR model package.
+     * <p/>
+     * This is the shared implementation that version-specific validators call from their
+     * {@link #extractFhirResourceType(String)} override, supplying the appropriate
+     * resource type names and model package for their FHIR version.
+     *
+     * @param groupPopulationBasisCode the population basis code from the Measure (e.g. "Encounter")
+     * @param resourceTypeNames the valid resource type names for the FHIR version (e.g. from ResourceType enum)
+     * @param fhirModelPackage the FHIR model package prefix (e.g. "org.hl7.fhir.r4.model.")
+     */
+    default Optional<Class<?>> resolveResourceType(
+            String groupPopulationBasisCode, Collection<String> resourceTypeNames, String fhirModelPackage) {
+
+        final Optional<String> optResourceClassName = resourceTypeNames.stream()
+                .filter(theName -> theName.equals(groupPopulationBasisCode))
+                .map(typeName -> fhirModelPackage + typeName)
+                .findFirst();
+
+        if (optResourceClassName.isPresent()) {
+            try {
+                return Optional.of(Class.forName(optResourceClassName.get()));
+            } catch (ClassNotFoundException exception) {
+                throw new InternalErrorException(exception);
+            }
+        }
+        return Optional.empty();
+    }
+
+    default void validateGroupPopulations(MeasureDef measureDef, GroupDef groupDef, EvaluationResult evaluationResult) {
+        groupDef.populations()
+                .forEach(population ->
+                        validateGroupPopulationBasisType(measureDef.url(), groupDef, population, evaluationResult));
+    }
+
+    default void validateStratifiers(MeasureDef measureDef, GroupDef groupDef, EvaluationResult evaluationResult) {
+        groupDef.stratifiers()
+                .forEach(stratifier -> validateStratifierPopulationBasisType(
+                        measureDef.url(), groupDef, stratifier, evaluationResult));
+    }
+
+    private void validateGroupPopulationBasisType(
+            String url, GroupDef groupDef, PopulationDef populationDef, EvaluationResult evaluationResult) {
+
+        var scoring = groupDef.measureScoring();
+        var populationExpression = populationDef.expression();
+        if (populationExpression == null || populationExpression.isBlank()) {
+            return;
+        }
+
+        var expressionResult = evaluationResult.get(populationExpression);
+
+        if (expressionResult == null || expressionResult.getValue() == null) {
+            return;
+        }
+
+        var resultClasses = StratifierUtils.extractClassesFromSingleOrListResult(expressionResult.getValue());
+        var groupPopulationBasisCode = groupDef.getPopulationBasis().code();
+        var optResourceClass = extractResourceType(groupPopulationBasisCode);
+
+        if (optResourceClass.isPresent()) {
+
+            var resultMatchingClasses = resultClasses.stream()
+                    .filter(it -> optResourceClass.get().isAssignableFrom(it))
+                    .toList();
+
+            if (resultMatchingClasses.size() != resultClasses.size()) {
+                throw new InvalidRequestException(
+                        "group expression criteria results for expression: [%s] and scoring: [%s] must fall within accepted types for population basis: [%s] for Measure: [%s] due to mismatch between total result classes: %s and matching result classes: %s"
+                                .formatted(
+                                        populationExpression,
+                                        scoring,
+                                        groupPopulationBasisCode,
+                                        url,
+                                        prettyClassNames(resultClasses),
+                                        prettyClassNames(resultMatchingClasses)));
+            }
+        }
+    }
+
+    private void validateStratifierPopulationBasisType(
+            String url, GroupDef groupDef, StratifierDef stratifierDef, EvaluationResult evaluationResult) {
+
+        if (stratifierDef.isCriteriaStratifier()) {
+            validateExpressionResultType(groupDef, stratifierDef, stratifierDef.expression(), evaluationResult, url);
+        } else {
+            for (var component : stratifierDef.components()) {
+                validateExpressionResultType(groupDef, stratifierDef, component.expression(), evaluationResult, url);
+            }
+        }
+    }
+
+    private void validateExpressionResultType(
+            GroupDef groupDef,
+            StratifierDef stratifierDef,
+            String expression,
+            EvaluationResult evaluationResult,
+            String url) {
+
+        var expressionResult = evaluationResult.get(expression);
+
+        if (expressionResult == null || expressionResult.getValue() == null) {
+            return;
+        }
+
+        var resultClasses = StratifierUtils.extractClassesFromSingleOrListResult(expressionResult.getValue());
+        var groupPopulationBasisCode = groupDef.getPopulationBasis().code();
+
+        if (stratifierDef.isCriteriaStratifier()) {
+            if (resultClasses.isEmpty()) {
+                log.warn("Criteria-based stratifier results are empty for measure: {}", url);
+                return;
+            }
+
+            if (resultClasses.stream()
+                    .noneMatch(resultClass -> doesBasisMatchResource(resultClass, groupPopulationBasisCode))) {
+
+                throw new InvalidRequestException(
+                        "criteria-based stratifier is invalid for expression: [%s] due to mismatch between population basis: [%s] and result types: %s for measure URL: %s"
+                                .formatted(expression, groupPopulationBasisCode, prettyClassNames(resultClasses), url));
+            }
+
+            // skip validation below since for criteria-based stratifier, the boolean basis test is irrelevant
+            return;
+        }
+
+        var resultMatchingClasses = resultClasses.stream()
+                .filter(resultClass ->
+                        allowedStratifierValueTypes().contains(resultClass) || Boolean.class == resultClass)
+                .toList();
+
+        if (resultMatchingClasses.size() != resultClasses.size()) {
+            throw new InvalidRequestException(
+                    "stratifier expression criteria results for expression: [%s] must fall within accepted types for population-basis: [%s] for Measure: [%s] due to mismatch between total eval result classes: %s and matching result classes: %s"
+                            .formatted(
+                                    expression,
+                                    groupPopulationBasisCode,
+                                    url,
+                                    prettyClassNames(resultClasses),
+                                    prettyClassNames(resultMatchingClasses)));
+        }
+    }
+
+    private boolean doesBasisMatchResource(Class<?> resultClass, String groupPopulationBasisCode) {
+        // FHIR primitive type codes are lowercase ("boolean", "string") but Java class simple names
+        // are uppercase ("Boolean", "String"). Handle these explicitly to match only the valid
+        // lowercase FHIR codes and reject invalid uppercase variants like "String" or "Boolean".
+        if (resultClass == Boolean.class) {
+            return BOOLEAN_BASIS.equals(groupPopulationBasisCode);
+        }
+        if (resultClass == String.class) {
+            return STRING_BASIS.equals(groupPopulationBasisCode);
+        }
+
+        return resultClass.getSimpleName().equals(groupPopulationBasisCode);
+    }
+
+    private List<String> prettyClassNames(List<Class<?>> classes) {
+        return classes.stream().map(Class::getSimpleName).toList();
+    }
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/dstu3/Dstu3PopulationBasisValidator.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/dstu3/Dstu3PopulationBasisValidator.java
@@ -6,19 +6,32 @@ import org.opencds.cqf.fhir.cr.measure.common.MeasureDef;
 import org.opencds.cqf.fhir.cr.measure.common.PopulationBasisValidator;
 
 /**
- * Validates group populations and stratifiers against population basis-es for DSTU3.
+ * Population basis validator for DSTU3 (STU3).
  * <p/>
- * Currently no-ops.
+ * The DSTU3 Measure resource does not support the {@code cqfm-populationBasis} extension —
+ * all measures are implicitly patient-based (boolean). Stratifiers in DSTU3 are flat elements
+ * with only {@code criteria} (a CQL expression name) or {@code path} (a FHIR resource path),
+ * with no component sub-elements and no criteria-vs-value distinction. Because there is no
+ * population basis concept in the DSTU3 spec, there is nothing to validate.
  */
 public class Dstu3PopulationBasisValidator implements PopulationBasisValidator {
 
+    /**
+     * No-op. DSTU3 measures have no population basis extension, so group population
+     * results cannot mismatch a basis that does not exist.
+     */
     @Override
     public void validateGroupPopulations(MeasureDef measureDef, GroupDef groupDef, EvaluationResult evaluationResult) {
-        // TODO: LD: Implement this if there's ever a requirement to validate DSTU3 Population Basis
+        // no-op
     }
 
+    /**
+     * No-op. DSTU3 stratifiers are simple expressions with no return-type constraints
+     * tied to a population basis. The criteria-vs-value stratifier classification and
+     * the allowed-types validation are R4+ (CQFMeasures IG) concepts.
+     */
     @Override
     public void validateStratifiers(MeasureDef measureDef, GroupDef groupDef, EvaluationResult evaluationResult) {
-        // TODO: LD: Implement this if there's ever a requirement to validate DSTU3 Population Basis
+        // no-op
     }
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureDefBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureDefBuilder.java
@@ -87,7 +87,7 @@ public class R4MeasureDefBuilder implements MeasureDefBuilder<Measure> {
         // group Measure Scoring
         var groupScoring = getGroupMeasureScoring(measure, group);
         // populationBasis
-        var groupBasis = getGroupPopulationBasis(group);
+        var groupBasis = getGroupPopulationBasis(measure, group);
         // improvement Notation
         var groupImpNotation = getGroupImpNotation(measure, group);
         var hasGroupImpNotation = groupImpNotation != null;
@@ -522,16 +522,40 @@ public class R4MeasureDefBuilder implements MeasureDefBuilder<Measure> {
         var ext = measure.getExtensionByUrl(MeasureConstants.POPULATION_BASIS_URL);
         // check for population-basis Extension, assume boolean if no Extension is found
         if (ext != null) {
-            return makeCodeDefFromExtension(ext);
+            return makeCodeDefFromExtension(ext, measure.getUrl());
         }
         return null;
     }
 
-    private CodeDef makeCodeDefFromExtension(Extension extension) {
+    private CodeDef makeCodeDefFromExtension(Extension extension, String measureUrl) {
         var code = extension.getValue().toString();
-        // validate code membership
-        assert Enumerations.FHIRAllTypes.fromCode(code) != null;
+        validatePopulationBasisCode(code, measureUrl);
         return new CodeDef(MeasureConstants.POPULATION_BASIS_URL, code);
+    }
+
+    private void validatePopulationBasisCode(String code, String measureUrl) {
+        try {
+            Enumerations.FHIRAllTypes.fromCode(code);
+        } catch (Exception e) {
+            var matchingCode = findCaseInsensitiveMatch(code);
+            if (matchingCode.isPresent()) {
+                throw new InvalidRequestException(
+                        "Measure %s has an invalid population basis of '%s'. Did you mean to enter '%s' instead?"
+                                .formatted(measureUrl, code, matchingCode.get()));
+            }
+            throw new InvalidRequestException(
+                    "Measure %s has an invalid population basis of '%s'. See http://hl7.org/fhir/R4/valueset-all-types.html for allowed codes."
+                            .formatted(measureUrl, code));
+        }
+    }
+
+    private Optional<String> findCaseInsensitiveMatch(String code) {
+        for (var type : Enumerations.FHIRAllTypes.values()) {
+            if (type.toCode() != null && type.toCode().equalsIgnoreCase(code)) {
+                return Optional.of(type.toCode());
+            }
+        }
+        return Optional.empty();
     }
 
     public CodeDef getMeasureImprovementNotation(Measure measure) {
@@ -564,11 +588,11 @@ public class R4MeasureDefBuilder implements MeasureDefBuilder<Measure> {
         return R4MeasureUtils.getGroupMeasureScoring(measure, group);
     }
 
-    public CodeDef getGroupPopulationBasis(MeasureGroupComponent group) {
+    public CodeDef getGroupPopulationBasis(Measure measure, MeasureGroupComponent group) {
         var ext = group.getExtensionByUrl(MeasureConstants.POPULATION_BASIS_URL);
         // check for population-basis Extension, assume boolean if no Extension is found
         if (ext != null) {
-            return makeCodeDefFromExtension(ext);
+            return makeCodeDefFromExtension(ext, measure.getUrl());
         }
         return null;
     }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4PopulationBasisValidator.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4PopulationBasisValidator.java
@@ -1,7 +1,5 @@
 package org.opencds.cqf.fhir.cr.measure.r4;
 
-import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
-import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -14,29 +12,17 @@ import org.hl7.fhir.r4.model.Quantity;
 import org.hl7.fhir.r4.model.Range;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.ResourceType;
-import org.opencds.cqf.cql.engine.execution.EvaluationResult;
 import org.opencds.cqf.cql.engine.runtime.Code;
-import org.opencds.cqf.fhir.cr.measure.common.GroupDef;
-import org.opencds.cqf.fhir.cr.measure.common.MeasureDef;
 import org.opencds.cqf.fhir.cr.measure.common.PopulationBasisValidator;
-import org.opencds.cqf.fhir.cr.measure.common.PopulationDef;
-import org.opencds.cqf.fhir.cr.measure.common.StratifierDef;
-import org.opencds.cqf.fhir.cr.measure.common.StratifierUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Validates group populations and stratifiers against population basis-es for R4 only.
+ * Validates group populations and stratifiers against population basis-es for R4.
+ * Provides R4-specific FHIR type mappings; all validation logic lives in
+ * {@link PopulationBasisValidator} default methods.
  */
 public class R4PopulationBasisValidator implements PopulationBasisValidator {
 
-    private static final String BOOLEAN_BASIS = "boolean";
-
-    /**
-     * For any given stratifier expression, we don't know if it was evaluated in the patient context or it's a valid
-     * expression, so we'll apply this heuristic for now
-     */
-    private static final Set<Class<?>> ALLOWED_STRATIFIER_BOOLEAN_BASIS_TYPES = new HashSet<>(Arrays.asList(
+    private static final Set<Class<?>> ALLOWED_STRATIFIER_VALUE_TYPES = new HashSet<>(Arrays.asList(
             CodeableConcept.class,
             Quantity.class,
             Range.class,
@@ -50,164 +36,18 @@ public class R4PopulationBasisValidator implements PopulationBasisValidator {
             // CQL type returned by some stratifier expression that don't map neatly to FHIR types
             Code.class));
 
-    private static final Logger log = LoggerFactory.getLogger(R4PopulationBasisValidator.class);
+    private static final String FHIR_MODEL_PACKAGE = "org.hl7.fhir.r4.model.";
+
+    private static final List<String> RESOURCE_TYPE_NAMES =
+            Arrays.stream(ResourceType.values()).map(ResourceType::name).toList();
 
     @Override
-    public void validateGroupPopulations(MeasureDef measureDef, GroupDef groupDef, EvaluationResult evaluationResult) {
-        groupDef.populations()
-                .forEach(population ->
-                        validateGroupPopulationBasisType(measureDef.url(), groupDef, population, evaluationResult));
+    public Set<Class<?>> allowedStratifierValueTypes() {
+        return ALLOWED_STRATIFIER_VALUE_TYPES;
     }
 
     @Override
-    public void validateStratifiers(MeasureDef measureDef, GroupDef groupDef, EvaluationResult evaluationResult) {
-        groupDef.stratifiers()
-                .forEach(stratifier -> validateStratifierPopulationBasisType(
-                        measureDef.url(), groupDef, stratifier, evaluationResult));
-    }
-
-    private void validateGroupPopulationBasisType(
-            String url, GroupDef groupDef, PopulationDef populationDef, EvaluationResult evaluationResult) {
-
-        // PROPORTION
-        var scoring = groupDef.measureScoring();
-        // Numerator
-        var populationExpression = populationDef.expression();
-        if (populationExpression == null || populationExpression.isBlank()) {
-            return;
-        }
-
-        var expressionResult = evaluationResult.get(populationExpression);
-
-        if (expressionResult == null || expressionResult.getValue() == null) {
-            return;
-        }
-
-        var resultClasses = StratifierUtils.extractClassesFromSingleOrListResult(expressionResult.getValue());
-        // Encounter
-        var groupPopulationBasisCode = groupDef.getPopulationBasis().code();
-        var optResourceClass = extractResourceType(groupPopulationBasisCode);
-
-        if (optResourceClass.isPresent()) {
-
-            var resultMatchingClasses = resultClasses.stream()
-                    .filter(it -> optResourceClass.get().isAssignableFrom(it))
-                    .toList();
-
-            if (resultMatchingClasses.size() != resultClasses.size()) {
-                throw new InvalidRequestException(
-                        "group expression criteria results for expression: [%s] and scoring: [%s] must fall within accepted types for population basis: [%s] for Measure: [%s] due to mismatch between total result classes: %s and matching result classes: %s"
-                                .formatted(
-                                        populationExpression,
-                                        scoring,
-                                        groupPopulationBasisCode,
-                                        url,
-                                        prettyClassNames(resultClasses),
-                                        prettyClassNames(resultMatchingClasses)));
-            }
-        }
-    }
-
-    private void validateStratifierPopulationBasisType(
-            String url, GroupDef groupDef, StratifierDef stratifierDef, EvaluationResult evaluationResult) {
-
-        if (stratifierDef.isCriteriaStratifier()) {
-            validateExpressionResultType(groupDef, stratifierDef, stratifierDef.expression(), evaluationResult, url);
-        } else {
-            for (var component : stratifierDef.components()) {
-                validateExpressionResultType(groupDef, stratifierDef, component.expression(), evaluationResult, url);
-            }
-        }
-    }
-
-    private void validateExpressionResultType(
-            GroupDef groupDef,
-            StratifierDef stratifierDef,
-            String expression,
-            EvaluationResult evaluationResult,
-            String url) {
-
-        var expressionResult = evaluationResult.get(expression);
-
-        if (expressionResult == null || expressionResult.getValue() == null) {
-            return;
-        }
-
-        var resultClasses = StratifierUtils.extractClassesFromSingleOrListResult(expressionResult.getValue());
-        var groupPopulationBasisCode = groupDef.getPopulationBasis().code();
-
-        if (stratifierDef.isCriteriaStratifier()) {
-            if (resultClasses.isEmpty()) {
-                log.warn("Criteria-based stratifier results are empty for measure: {}", url);
-                return;
-            }
-
-            if (resultClasses.stream()
-                    .noneMatch(resultClass -> doesBasisMatchResource(resultClass, groupPopulationBasisCode))) {
-
-                throw new InvalidRequestException(
-                        "criteria-based stratifier is invalid for expression: [%s] due to mismatch between population basis: [%s] and result types: %s for measure URL: %s"
-                                .formatted(expression, groupPopulationBasisCode, prettyClassNames(resultClasses), url));
-            }
-
-            // skip validation below since for criteria-based stratifier, the boolean basis test is irrelevant
-            return;
-        }
-
-        var resultMatchingClasses = resultClasses.stream()
-                .filter(resultClass ->
-                        ALLOWED_STRATIFIER_BOOLEAN_BASIS_TYPES.contains(resultClass) || Boolean.class == resultClass)
-                .toList();
-
-        if (resultMatchingClasses.size() != resultClasses.size()) {
-            throw new InvalidRequestException(
-                    "stratifier expression criteria results for expression: [%s] must fall within accepted types for population-basis: [%s] for Measure: [%s] due to mismatch between total eval result classes: %s and matching result classes: %s"
-                            .formatted(
-                                    expression,
-                                    groupPopulationBasisCode,
-                                    url,
-                                    prettyClassNames(resultClasses),
-                                    prettyClassNames(resultMatchingClasses)));
-        }
-    }
-
-    private boolean doesBasisMatchResource(Class<?> resultClass, String groupPopulationBasisCode) {
-        // If we don't do this we'll fail with "boolean" vs. "Boolean"
-        if (resultClass == Boolean.class && BOOLEAN_BASIS.equals(groupPopulationBasisCode)) {
-            return true;
-        }
-
-        return resultClass.getSimpleName().equals(groupPopulationBasisCode);
-    }
-
-    private Optional<Class<?>> extractResourceType(String groupPopulationBasisCode) {
-        if (BOOLEAN_BASIS.equals(groupPopulationBasisCode)) {
-            return Optional.of(Boolean.class);
-        }
-
-        final Optional<String> optResourceClassName = Arrays.stream(ResourceType.values())
-                .map(ResourceType::name)
-                .filter(theName -> {
-                    if ("ListResource".equals(groupPopulationBasisCode)) {
-                        return true;
-                    }
-
-                    return theName.equals(groupPopulationBasisCode);
-                })
-                .map(typeName -> "org.hl7.fhir.r4.model." + typeName)
-                .findFirst();
-
-        if (optResourceClassName.isPresent()) {
-            try {
-                return Optional.of(Class.forName(optResourceClassName.get()));
-            } catch (ClassNotFoundException exception) {
-                throw new InternalErrorException(exception);
-            }
-        }
-        return Optional.empty();
-    }
-
-    private List<String> prettyClassNames(List<Class<?>> classes) {
-        return classes.stream().map(Class::getSimpleName).toList();
+    public Optional<Class<?>> extractFhirResourceType(String groupPopulationBasisCode) {
+        return resolveResourceType(groupPopulationBasisCode, RESOURCE_TYPE_NAMES, FHIR_MODEL_PACKAGE);
     }
 }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureDefBuilderTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureDefBuilderTest.java
@@ -22,7 +22,6 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
@@ -323,8 +322,8 @@ class MeasureDefBuilderTest {
         try {
             measureDefBuilder("fish", "cohort", decrease, null, "fish", "cohort", increase, null, null, null, null);
             fail("invalid code, should fail");
-        } catch (FHIRException e) {
-            assertTrue(e.getMessage().contains("Unknown FHIRAllTypes code 'fish'"));
+        } catch (InvalidRequestException e) {
+            assertTrue(e.getMessage().contains("has an invalid population basis of 'fish'"));
         }
     }
 
@@ -333,8 +332,8 @@ class MeasureDefBuilderTest {
         try {
             measureDefBuilder(null, null, null, null, null, null, null, null, "whale", "ratio", decrease);
             fail("invalid code, should fail");
-        } catch (FHIRException e) {
-            assertTrue(e.getMessage().contains("Unknown FHIRAllTypes code 'whale'"));
+        } catch (InvalidRequestException e) {
+            assertTrue(e.getMessage().contains("has an invalid population basis of 'whale'"));
         }
     }
 

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest.java
@@ -1155,6 +1155,44 @@ class MeasureStratifierTest {
     }
 
     /**
+     * DQM-692: Uppercase "String" is NOT a valid FHIRAllTypes code — only lowercase "string" is valid.
+     * The measure should fail at the definition-building stage before evaluation even begins.
+     */
+    @Test
+    void ratioStringCriteriaStratUppercaseBasisShouldFail() {
+        try {
+            GIVEN_MEASURE_STRATIFIER_TEST
+                    .when()
+                    .measureId("RatioStringCriteriaStratUppercase")
+                    .evaluate()
+                    .then();
+            fail("Expected uppercase 'String' population basis to be rejected");
+        } catch (InvalidRequestException e) {
+            assertTrue(e.getMessage().contains("has an invalid population basis of 'String'"));
+            assertTrue(e.getMessage().contains("Did you mean to enter 'string' instead?"));
+        }
+    }
+
+    /**
+     * DQM-692: Ratio measure with lowercase "string" population basis (the valid FHIR type code)
+     * and CRITERIA stratifier returning String values. Validates that the fix for case-sensitive
+     * comparison in doesBasisMatchResource allows "string" basis to match String result types.
+     */
+    @Test
+    void ratioStringCriteriaStratLowercaseBasisShouldPass() {
+        GIVEN_MEASURE_STRATIFIER_TEST
+                .when()
+                .measureId("RatioStringCriteriaStratLowercase")
+                .evaluate()
+                .then()
+                .hasStatus(MeasureReportStatus.COMPLETE)
+                .firstGroup()
+                .firstStratifier()
+                .hasCodeText("Gender Stratification String")
+                .hasStratumCount(1);
+    }
+
+    /**
      * Tests that patient with no encounters results in no stratum.
      * Patient with no encounters should not contribute to any stratum.
      */

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest.java
@@ -538,7 +538,19 @@ class MeasureStratifierTest {
                 .then()
                 .hasContainedOperationOutcome()
                 .hasContainedOperationOutcomeMsg(
-                        "Exception for subjectId: Patient/patient-8, Message: stratifier expression criteria results for expression: [Encounters in Period] must fall within accepted types for population-basis: [boolean] for Measure: [http://example.com/Measure/CohortBooleanStratValueNonBoolean] due to mismatch between total eval result classes: [Encounter] and matching result classes: []");
+                        "Value stratifier expression for [Encounters in Period] returned invalid result type(s): [Encounter] for Measure: [http://example.com/Measure/CohortBooleanStratValueNonBoolean].");
+    }
+
+    @Test
+    void ratioEncounterValueStratExpressionNonCategorical() {
+        GIVEN_MEASURE_STRATIFIER_TEST
+                .when()
+                .measureId("RatioResourceStratValueNonCategorical")
+                .evaluate()
+                .then()
+                .hasContainedOperationOutcome()
+                .hasContainedOperationOutcomeMsg(
+                        "Non Subject Value stratifier expression for [All Patient Encounters] returned invalid result type(s): [Encounter] for Measure: [http://example.com/Measure/RatioResourceStratValueNonCategorical] with population basis: [Encounter].");
     }
 
     @Test

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest.java
@@ -1172,12 +1172,13 @@ class MeasureStratifierTest {
      */
     @Test
     void ratioStringCriteriaStratUppercaseBasisShouldFail() {
+        final When when = GIVEN_MEASURE_STRATIFIER_TEST
+                .when()
+                .measureId("RatioStringCriteriaStratUppercase")
+                .evaluate();
+
         try {
-            GIVEN_MEASURE_STRATIFIER_TEST
-                    .when()
-                    .measureId("RatioStringCriteriaStratUppercase")
-                    .evaluate()
-                    .then();
+            when.then();
             fail("Expected uppercase 'String' population basis to be rejected");
         } catch (InvalidRequestException e) {
             assertTrue(e.getMessage().contains("has an invalid population basis of 'String'"));

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/R4PopulationBasisValidatorTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/R4PopulationBasisValidatorTest.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.fhir.cr.measure.r4;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.opencds.cqf.fhir.cr.measure.common.MeasurePopulationType.DENOMINATOR;
 import static org.opencds.cqf.fhir.cr.measure.common.MeasurePopulationType.INITIALPOPULATION;
@@ -458,7 +459,7 @@ class R4PopulationBasisValidatorTest {
                 ENCOUNTER));
 
         var expectedExceptionMessage =
-                "stratifier expression criteria results for expression: [InitialPopulation] must fall within accepted types for population-basis: [boolean] for Measure: [fakeMeasureUrl] due to mismatch between total eval result classes: [Encounter] and matching result classes: []";
+                "Value stratifier expression for [InitialPopulation] returned invalid result type(s): [Encounter] for Measure: [fakeMeasureUrl].";
 
         validateStratifierBasisTypeErrorPath(expectedGroupDef, expectedEvaluationResult, expectedExceptionMessage);
     }
@@ -484,7 +485,7 @@ class R4PopulationBasisValidatorTest {
                 List.of(ENCOUNTER, ENCOUNTER, ENCOUNTER)));
 
         var expectedExceptionMessage =
-                "stratifier expression criteria results for expression: [InitialPopulation] must fall within accepted types for population-basis: [boolean] for Measure: [fakeMeasureUrl] due to mismatch between total eval result classes: [Encounter, Encounter, Encounter] and matching result classes: []";
+                "Value stratifier expression for [InitialPopulation] returned invalid result type(s): [Encounter, Encounter, Encounter] for Measure: [fakeMeasureUrl].";
 
         validateStratifierBasisTypeErrorPath(expectedGroupDef, expectedEvaluationResult, expectedExceptionMessage);
     }
@@ -509,7 +510,82 @@ class R4PopulationBasisValidatorTest {
                 List.of(Boolean.TRUE, Boolean.TRUE, ENCOUNTER)));
 
         var expectedExceptionMessage =
-                "stratifier expression criteria results for expression: [Numerator] must fall within accepted types for population-basis: [boolean] for Measure: [fakeMeasureUrl] due to mismatch between total eval result classes: [Boolean, Boolean, Encounter] and matching result classes: [Boolean, Boolean]";
+                "Value stratifier expression for [Numerator] returned invalid result type(s): [Boolean, Boolean, Encounter] for Measure: [fakeMeasureUrl].";
+
+        validateStratifierBasisTypeErrorPath(expectedGroupDef, expectedEvaluationResult, expectedExceptionMessage);
+    }
+
+    @Test
+    void mismatchEncounterBasisSingleEncounterResult() {
+        var expectedGroupDef = buildGroupDef(
+                Basis.ENCOUNTER,
+                buildPopulationDefs(Basis.ENCOUNTER, INITIALPOPULATION, DENOMINATOR, NUMERATOR),
+                buildStratifierDefs(
+                        MeasureStratifierType.NON_SUBJECT_VALUE,
+                        EXPRESSION_INITIALPOPULATION,
+                        EXPRESSION_DENOMINATOR,
+                        EXPRESSION_NUMERATOR));
+
+        var expectedEvaluationResult = buildEvaluationResult(Map.of(
+                EXPRESSION_INITIALPOPULATION,
+                ENCOUNTER,
+                EXPRESSION_DENOMINATOR,
+                ENCOUNTER,
+                EXPRESSION_NUMERATOR,
+                ENCOUNTER));
+
+        var expectedExceptionMessage =
+                "Non Subject Value stratifier expression for [InitialPopulation] returned invalid result type(s): [Encounter] for Measure: [fakeMeasureUrl] with population basis: [Encounter].";
+
+        validateStratifierBasisTypeErrorPath(expectedGroupDef, expectedEvaluationResult, expectedExceptionMessage);
+    }
+
+    @Test
+    void mismatchEncounterBasisMultipleEncounterResults() {
+        var expectedGroupDef = buildGroupDef(
+                Basis.ENCOUNTER,
+                buildPopulationDefs(Basis.ENCOUNTER, INITIALPOPULATION, DENOMINATOR, NUMERATOR),
+                buildStratifierDefs(
+                        MeasureStratifierType.NON_SUBJECT_VALUE,
+                        EXPRESSION_INITIALPOPULATION,
+                        EXPRESSION_DENOMINATOR,
+                        EXPRESSION_NUMERATOR));
+
+        var expectedEvaluationResult = buildEvaluationResult(Map.of(
+                EXPRESSION_INITIALPOPULATION,
+                List.of(ENCOUNTER, ENCOUNTER, ENCOUNTER),
+                EXPRESSION_DENOMINATOR,
+                List.of(ENCOUNTER, ENCOUNTER, ENCOUNTER),
+                EXPRESSION_NUMERATOR,
+                List.of(ENCOUNTER, ENCOUNTER, ENCOUNTER)));
+
+        var expectedExceptionMessage =
+                "Non Subject Value stratifier expression for [InitialPopulation] returned invalid result type(s): [Encounter, Encounter, Encounter] for Measure: [fakeMeasureUrl] with population basis: [Encounter].";
+
+        validateStratifierBasisTypeErrorPath(expectedGroupDef, expectedEvaluationResult, expectedExceptionMessage);
+    }
+
+    @Test
+    void mismatchEncounterBasisMixedCategoricalAndEncounterResults() {
+        var expectedGroupDef = buildGroupDef(
+                Basis.ENCOUNTER,
+                buildPopulationDefs(Basis.ENCOUNTER, INITIALPOPULATION, DENOMINATOR, NUMERATOR),
+                buildStratifierDefs(
+                        MeasureStratifierType.NON_SUBJECT_VALUE,
+                        EXPRESSION_INITIALPOPULATION,
+                        EXPRESSION_DENOMINATOR,
+                        EXPRESSION_NUMERATOR));
+
+        var expectedEvaluationResult = buildEvaluationResult(Map.of(
+                EXPRESSION_INITIALPOPULATION,
+                List.of(Boolean.TRUE, Boolean.TRUE, Boolean.TRUE),
+                EXPRESSION_DENOMINATOR,
+                List.of(Boolean.TRUE, Boolean.TRUE, Boolean.TRUE),
+                EXPRESSION_NUMERATOR,
+                List.of(Boolean.TRUE, Boolean.TRUE, ENCOUNTER)));
+
+        var expectedExceptionMessage =
+                "Non Subject Value stratifier expression for [Numerator] returned invalid result type(s): [Boolean, Boolean, Encounter] for Measure: [fakeMeasureUrl] with population basis: [Encounter].";
 
         validateStratifierBasisTypeErrorPath(expectedGroupDef, expectedEvaluationResult, expectedExceptionMessage);
     }
@@ -576,7 +652,10 @@ class R4PopulationBasisValidatorTest {
             testSubject.validateStratifiers(MEASURE_DEF, groupDef, evaluationResult);
             fail("Expected this test to fail");
         } catch (InvalidRequestException exception) {
-            assertEquals(expectedExceptionMessage, exception.getMessage());
+            assertTrue(
+                    exception.getMessage().startsWith(expectedExceptionMessage),
+                    "Expected message to start with:\n  " + expectedExceptionMessage + "\nbut was:\n  "
+                            + exception.getMessage());
         }
     }
 
@@ -623,7 +702,8 @@ class R4PopulationBasisValidatorTest {
     @Nonnull
     private static StratifierDef buildStratifierDef(MeasureStratifierType stratifierType, String expression) {
         final List<StratifierComponentDef> stratifierComponentDefs;
-        if (stratifierType == MeasureStratifierType.VALUE) {
+        if (stratifierType == MeasureStratifierType.VALUE
+                || stratifierType == MeasureStratifierType.NON_SUBJECT_VALUE) {
             stratifierComponentDefs = List.of(new StratifierComponentDef(null, null, expression));
         } else {
             stratifierComponentDefs = List.of();

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/R4PopulationBasisValidatorTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/R4PopulationBasisValidatorTest.java
@@ -55,6 +55,8 @@ class R4PopulationBasisValidatorTest {
             NUMERATOR, EXPRESSION_NUMERATOR);
 
     private static final CodeDef BASIS_BOOLEAN = new CodeDef(MeasureConstants.POPULATION_BASIS_URL, "boolean");
+    private static final CodeDef BASIS_STRING_LOWERCASE = new CodeDef(MeasureConstants.POPULATION_BASIS_URL, "string");
+    private static final CodeDef BASIS_STRING_UPPERCASE = new CodeDef(MeasureConstants.POPULATION_BASIS_URL, "String");
     private static final CodeDef BASIS_ENCOUNTER = new CodeDef(MeasureConstants.POPULATION_BASIS_URL, "Encounter");
     private static final CodeDef BASIS_PROCEDURE = new CodeDef(MeasureConstants.POPULATION_BASIS_URL, "Procedure");
     private static final Encounter ENCOUNTER = new Encounter();
@@ -62,6 +64,8 @@ class R4PopulationBasisValidatorTest {
 
     private enum Basis {
         BOOLEAN(BASIS_BOOLEAN),
+        STRING_LOWERCASE(BASIS_STRING_LOWERCASE),
+        STRING_UPPERCASE(BASIS_STRING_UPPERCASE),
         ENCOUNTER(BASIS_ENCOUNTER),
         PROCEDURE(BASIS_PROCEDURE);
 
@@ -508,6 +512,62 @@ class R4PopulationBasisValidatorTest {
                 "stratifier expression criteria results for expression: [Numerator] must fall within accepted types for population-basis: [boolean] for Measure: [fakeMeasureUrl] due to mismatch between total eval result classes: [Boolean, Boolean, Encounter] and matching result classes: [Boolean, Boolean]";
 
         validateStratifierBasisTypeErrorPath(expectedGroupDef, expectedEvaluationResult, expectedExceptionMessage);
+    }
+
+    /**
+     * DQM-692: "String" (uppercase) is NOT a valid FHIR type code — only lowercase "string" is valid
+     * per FHIRAllTypes. A criteria stratifier with uppercase "String" basis should fail validation.
+     */
+    @Test
+    void criteriaStratifierWithUppercaseStringBasisShouldFail() {
+        var groupDef = buildGroupDef(
+                Basis.STRING_UPPERCASE,
+                buildPopulationDefs(Basis.STRING_UPPERCASE, INITIALPOPULATION, DENOMINATOR, NUMERATOR),
+                buildStratifierDefs(
+                        MeasureStratifierType.CRITERIA,
+                        EXPRESSION_INITIALPOPULATION,
+                        EXPRESSION_DENOMINATOR,
+                        EXPRESSION_NUMERATOR));
+
+        var evaluationResult = buildEvaluationResult(Map.of(
+                EXPRESSION_INITIALPOPULATION,
+                "someStringValue",
+                EXPRESSION_DENOMINATOR,
+                "someStringValue",
+                EXPRESSION_NUMERATOR,
+                "someStringValue"));
+
+        var expectedExceptionMessage =
+                "criteria-based stratifier is invalid for expression: [InitialPopulation] due to mismatch between population basis: [String] and result types: [String] for measure URL: fakeMeasureUrl";
+
+        validateStratifierBasisTypeErrorPath(groupDef, evaluationResult, expectedExceptionMessage);
+    }
+
+    /**
+     * DQM-692: criteria-based stratifier with lowercase "string" population basis (the valid FHIR
+     * type code) should pass validation when the CQL expression returns String results.
+     */
+    @Test
+    void criteriaStratifierWithLowercaseStringBasisShouldPass() {
+        var groupDef = buildGroupDef(
+                Basis.STRING_LOWERCASE,
+                buildPopulationDefs(Basis.STRING_LOWERCASE, INITIALPOPULATION, DENOMINATOR, NUMERATOR),
+                buildStratifierDefs(
+                        MeasureStratifierType.CRITERIA,
+                        EXPRESSION_INITIALPOPULATION,
+                        EXPRESSION_DENOMINATOR,
+                        EXPRESSION_NUMERATOR));
+
+        var evaluationResult = buildEvaluationResult(Map.of(
+                EXPRESSION_INITIALPOPULATION,
+                "someStringValue",
+                EXPRESSION_DENOMINATOR,
+                "someStringValue",
+                EXPRESSION_NUMERATOR,
+                "someStringValue"));
+
+        // This should NOT throw — lowercase "string" basis should match String result type
+        testSubject.validateStratifiers(MEASURE_DEF, groupDef, evaluationResult);
     }
 
     private void validateStratifierBasisTypeErrorPath(

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/ContinuousVariableObservationBooleanBasis/input/resources/measure/ContinuousVariableResourceMeasureObservationBooleanBasisAvg.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/ContinuousVariableObservationBooleanBasis/input/resources/measure/ContinuousVariableResourceMeasureObservationBooleanBasisAvg.json
@@ -41,7 +41,7 @@
           }
         },
         {
-          "id": "measure-population",
+          "id": "measure-population-1",
           "code": {
             "coding": [
               {
@@ -77,7 +77,7 @@
           "extension" : [
             {
               "url" : "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference",
-              "valueString" : "measure-population"
+              "valueString" : "measure-population-1"
             },
             {
               "url" : "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/cql/LibrarySimple.cql
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/cql/LibrarySimple.cql
@@ -101,6 +101,9 @@ define function "MeasureObservation"(Encounter Encounter):
 define "Gender Stratification":
   "SDE Sex"
 
+define "Gender Stratification String":
+  if Patient.gender = 'male' then 'male' else 'female'
+
 // boolean criteria stratifier
 
 define "boolean strat not finished":

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/measure/RatioResourceStratValueNonCategorical.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/measure/RatioResourceStratValueNonCategorical.json
@@ -1,0 +1,94 @@
+{
+  "id": "RatioResourceStratValueNonCategorical",
+  "resourceType": "Measure",
+  "url": "http://example.com/Measure/RatioResourceStratValueNonCategorical",
+  "library": [
+    "http://example.com/Library/LibrarySimple"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "Encounter"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "ratio"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population Resource"
+          }
+        },
+        {
+          "id": "denominator",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "denominator",
+                "display": "Denominator"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Denominator Resource"
+          }
+        },
+        {
+          "id": "numerator",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "numerator",
+                "display": "Numerator"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Numerator Resource"
+          }
+        }
+      ],
+      "stratifier": [
+        {
+          "id": "stratifier-1",
+          "code": {
+            "text": "All Patient Encounters"
+          },
+          "component": [
+            {
+              "id": "stratifier-1-comp-1",
+              "criteria": {
+                "language": "text/cql.identifier",
+                "expression": "All Patient Encounters"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/measure/RatioStringCriteriaStratLowercase.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/measure/RatioStringCriteriaStratLowercase.json
@@ -1,0 +1,89 @@
+{
+  "id": "RatioStringCriteriaStratLowercase",
+  "resourceType": "Measure",
+  "url": "http://example.com/Measure/RatioStringCriteriaStratLowercase",
+  "library": [
+    "http://example.com/Library/LibrarySimple"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "string"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "ratio"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population Boolean"
+          }
+        },
+        {
+          "id": "denominator",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "denominator",
+                "display": "Denominator"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Denominator Boolean"
+          }
+        },
+        {
+          "id": "numerator",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "numerator",
+                "display": "Numerator"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Numerator Boolean"
+          }
+        }
+      ],
+      "stratifier": [
+        {
+          "id": "stratifier",
+          "code": {
+            "text": "Gender Stratification"
+          },
+          "criteria": {
+            "language": "text/cql.identifier",
+            "expression": "Gender Stratification String"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/measure/RatioStringCriteriaStratUppercase.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/measure/RatioStringCriteriaStratUppercase.json
@@ -1,0 +1,89 @@
+{
+  "id": "RatioStringCriteriaStratUppercase",
+  "resourceType": "Measure",
+  "url": "http://example.com/Measure/RatioStringCriteriaStratUppercase",
+  "library": [
+    "http://example.com/Library/LibrarySimple"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "String"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "ratio"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population Boolean"
+          }
+        },
+        {
+          "id": "denominator",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "denominator",
+                "display": "Denominator"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Denominator Boolean"
+          }
+        },
+        {
+          "id": "numerator",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "numerator",
+                "display": "Numerator"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Numerator Boolean"
+          }
+        }
+      ],
+      "stratifier": [
+        {
+          "id": "stratifier",
+          "code": {
+            "text": "Gender Stratification"
+          },
+          "criteria": {
+            "language": "text/cql.identifier",
+            "expression": "Gender Stratification String"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This MR fixes DQM-692, where `$evaluate-measure` failed for Measures using a lowercase `"string"` population basis with criteria-based stratifiers. The root cause was a case-sensitive comparison between CQL result type names (`"String"`) and FHIR population basis codes (`"string"`). The fix also refactors the population basis validation architecture to be FHIR-version-agnostic and improves error messages for invalid population basis codes.

1. **Bug fix**: Added explicit handling for `"string"` (and `"boolean"`) primitive FHIR type codes in `doesBasisMatchResource`, ensuring lowercase FHIR codes match their uppercase Java class counterparts while rejecting invalid uppercase variants like `"String"`.
2. **Validation improvement**: Replaced the `assert`-only population basis code validation in `R4MeasureDefBuilder` with proper `InvalidRequestException` messages that include the measure URL, suggest the correct code for casing errors, and link to the FHIR spec for unrecognized codes.
3. **Architecture refactor**: Moved all version-agnostic validation logic from `R4PopulationBasisValidator` into `PopulationBasisValidator` as default interface methods. R4 now only supplies type mappings; DSTU3 remains a documented no-op since DSTU3 has no populationBasis extension.
4. **Improved value stratifier error messages with stratifier-type-specific wording** (DQM-691) — "Value" stratifiers (boolean basis) get a message that omits the irrelevant population basis and lists allowed categorical types. "Non Subject Value" stratifiers (resource basis) include the population basis for context. Both messages suggest using a CRITERIA-based stratifier as an alternative.


## Code Review Suggestions

- [ ] Verify that the `PopulationBasisValidator` default methods (especially `resolveResourceType`) being `default` rather than `private` is acceptable from an API surface perspective — they are callable by any implementor, not just internally.
- [ ] The `doesBasisMatchResource` logic now gates `Boolean.class` and `String.class` through explicit constant checks and rejects them from the generic `getSimpleName()` path. Confirm there are no other CQL/FHIR primitive types (e.g. `Integer`, `Decimal`) that could hit the same case-sensitivity issue with their FHIR codes.
- [ ] The `ListResource` special case that previously existed in `extractResourceType` was removed during the refactor. If any existing Measures use `"ListResource"` as a population basis code, this would be a behavioral change. Verify whether this code path was ever exercised in production.
- [ ] The `findCaseInsensitiveMatch` in `R4MeasureDefBuilder` iterates all `FHIRAllTypes` enum values. Confirm this is acceptable for the error path (it only runs on invalid input) and that no enum values have null `toCode()` results that could cause issues despite the null check.
- [ ] The value stratifier error message includes `List.copyOf(allowedStratifierValueTypes())` — since this comes from a `HashSet`, the ordering in the error message is non-deterministic. Verify this is acceptable for log-based alerting or automated error parsing downstream.

## QA Test Suggestions

### Setup

Load a FHIR R4 server with:
- An Organization resource
- 2+ Patient resources (with different genders, e.g. male and female)
- Encounter resources for each patient
- A CQL Library that includes a string-returning stratifier expression (e.g. `if Patient.gender = 'male' then 'male' else 'female'`)

### Test Cases

- [ ] **Lowercase "string" basis with criteria stratifier**: Create a Ratio Measure with `populationBasis: "string"` and a `stratifier.criteria` expression returning String values. Run `$evaluate-measure` with multiple patients. Expect: `200 OK` with a COMPLETE MeasureReport containing stratified results.
- [ ] **Uppercase "String" basis (invalid)**: Create the same Measure but with `populationBasis: "String"`. Run `$evaluate-measure`. Expect: an error response containing `"has an invalid population basis of 'String'. Did you mean to enter 'string' instead?"`.
- [ ] **Nonsensical basis code**: Create a Measure with `populationBasis: "Foo"`. Run `$evaluate-measure`. Expect: an error response containing `"has an invalid population basis of 'Foo'"` and a reference to the FHIR spec URL.
- [ ] **Existing Encounter basis measures**: Run `$evaluate-measure` on an existing Encounter-basis Measure with criteria and value stratifiers. Expect: no regression, same results as before.
- [ ] **Boolean basis measures**: Run `$evaluate-measure` on an existing boolean-basis Measure with stratifiers. Expect: no regression, same results as before.
- [ ] **Group-level population basis**: Create a Measure with `populationBasis` set at the group level (on `Measure.group` rather than `Measure`) using an invalid code. Expect: the same improved error message including the measure URL.
