### PR TITLE
Ensure Leaf ValueSet versions are stripped during $draft

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/crmi/KnowledgeArtifactProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/crmi/KnowledgeArtifactProcessor.java
@@ -167,6 +167,18 @@ public class KnowledgeArtifactProcessor {
                         .anyMatch(uc -> uc.hasCode() && uc.getCode().getCode().equals(TransformProperties.grouperType));
     }
 
+    public static boolean isGrouper(org.hl7.fhir.r5.model.MetadataResource resource) {
+        return resource.getResourceType() == org.hl7.fhir.r5.model.ResourceType.ValueSet
+                && resource.getUseContext().stream()
+                        .anyMatch(uc -> uc.hasCode() && uc.getCode().getCode().equals(TransformProperties.grouperType));
+    }
+
+    public static boolean isGrouper(org.hl7.fhir.dstu3.model.MetadataResource resource) {
+        return resource.getResourceType() == org.hl7.fhir.dstu3.model.ResourceType.ValueSet
+                && resource.getUseContext().stream()
+                        .anyMatch(uc -> uc.hasCode() && uc.getCode().getCode().equals(TransformProperties.grouperType));
+    }
+
     public static boolean checkIfValueSetNeedsCondition(
             MetadataResource resource, IDependencyInfo relatedArtifact, IRepository hapiFhirRepository)
             throws UnprocessableEntityException {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/DraftVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/DraftVisitor.java
@@ -16,6 +16,7 @@ import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IBaseReference;
 import org.hl7.fhir.instance.model.api.IDomainResource;
+import org.opencds.cqf.fhir.cr.crmi.KnowledgeArtifactProcessor;
 import org.opencds.cqf.fhir.utility.BundleHelper;
 import org.opencds.cqf.fhir.utility.Canonicals;
 import org.opencds.cqf.fhir.utility.PackageHelper;
@@ -123,6 +124,31 @@ public class DraftVisitor extends BaseKnowledgeArtifactVisitor {
                     IAdapterFactory.forFhirVersion(fhirVersion()).createKnowledgeArtifactAdapter(newResource);
             newResourceAdapter.setStatus("draft");
             newResourceAdapter.setVersion(draftVersion);
+
+            // Leaf ValueSet versions should be removed from grouper dependencies
+            var isGrouper =
+                    switch (repository.fhirContext().getVersion().getVersion()) {
+                        case DSTU3 ->
+                            KnowledgeArtifactProcessor.isGrouper(
+                                    (org.hl7.fhir.dstu3.model.MetadataResource) newResource);
+                        case R4 ->
+                            KnowledgeArtifactProcessor.isGrouper((org.hl7.fhir.r4.model.MetadataResource) newResource);
+                        case R5 ->
+                            KnowledgeArtifactProcessor.isGrouper((org.hl7.fhir.r5.model.MetadataResource) newResource);
+                        default ->
+                            throw new UnprocessableEntityException("Unsupported FHIR version: "
+                                    + repository.fhirContext().getVersion().getVersion());
+                    };
+
+            if (isGrouper) {
+                newResourceAdapter.getDependencies().forEach(vs -> {
+                    if (vs.getReference().contains("|")) {
+                        vs.setReference(
+                                vs.getReference().substring(0, vs.getReference().indexOf("|")));
+                    }
+                });
+            }
+
             resourcesToCreate.add(newResource);
             var ownedRelatedArtifacts = sourceResourceAdapter.getOwnedRelatedArtifacts();
             for (var ra : ownedRelatedArtifacts) {

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/dstu3/DraftVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/dstu3/DraftVisitorTests.java
@@ -27,6 +27,7 @@ import org.hl7.fhir.dstu3.model.Period;
 import org.hl7.fhir.dstu3.model.PlanDefinition;
 import org.hl7.fhir.dstu3.model.RelatedArtifact;
 import org.hl7.fhir.dstu3.model.StringType;
+import org.hl7.fhir.dstu3.model.ValueSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opencds.cqf.fhir.cr.visitor.DraftVisitor;
@@ -97,6 +98,16 @@ class DraftVisitorTests {
         assertFalse(lib.hasApprovalDate());
         assertFalse(lib.hasExtension(IKnowledgeArtifactAdapter.RELEASE_DESCRIPTION_URL));
         assertFalse(lib.hasExtension(IKnowledgeArtifactAdapter.RELEASE_LABEL_URL));
+        Optional<BundleEntryComponent> maybeGrouper = returnedBundle.getEntry().stream()
+                .filter(entry -> entry.getResponse().getLocation().contains("ValueSet"))
+                .findAny();
+        assertTrue(maybeGrouper.isPresent());
+        ValueSet grouper = repo.read(
+                ValueSet.class, new IdType(maybeGrouper.get().getResponse().getLocation()));
+        assertNotNull(grouper);
+        grouper.getCompose().getInclude().forEach(include -> {
+            assertFalse(include.getValueSet().get(0).getValueAsString().contains("|"));
+        });
         List<RelatedArtifact> relatedArtifacts = lib.getRelatedArtifact();
         assertFalse(relatedArtifacts.isEmpty());
         MetadataResourceHelper.forEachMetadataResource(

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/DraftVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/DraftVisitorTests.java
@@ -27,6 +27,7 @@ import org.hl7.fhir.r4.model.Period;
 import org.hl7.fhir.r4.model.PlanDefinition;
 import org.hl7.fhir.r4.model.RelatedArtifact;
 import org.hl7.fhir.r4.model.StringType;
+import org.hl7.fhir.r4.model.ValueSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opencds.cqf.fhir.cr.visitor.DraftVisitor;
@@ -96,6 +97,16 @@ class DraftVisitorTests {
         assertFalse(lib.hasApprovalDate());
         assertFalse(lib.hasExtension(IKnowledgeArtifactAdapter.RELEASE_DESCRIPTION_URL));
         assertFalse(lib.hasExtension(IKnowledgeArtifactAdapter.RELEASE_LABEL_URL));
+        Optional<BundleEntryComponent> maybeGrouper = returnedBundle.getEntry().stream()
+                .filter(entry -> entry.getResponse().getLocation().contains("ValueSet"))
+                .findAny();
+        assertTrue(maybeGrouper.isPresent());
+        ValueSet grouper = repo.read(
+                ValueSet.class, new IdType(maybeGrouper.get().getResponse().getLocation()));
+        assertNotNull(grouper);
+        grouper.getCompose().getInclude().forEach(include -> {
+            assertFalse(include.getValueSet().get(0).getValueAsString().contains("|"));
+        });
         List<RelatedArtifact> relatedArtifacts = lib.getRelatedArtifact();
         assertFalse(relatedArtifacts.isEmpty());
         MetadataResourceHelper.forEachMetadataResource(

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r5/DraftVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r5/DraftVisitorTests.java
@@ -27,6 +27,7 @@ import org.hl7.fhir.r5.model.Period;
 import org.hl7.fhir.r5.model.PlanDefinition;
 import org.hl7.fhir.r5.model.RelatedArtifact;
 import org.hl7.fhir.r5.model.StringType;
+import org.hl7.fhir.r5.model.ValueSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opencds.cqf.fhir.cr.visitor.DraftVisitor;
@@ -96,6 +97,16 @@ class DraftVisitorTests {
         assertFalse(lib.hasApprovalDate());
         assertFalse(lib.hasExtension(IKnowledgeArtifactAdapter.RELEASE_DESCRIPTION_URL));
         assertFalse(lib.hasExtension(IKnowledgeArtifactAdapter.RELEASE_LABEL_URL));
+        Optional<BundleEntryComponent> maybeGrouper = returnedBundle.getEntry().stream()
+                .filter(entry -> entry.getResponse().getLocation().contains("ValueSet"))
+                .findAny();
+        assertTrue(maybeGrouper.isPresent());
+        ValueSet grouper = repo.read(
+                ValueSet.class, new IdType(maybeGrouper.get().getResponse().getLocation()));
+        assertNotNull(maybeGrouper);
+        grouper.getCompose().getInclude().forEach(include -> {
+            assertFalse(include.getValueSet().get(0).getValueAsString().contains("|"));
+        });
         List<RelatedArtifact> relatedArtifacts = lib.getRelatedArtifact();
         assertFalse(relatedArtifacts.isEmpty());
         MetadataResourceHelper.forEachMetadataResource(

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/visitor/dstu3/Bundle-ersd-small-active.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/visitor/dstu3/Bundle-ersd-small-active.json
@@ -264,6 +264,15 @@
                         }
                     ]
                 },
+                "useContext": [
+                  {
+                    "code":{
+                      "system":"http://terminology.hl7.org/CodeSystem/usage-context-type",
+                      "code":"grouper-type",
+                      "display":"model-grouper"
+                    }
+                  }
+                ],
                 "expansion": {
                     "timestamp": "2022-10-21T15:18:29-04:00",
                     "contains": [

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/visitor/r4/Bundle-ersd-small-active.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/visitor/r4/Bundle-ersd-small-active.json
@@ -239,6 +239,13 @@
             "valueReference": {
               "reference": "http://hl7.org/fhir/us/ecr/PlanDefinition/us-ecr-specification"
             }
+          },
+          {
+            "code":{
+              "system":"http://terminology.hl7.org/CodeSystem/usage-context-type",
+              "code":"grouper-type",
+              "display":"model-grouper"
+            }
           }
         ],
         "compose": {

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/visitor/r5/Bundle-ersd-small-active.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/visitor/r5/Bundle-ersd-small-active.json
@@ -239,6 +239,13 @@
             "valueReference": {
               "reference": "http://hl7.org/fhir/us/ecr/PlanDefinition/us-ecr-specification"
             }
+          },
+          {
+            "code":{
+              "system":"http://terminology.hl7.org/CodeSystem/usage-context-type",
+              "code":"grouper-type",
+              "display":"model-grouper"
+            }
           }
         ],
         "compose": {


### PR DESCRIPTION
Currently in VSM, when a new program is drafted - pinned ValueSet versions are persisted from the original program into the new draft. This is not desirable, new drafts should default to using the latest version of the ValueSet - until the user manually pins a version. 

This change ensures freshly drafted programs do not have ValueSet versions pinned.

Includes updated tests for each FHIR version, modified test data to satisfy the 'isGrouper' check & addition of versioned 'isGrouper' methods.