### PR TITLE
multi-component stratifiers:  Ensure FHIR MeasureReport stratumPopulations contain scores and aggregation extensions, including criteriaReference 

### DIFF
--- a/PRPs/fix-copy-stratifier-scores-multi-component-matching.md
+++ b/PRPs/fix-copy-stratifier-scores-multi-component-matching.md
@@ -1,0 +1,203 @@
+# PRP: Fix copyStratifierScores Matching for Multi-Component Stratifiers
+
+## Metadata
+- **Title**: Fix broken stratum matching in copyStratifierScores for multi-component stratifiers
+- **Status**: Proposed
+- **Priority**: High (Bug Fix - DQM-693)
+- **Estimated Effort**: 0.5 days
+- **Related CQIS Ticket**: DQM-693
+
+## Problem Statement
+
+`R4MeasureReportBuilder#copyStratifierScores` fails to match any multi-component strata, causing stratum scores and per-stratum population aggregation results (criteria references, aggregate methods, aggregation results) to never be copied to the MeasureReport.
+
+### Root Cause
+
+The matching logic in `R4MeasureReportUtils#matchesStratumValue` (line 124-130) only checks the stratum's top-level `value` field:
+
+```java
+public static boolean matchesStratumValue(
+        StratifierGroupComponent reportStratum, StratumDef stratumDef, StratifierDef stratifierDef) {
+    String reportText = reportStratum.hasValue() ? reportStratum.getValue().getText() : null;
+    String defText = getStratumDefText(stratifierDef, stratumDef);
+    return Objects.equals(reportText, defText);
+}
+```
+
+For multi-component strata, `R4StratifierBuilder#buildStratum` (line 152-188) sets data on `stratum.component` entries, **never** on `stratum.value`. So `reportStratum.hasValue()` is always `false`, `reportText` is always `null`, and the match always fails.
+
+Meanwhile `getStratumDefText` returns a non-null string for the `StratumDef` (e.g., a component code text like `"Gender"` or a value string like `"74"`).
+
+`Objects.equals(null, "74")` is always `false`. The match never succeeds.
+
+### Downstream Impact
+
+Because `reportStratum` is always null in the `copyStratifierScores` loop, two things never happen:
+
+1. **Stratum scores are never set** (line 636-638 in `R4MeasureReportBuilder`):
+   ```java
+   Double stratumScore = stratumDef.getScore();
+   if (stratumScore != null) {
+       reportStratum.getMeasureScore().setValue(stratumScore);
+   }
+   ```
+
+2. **Per-stratum population aggregation results are never copied** (line 641 `copyStratumPopulationAggregationResults`), which means stratum observation populations are missing:
+   - `cqfm-criteriaReference` extension
+   - `cqfm-aggregateMethod` extension
+   - `cqfm-aggregationMethodResult` extension
+
+   This in turn causes an NPE in CQIS's `StratifierReportAggregator#isNumeratorObservation` when it calls `getCriteriaReference()` on the extensionless stratum population and passes null to `String.equals()`.
+
+### How to Reproduce
+
+Use a Measure with a multi-component stratifier (2+ components in `stratifier.component[]`) and evaluate with `$evaluate-measure`. Inspect the resulting MeasureReport's stratum-level data:
+- Stratum measure scores will be absent/null
+- Stratum MEASUREOBSERVATION populations will have no `cqfm-criteriaReference`, `cqfm-aggregateMethod`, or `cqfm-aggregationMethodResult` extensions
+
+Compare with a single-component stratifier on the same data — those strata will have scores and extensions properly set.
+
+## Solution Overview
+
+Fix `matchesStratumValue` to handle multi-component strata by matching component-by-component instead of comparing the top-level `value` field.
+
+### How R4StratifierBuilder builds multi-component strata (the "write" side)
+
+For each `StratumValueDef` in a multi-component stratum, `buildStratum` (line 159-182) creates a `StratifierGroupComponentComponent` with:
+- `code`: set to `new CodeableConcept().setText(componentDef.code().text())`
+- `value`: set to `expressionResultToCodableConcept(value)` which is `new CodeableConcept().setText(value.getValueAsString())`
+
+So each report component has:
+- `component.getCode().getText()` = the component definition's code text (e.g., `"Gender"`, `"Age"`)
+- `component.getValue().getText()` = the CQL expression result as string (e.g., `"male"`, `"74"`)
+
+### How matching should work (the "read" side)
+
+For each `StratumValueDef` in the `StratumDef`:
+- `valueDef.def().code().text()` corresponds to the report component's `code.text`
+- `valueDef.value().getValueAsString()` corresponds to the report component's `value.text`
+
+The fix should match all components between the report stratum and the `StratumDef` by pairing on code text and comparing value text.
+
+## Implementation Details
+
+### 1. Fix `matchesStratumValue` in `R4MeasureReportUtils`
+
+**File**: `cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/utils/R4MeasureReportUtils.java` (line 124-130)
+
+Replace the current implementation with one that branches on whether the stratum is component-based:
+
+```java
+public static boolean matchesStratumValue(
+        StratifierGroupComponent reportStratum, StratumDef stratumDef, StratifierDef stratifierDef) {
+
+    if (stratumDef.isComponent()) {
+        return matchesComponentStratumValues(reportStratum, stratumDef);
+    }
+
+    // Existing single-value matching logic (unchanged)
+    String reportText = reportStratum.hasValue() ? reportStratum.getValue().getText() : null;
+    String defText = getStratumDefText(stratifierDef, stratumDef);
+    return Objects.equals(reportText, defText);
+}
+```
+
+Add a new private method for component matching:
+
+```java
+/**
+ * Match a multi-component report stratum against a StratumDef by comparing
+ * each component's code text and value text.
+ *
+ * For each StratumValueDef in the StratumDef, there must be a matching
+ * report component where:
+ *   - component.getCode().getText() equals valueDef.def().code().text()
+ *   - component.getValue().getText() equals valueDef.value().getValueAsString()
+ */
+private static boolean matchesComponentStratumValues(
+        StratifierGroupComponent reportStratum, StratumDef stratumDef) {
+
+    var reportComponents = reportStratum.getComponent();
+    var valueDefs = stratumDef.valueDefs();
+
+    // Component count must match
+    if (reportComponents.size() != valueDefs.size()) {
+        return false;
+    }
+
+    // Every StratumValueDef must find a matching report component
+    for (var valueDef : valueDefs) {
+        var componentDef = valueDef.def();
+        if (componentDef == null || componentDef.code() == null) {
+            return false;
+        }
+
+        String expectedCodeText = componentDef.code().text();
+        String expectedValueText = valueDef.value().getValueAsString();
+
+        boolean found = reportComponents.stream().anyMatch(rc ->
+                Objects.equals(expectedCodeText, rc.getCode().getText())
+                && Objects.equals(expectedValueText, rc.getValue().getText()));
+
+        if (!found) {
+            return false;
+        }
+    }
+
+    return true;
+}
+```
+
+**Rationale**:
+- Mirrors the symmetry of `R4StratifierBuilder#buildStratum`: the builder sets `code` from `componentDef.code().text()` and `value` from `value.getValueAsString()`, so the matcher reads the same fields
+- Order-independent matching (components may appear in different order between reports)
+- Size check ensures no extra/missing components
+- Single-value matching is unchanged (no risk to existing behavior)
+
+### 2. Add Unit Tests for `matchesStratumValue`
+
+**File**: `cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/utils/R4MeasureReportUtilsTest.java` (create or extend)
+
+Add tests covering:
+
+1. **Single-value stratum matching still works** (regression guard)
+   - Report stratum with `value.text = "male"`, StratumDef with single CodeableConcept value "male" -> true
+   - Mismatched values -> false
+
+2. **Multi-component matching works**
+   - Report stratum with components `[{code:"Gender", value:"male"}, {code:"Age", value:"74"}]` matches StratumDef with matching valueDefs -> true
+   - Same components in different order -> true (order-independent)
+   - One mismatched value -> false
+   - Different component count -> false
+
+3. **Multi-component stratum with non-CodeableConcept values** (e.g., Age as integer)
+   - Report component value text "74", StratumDef value `getValueAsString()` returns "74" -> true
+
+### 3. Verify with Existing Integration Tests
+
+**File**: `cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest.java`
+
+The existing test `cohortBooleanValueStratComponentStrat` (line 194) exercises multi-component stratifiers but does **not** assert stratum scores or population extensions. After the fix, consider extending this test (or adding a new one) to verify that:
+- Stratum measure scores are non-null where expected
+- Stratum observation populations have `cqfm-criteriaReference` and `cqfm-aggregateMethod` extensions
+
+This is important because these are exactly the fields that were silently not being set before.
+
+## Verification
+
+1. Run existing clinical-reasoning tests: `./gradlew :cqf-fhir-cr:test`
+2. Run the multi-component stratifier test specifically: `./gradlew :cqf-fhir-cr:test --tests "*MeasureStratifierTest*cohortBooleanValueStratComponentStrat*"`
+3. After integrating this fix into CQIS (by updating the clinical-reasoning dependency version), re-run the CQIS end-to-end test: `./gradlew :cdr-persistence-dqm:test --tests "*BatchMeasureAsyncEndToEndIgCvRcvComboTest*"` — the stratum scores and observation population extensions should now be populated, allowing the CQIS aggregation code to fully function (including RCV stratum score recomputation via `isNumeratorObservation`/`isDenominatorObservation`)
+4. At that point, the null guard added to `StratifierReportAggregator#isNumeratorObservation`/`isDenominatorObservation` in CQIS will become a defensive safety net rather than a required workaround
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `cqf-fhir-cr/.../r4/utils/R4MeasureReportUtils.java` | Fix `matchesStratumValue` to handle multi-component strata; add `matchesComponentStratumValues` |
+| `cqf-fhir-cr/.../r4/utils/R4MeasureReportUtilsTest.java` | Add unit tests for component matching |
+| `cqf-fhir-cr/.../r4/MeasureStratifierTest.java` | Optionally extend to assert stratum scores/extensions for multi-component strata |
+
+## Secondary Concern: `getStratumDefText` for Multi-Component Strata
+
+The `getStratumDefText` method (line 53-110) has a secondary bug in its multi-component path (line 89-109): for CodeableConcept component values, it returns the **component code text** (e.g., `"Gender"`) instead of the **component value text** (e.g., `"male"`). For non-CodeableConcept values, it returns the value but breaks out of the loop on the first component, ignoring the rest. This method is not needed for the component matching fix (which bypasses `getStratumDefText` entirely), but it may cause issues if other callers rely on it for multi-component strata. Consider cleaning it up as a follow-up.

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/utils/R4MeasureReportUtils.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/utils/R4MeasureReportUtils.java
@@ -123,10 +123,51 @@ public class R4MeasureReportUtils {
      */
     public static boolean matchesStratumValue(
             StratifierGroupComponent reportStratum, StratumDef stratumDef, StratifierDef stratifierDef) {
-        // Use the same logic as R4MeasureReportScorer: compare CodeableConcept.text
+
+        if (stratumDef.isComponent()) {
+            return matchesComponentStratumValues(reportStratum, stratumDef);
+        }
+
+        // Existing single-value matching logic (unchanged)
         String reportText = reportStratum.hasValue() ? reportStratum.getValue().getText() : null;
         String defText = getStratumDefText(stratifierDef, stratumDef);
         return Objects.equals(reportText, defText);
+    }
+
+    /**
+     * Match a multi-component report stratum against a StratumDef by comparing
+     * each component's code text and value text.
+     */
+    private static boolean matchesComponentStratumValues(
+            StratifierGroupComponent reportStratum, StratumDef stratumDef) {
+
+        var reportComponents = reportStratum.getComponent();
+        var valueDefs = stratumDef.valueDefs();
+
+        if (reportComponents.size() != valueDefs.size()) {
+            return false;
+        }
+
+        for (var valueDef : valueDefs) {
+            var componentDef = valueDef.def();
+            if (componentDef == null || componentDef.code() == null) {
+                return false;
+            }
+
+            String expectedCodeText = componentDef.code().text();
+            String expectedValueText = valueDef.value().getValueAsString();
+
+            boolean found = reportComponents.stream()
+                    .anyMatch(rc -> Objects.equals(
+                                    expectedCodeText, rc.getCode().getText())
+                            && Objects.equals(expectedValueText, rc.getValue().getText()));
+
+            if (!found) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public static void addAggregationResultMethodAndCriteriaRef(

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest.java
@@ -302,6 +302,60 @@ class MeasureStratifierTest {
                 .hasCount(5);
     }
 
+    /**
+     * Ratio Measure with Boolean Basis and multi-component stratifier (Gender + Age).
+     * This tests the critical path that was broken before the matchesStratumValue fix:
+     * stratum scores must be copied for multi-component strata, not just single-component.
+     *
+     * <p>Test data: 10 patients, all in IP and Denominator.
+     * Numerator = patients with finished encounters in measurement period.
+     * <ul>
+     *   <li>(M, 35): patients 1,3,5,7,9 → IP=5, Denom=5, Numer=1 (patient-9), Score=0.2</li>
+     *   <li>(F, 38): patients 0,2,4,6,8 → IP=5, Denom=5, Numer=1 (patient-8), Score=0.2</li>
+     * </ul>
+     */
+    @Test
+    void ratioBooleanMultiComponentStratHasScores() {
+        GIVEN_MEASURE_STRATIFIER_TEST
+                .when()
+                .measureId("RatioBooleanStratComponent")
+                .evaluate()
+                .then()
+                .firstGroup()
+                .population(MeasurePopulationType.INITIALPOPULATION)
+                .hasCount(10)
+                .up()
+                .firstStratifier()
+                .hasCodeText("Gender and Age")
+                .hasStratumCount(2)
+                // Male stratum (M, 35): 5 males, 1 with finished encounter in period
+                .stratumByComponentValueText("M")
+                .hasComponentStratifierCount(2)
+                .hasScore("0.2")
+                .population(MeasurePopulationType.INITIALPOPULATION)
+                .hasCount(5)
+                .up()
+                .population(MeasurePopulationType.DENOMINATOR)
+                .hasCount(5)
+                .up()
+                .population(MeasurePopulationType.NUMERATOR)
+                .hasCount(1)
+                .up()
+                .up()
+                // Female stratum (F, 38): 5 females, 2 with finished encounters in period
+                .stratumByComponentValueText("F")
+                .hasComponentStratifierCount(2)
+                .hasScore("0.4")
+                .population(MeasurePopulationType.INITIALPOPULATION)
+                .hasCount(5)
+                .up()
+                .population(MeasurePopulationType.DENOMINATOR)
+                .hasCount(5)
+                .up()
+                .population(MeasurePopulationType.NUMERATOR)
+                .hasCount(2);
+    }
+
     @Test
     void invalidStratifierTopLevelCriteriaEmptyComponent() {
 

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/utils/R4MeasureReportUtilsTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/utils/R4MeasureReportUtilsTest.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.fhir.cr.measure.r4.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -9,6 +10,7 @@ import static org.opencds.cqf.fhir.cr.measure.constant.MeasureConstants.EXT_CQFM
 
 import java.math.BigDecimal;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import org.hl7.fhir.r4.model.CodeableConcept;
@@ -19,6 +21,7 @@ import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.MeasureReport;
 import org.hl7.fhir.r4.model.MeasureReport.MeasureReportGroupComponent;
 import org.hl7.fhir.r4.model.MeasureReport.MeasureReportGroupPopulationComponent;
+import org.hl7.fhir.r4.model.MeasureReport.StratifierGroupComponent;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.Test;
 import org.opencds.cqf.fhir.cr.measure.MeasureStratifierType;
@@ -1158,6 +1161,200 @@ class R4MeasureReportUtilsTest {
 
         // Assert
         assertNull(result, "Should return null when component has CodeableConcept but componentDef is null");
+    }
+
+    // ========================================
+    // Tests for matchesStratumValue()
+    // ========================================
+
+    @Test
+    void testMatchesStratumValue_SingleValue_Matches() {
+        StratifierDef stratifierDef = new StratifierDef(
+                "stratifier-1", new ConceptDef(List.of(), "Gender"), "GenderExpr", MeasureStratifierType.VALUE);
+
+        StringType stringValue = new StringType("male");
+        StratumValueWrapper valueWrapper = new StratumValueWrapper(stringValue);
+        StratumValueDef valueDef = new StratumValueDef(valueWrapper, null);
+        StratumDef stratumDef =
+                new StratumDef(Collections.emptyList(), Set.of(valueDef), Collections.emptyList(), null);
+
+        StratifierGroupComponent reportStratum = new StratifierGroupComponent();
+        reportStratum.setValue(new CodeableConcept().setText("male"));
+
+        assertTrue(R4MeasureReportUtils.matchesStratumValue(reportStratum, stratumDef, stratifierDef));
+    }
+
+    @Test
+    void testMatchesStratumValue_SingleValue_Mismatch() {
+        StratifierDef stratifierDef = new StratifierDef(
+                "stratifier-1", new ConceptDef(List.of(), "Gender"), "GenderExpr", MeasureStratifierType.VALUE);
+
+        StringType stringValue = new StringType("male");
+        StratumValueWrapper valueWrapper = new StratumValueWrapper(stringValue);
+        StratumValueDef valueDef = new StratumValueDef(valueWrapper, null);
+        StratumDef stratumDef =
+                new StratumDef(Collections.emptyList(), Set.of(valueDef), Collections.emptyList(), null);
+
+        StratifierGroupComponent reportStratum = new StratifierGroupComponent();
+        reportStratum.setValue(new CodeableConcept().setText("female"));
+
+        assertFalse(R4MeasureReportUtils.matchesStratumValue(reportStratum, stratumDef, stratifierDef));
+    }
+
+    @Test
+    void testMatchesStratumValue_MultiComponent_Matches() {
+        StratifierComponentDef genderComponentDef =
+                new StratifierComponentDef("comp-1", new ConceptDef(List.of(), "Gender"), "GenderExpr");
+        StratifierComponentDef ageComponentDef =
+                new StratifierComponentDef("comp-2", new ConceptDef(List.of(), "Age"), "AgeExpr");
+
+        StratifierDef stratifierDef = new StratifierDef(
+                "stratifier-1",
+                new ConceptDef(List.of(), "Gender and Age"),
+                null,
+                MeasureStratifierType.VALUE,
+                List.of(genderComponentDef, ageComponentDef));
+
+        Set<StratumValueDef> valueDefs = new LinkedHashSet<>();
+        valueDefs.add(new StratumValueDef(new StratumValueWrapper(new StringType("male")), genderComponentDef));
+        valueDefs.add(new StratumValueDef(new StratumValueWrapper(new IntegerType(74)), ageComponentDef));
+        StratumDef stratumDef = new StratumDef(Collections.emptyList(), valueDefs, Collections.emptyList(), null);
+
+        StratifierGroupComponent reportStratum = new StratifierGroupComponent();
+        reportStratum
+                .addComponent()
+                .setCode(new CodeableConcept().setText("Gender"))
+                .setValue(new CodeableConcept().setText("male"));
+        reportStratum
+                .addComponent()
+                .setCode(new CodeableConcept().setText("Age"))
+                .setValue(new CodeableConcept().setText("74"));
+
+        assertTrue(R4MeasureReportUtils.matchesStratumValue(reportStratum, stratumDef, stratifierDef));
+    }
+
+    @Test
+    void testMatchesStratumValue_MultiComponent_DifferentOrder_Matches() {
+        StratifierComponentDef genderComponentDef =
+                new StratifierComponentDef("comp-1", new ConceptDef(List.of(), "Gender"), "GenderExpr");
+        StratifierComponentDef ageComponentDef =
+                new StratifierComponentDef("comp-2", new ConceptDef(List.of(), "Age"), "AgeExpr");
+
+        StratifierDef stratifierDef = new StratifierDef(
+                "stratifier-1",
+                new ConceptDef(List.of(), "Gender and Age"),
+                null,
+                MeasureStratifierType.VALUE,
+                List.of(genderComponentDef, ageComponentDef));
+
+        Set<StratumValueDef> valueDefs = new LinkedHashSet<>();
+        valueDefs.add(new StratumValueDef(new StratumValueWrapper(new StringType("male")), genderComponentDef));
+        valueDefs.add(new StratumValueDef(new StratumValueWrapper(new IntegerType(74)), ageComponentDef));
+        StratumDef stratumDef = new StratumDef(Collections.emptyList(), valueDefs, Collections.emptyList(), null);
+
+        // Report components in reverse order
+        StratifierGroupComponent reportStratum = new StratifierGroupComponent();
+        reportStratum
+                .addComponent()
+                .setCode(new CodeableConcept().setText("Age"))
+                .setValue(new CodeableConcept().setText("74"));
+        reportStratum
+                .addComponent()
+                .setCode(new CodeableConcept().setText("Gender"))
+                .setValue(new CodeableConcept().setText("male"));
+
+        assertTrue(R4MeasureReportUtils.matchesStratumValue(reportStratum, stratumDef, stratifierDef));
+    }
+
+    @Test
+    void testMatchesStratumValue_MultiComponent_ValueMismatch() {
+        StratifierComponentDef genderComponentDef =
+                new StratifierComponentDef("comp-1", new ConceptDef(List.of(), "Gender"), "GenderExpr");
+        StratifierComponentDef ageComponentDef =
+                new StratifierComponentDef("comp-2", new ConceptDef(List.of(), "Age"), "AgeExpr");
+
+        StratifierDef stratifierDef = new StratifierDef(
+                "stratifier-1",
+                new ConceptDef(List.of(), "Gender and Age"),
+                null,
+                MeasureStratifierType.VALUE,
+                List.of(genderComponentDef, ageComponentDef));
+
+        Set<StratumValueDef> valueDefs = new LinkedHashSet<>();
+        valueDefs.add(new StratumValueDef(new StratumValueWrapper(new StringType("male")), genderComponentDef));
+        valueDefs.add(new StratumValueDef(new StratumValueWrapper(new IntegerType(74)), ageComponentDef));
+        StratumDef stratumDef = new StratumDef(Collections.emptyList(), valueDefs, Collections.emptyList(), null);
+
+        StratifierGroupComponent reportStratum = new StratifierGroupComponent();
+        reportStratum
+                .addComponent()
+                .setCode(new CodeableConcept().setText("Gender"))
+                .setValue(new CodeableConcept().setText("female")); // mismatch
+        reportStratum
+                .addComponent()
+                .setCode(new CodeableConcept().setText("Age"))
+                .setValue(new CodeableConcept().setText("74"));
+
+        assertFalse(R4MeasureReportUtils.matchesStratumValue(reportStratum, stratumDef, stratifierDef));
+    }
+
+    @Test
+    void testMatchesStratumValue_MultiComponent_DifferentComponentCount() {
+        StratifierComponentDef genderComponentDef =
+                new StratifierComponentDef("comp-1", new ConceptDef(List.of(), "Gender"), "GenderExpr");
+        StratifierComponentDef ageComponentDef =
+                new StratifierComponentDef("comp-2", new ConceptDef(List.of(), "Age"), "AgeExpr");
+
+        StratifierDef stratifierDef = new StratifierDef(
+                "stratifier-1",
+                new ConceptDef(List.of(), "Gender and Age"),
+                null,
+                MeasureStratifierType.VALUE,
+                List.of(genderComponentDef, ageComponentDef));
+
+        Set<StratumValueDef> valueDefs = new LinkedHashSet<>();
+        valueDefs.add(new StratumValueDef(new StratumValueWrapper(new StringType("male")), genderComponentDef));
+        valueDefs.add(new StratumValueDef(new StratumValueWrapper(new IntegerType(74)), ageComponentDef));
+        StratumDef stratumDef = new StratumDef(Collections.emptyList(), valueDefs, Collections.emptyList(), null);
+
+        // Report stratum with only 1 component
+        StratifierGroupComponent reportStratum = new StratifierGroupComponent();
+        reportStratum
+                .addComponent()
+                .setCode(new CodeableConcept().setText("Gender"))
+                .setValue(new CodeableConcept().setText("male"));
+
+        assertFalse(R4MeasureReportUtils.matchesStratumValue(reportStratum, stratumDef, stratifierDef));
+    }
+
+    @Test
+    void testMatchesStratumValue_MultiComponent_NullComponentDef() {
+        StratifierComponentDef genderComponentDef =
+                new StratifierComponentDef("comp-1", new ConceptDef(List.of(), "Gender"), "GenderExpr");
+
+        StratifierDef stratifierDef = new StratifierDef(
+                "stratifier-1",
+                new ConceptDef(List.of(), "Gender and Age"),
+                null,
+                MeasureStratifierType.VALUE,
+                List.of(genderComponentDef));
+
+        Set<StratumValueDef> valueDefs = new LinkedHashSet<>();
+        valueDefs.add(new StratumValueDef(new StratumValueWrapper(new StringType("male")), genderComponentDef));
+        valueDefs.add(new StratumValueDef(new StratumValueWrapper(new IntegerType(74)), null)); // null componentDef
+        StratumDef stratumDef = new StratumDef(Collections.emptyList(), valueDefs, Collections.emptyList(), null);
+
+        StratifierGroupComponent reportStratum = new StratifierGroupComponent();
+        reportStratum
+                .addComponent()
+                .setCode(new CodeableConcept().setText("Gender"))
+                .setValue(new CodeableConcept().setText("male"));
+        reportStratum
+                .addComponent()
+                .setCode(new CodeableConcept().setText("Age"))
+                .setValue(new CodeableConcept().setText("74"));
+
+        assertFalse(R4MeasureReportUtils.matchesStratumValue(reportStratum, stratumDef, stratifierDef));
     }
 
     @Test

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/measure/RatioBooleanStratComponent.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/measure/RatioBooleanStratComponent.json
@@ -1,0 +1,126 @@
+{
+  "id": "RatioBooleanStratComponent",
+  "resourceType": "Measure",
+  "url": "http://example.com/Measure/RatioBooleanStratComponent",
+  "library": [
+    "http://example.com/Library/LibrarySimple"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "boolean"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "ratio"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population Boolean"
+          }
+        },
+        {
+          "id": "denominator",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "denominator",
+                "display": "Denominator"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Denominator Boolean"
+          }
+        },
+        {
+          "id": "numerator",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "numerator",
+                "display": "Numerator"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Numerator Boolean"
+          }
+        }
+      ],
+      "stratifier": [
+        {
+          "id": "stratifier-1",
+          "code": {
+            "text": "Gender and Age"
+          },
+          "component": [
+            {
+              "id": "stratifier-comp-1",
+              "code": {
+                "text": "Gender"
+              },
+              "criteria": {
+                "language": "text/cql.identifier",
+                "expression": "Gender Stratification"
+              }
+            },
+            {
+              "id": "stratifier-comp-2",
+              "code": {
+                "text": "Age"
+              },
+              "criteria": {
+                "language": "text/cql.identifier",
+                "expression": "Age"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "supplementalData": [
+    {
+      "id": "sde-patient-sex",
+      "usage": [
+        {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/measure-data-usage",
+              "code": "supplemental-data"
+            }
+          ]
+        }
+      ],
+      "criteria": {
+        "language": "text/cql.identifier",
+        "expression": "SDE Sex"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

`R4MeasureReportBuilder#copyStratifierScores` silently failed to copy stratum scores and per-stratum population aggregation extensions (`cqfm-criteriaReference`, `cqfm-aggregateMethod`, `cqfm-aggregationMethodResult`) for any measure using multi-component stratifiers (2+ components in `stratifier.component[]`). The root cause was `matchesStratumValue` only checking the top-level `stratum.value` field, which multi-component strata never populate -- they store data on `stratum.component[]` entries instead. This fix adds component-aware matching and closes the test coverage gap that allowed the bug to go undetected.

1. **Fix `matchesStratumValue` to handle multi-component strata**: When `StratumDef.isComponent()` is true, delegate to a new `matchesComponentStratumValues` method that pairs report components with `StratumDef` value definitions by code text and value text, with order-independent matching and size validation. The single-value path is unchanged.

2. **Close the test coverage gap**: All prior multi-component stratifier tests used COHORT scoring (which never scores strata -- scorer returns null), and all RATIO/PROPORTION tests used single-component stratifiers. Added a new RATIO measure fixture with a 2-component stratifier (Gender + Age) and an integration test that asserts stratum scores and per-stratum population counts -- the exact combination that was missing.

## Code Review Suggestions

- [ ] Verify that `matchesComponentStratumValues` correctly mirrors the "write" side in `R4StratifierBuilder#buildStratum`: the builder sets component value via `expressionResultToCodableConcept(value)` which uses `StratumValueWrapper.getValueAsString()`, and the matcher reads `rc.getValue().getText()`. Confirm these are always symmetric for all value types the CQL engine can produce (Codes, integers, strings, booleans, etc.).
- [ ] Check whether `StratumValueWrapper.getValueAsString()` can ever diverge from what `expressionResultToCodableConcept` stores as `CodeableConcept.text`. For example, if a CQL expression returns a `CodeableConcept` (not just a `Code`), does `getValueAsString()` return the same thing that gets set as the component value text?
- [ ] The matching uses `valueDef.value().getValueAsString()` on the StratumDef side, but the report side uses `rc.getValue().getText()`. These come from different code paths (scorer vs builder). Confirm there is no edge case where one normalizes whitespace, casing, or null/empty differently than the other.
- [ ] The PRP mentions a secondary bug in `getStratumDefText` for multi-component strata (returns component code text instead of value text for CodeableConcept values). While the fix bypasses `getStratumDefText` entirely for component matching, verify no other callers depend on `getStratumDefText` for multi-component strata.

## QA Test Suggestions

### Setup

- Deploy a FHIR server with the clinical-reasoning module
- Load a Measure with RATIO or PROPORTION scoring that has a multi-component stratifier (2+ entries in `stratifier.component[]`), e.g., stratifying by both Gender and Age
- Load test Patient and Encounter resources with varied demographics to produce multiple strata
- Ensure the measurement period covers the encounter dates

### Test Cases

- [ ] **Multi-component RATIO stratum scores are present**: Run `$evaluate-measure` on the RATIO measure with multi-component stratifier. Inspect the resulting MeasureReport's `group.stratifier.stratum` entries. Each stratum should have a non-null `measureScore` value matching the expected numerator/denominator ratio for that stratum's subject subset.
- [ ] **Multi-component RATIO stratum populations are correct**: In the same MeasureReport, verify that each stratum's `population` entries (IP, Denominator, Numerator) have correct counts that partition the group-level populations by the stratifier components.
- [ ] **Single-component stratifier still works (regression)**: Run `$evaluate-measure` on a RATIO measure with a single-component stratifier. Verify stratum scores and population counts are unchanged from prior behavior.
- [ ] **COHORT multi-component stratifier still works (regression)**: Run `$evaluate-measure` on a COHORT measure with a multi-component stratifier. Verify strata are present with correct population counts (scores should remain absent since COHORT doesn't score strata).
- [ ] **RATIO with MEASUREOBSERVATION populations + multi-component stratifier**: If applicable, run `$evaluate-measure` on a RATIO CV measure with multi-component stratifier. Verify that stratum observation populations have `cqfm-criteriaReference`, `cqfm-aggregateMethod`, and `cqfm-aggregationMethodResult` extensions populated.
- [ ] **CQIS downstream aggregation (if integrated)**: After updating the clinical-reasoning dependency in CQIS, run an end-to-end measure evaluation with a multi-component stratifier RCV combo measure. Verify that `StratifierReportAggregator` no longer encounters null `criteriaReference` values on stratum observation populations.
