### PR TITLE
Preserve existing releaseLabel when not provided in Release operation

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/ReleaseVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/ReleaseVisitor.java
@@ -103,8 +103,7 @@ public class ReleaseVisitor extends BaseKnowledgeArtifactVisitor {
         }
         final var version = VisitorHelper.getStringParameter("version", operationParameters)
                 .orElseThrow(() -> new UnprocessableEntityException("Version must be present"));
-        final var releaseLabel = VisitorHelper.getStringParameter("releaseLabel", operationParameters)
-                .orElse("");
+        final var releaseLabel = VisitorHelper.getStringParameter("releaseLabel", operationParameters);
         final var versionBehavior = VisitorHelper.getStringParameter("versionBehavior", operationParameters);
         final var requireNonExperimental = VisitorHelper.getStringParameter(
                         "requireNonExperimental", operationParameters)
@@ -118,7 +117,7 @@ public class ReleaseVisitor extends BaseKnowledgeArtifactVisitor {
                 });
         checkReleaseVersion(version, versionBehavior);
         checkReleasePreconditions(rootAdapter, rootAdapter.getApprovalDate());
-        updateReleaseLabel(rootLibrary, releaseLabel);
+        releaseLabel.ifPresent(label -> updateReleaseLabel(rootLibrary, label));
         // Determine which version should be used.
         final var existingVersion =
                 rootAdapter.hasVersion() ? rootAdapter.getVersion().replace("-draft", "") : null;

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/dstu3/ReleaseVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/dstu3/ReleaseVisitorTests.java
@@ -665,6 +665,52 @@ class ReleaseVisitorTests {
     }
 
     @Test
+    void release_releaseLabel_not_provided_should_preserve_existing() {
+        Bundle bundle = (Bundle) jsonParser.parseResource(
+            ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
+        repo.transaction(bundle);
+
+        ReleaseVisitor releaseVisitor = new ReleaseVisitor(repo);
+
+        // Load and PRE-SET an existing releaseLabel on the resource
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary")).copy();
+        String existingLabel = "existing-release-label";
+
+        Extension existingExtension = new Extension();
+        existingExtension.setUrl(IKnowledgeArtifactAdapter.RELEASE_LABEL_URL);
+        existingExtension.setValue(new StringType(existingLabel));
+        library.addExtension(existingExtension);
+
+        ILibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
+
+        // IMPORTANT: Do NOT include releaseLabel parameter
+        Parameters params = parameters(
+            part("version", "1.2.3"),
+            part("versionBehavior", new CodeType("default")));
+
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, params);
+
+        Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
+            .filter(entry -> entry.getResponse().getLocation().contains("Library/SpecificationLibrary"))
+            .findFirst();
+
+        assertTrue(maybeLib.isPresent());
+
+        Library releasedLibrary =
+            repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+
+        Optional<Extension> maybeReleaseLabel = releasedLibrary.getExtension().stream()
+            .filter(ext -> ext.getUrl().equals(IKnowledgeArtifactAdapter.RELEASE_LABEL_URL))
+            .findFirst();
+
+        // ASSERT: it is still there
+        assertTrue(maybeReleaseLabel.isPresent());
+
+        // ASSERT: value unchanged
+        assertEquals(existingLabel, ((StringType) maybeReleaseLabel.get().getValue()).getValue());
+    }
+
+    @Test
     void release_version_active_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/dstu3/ReleaseVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/dstu3/ReleaseVisitorTests.java
@@ -667,13 +667,14 @@ class ReleaseVisitorTests {
     @Test
     void release_releaseLabel_not_provided_should_preserve_existing() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
-            ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
+                ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
         repo.transaction(bundle);
 
         ReleaseVisitor releaseVisitor = new ReleaseVisitor(repo);
 
         // Load and PRE-SET an existing releaseLabel on the resource
-        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary")).copy();
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
+                .copy();
         String existingLabel = "existing-release-label";
 
         Extension existingExtension = new Extension();
@@ -684,24 +685,22 @@ class ReleaseVisitorTests {
         ILibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
 
         // IMPORTANT: Do NOT include releaseLabel parameter
-        Parameters params = parameters(
-            part("version", "1.2.3"),
-            part("versionBehavior", new CodeType("default")));
+        Parameters params = parameters(part("version", "1.2.3"), part("versionBehavior", new CodeType("default")));
 
         Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, params);
 
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
-            .filter(entry -> entry.getResponse().getLocation().contains("Library/SpecificationLibrary"))
-            .findFirst();
+                .filter(entry -> entry.getResponse().getLocation().contains("Library/SpecificationLibrary"))
+                .findFirst();
 
         assertTrue(maybeLib.isPresent());
 
         Library releasedLibrary =
-            repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
 
         Optional<Extension> maybeReleaseLabel = releasedLibrary.getExtension().stream()
-            .filter(ext -> ext.getUrl().equals(IKnowledgeArtifactAdapter.RELEASE_LABEL_URL))
-            .findFirst();
+                .filter(ext -> ext.getUrl().equals(IKnowledgeArtifactAdapter.RELEASE_LABEL_URL))
+                .findFirst();
 
         // ASSERT: it is still there
         assertTrue(maybeReleaseLabel.isPresent());

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/ReleaseVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/ReleaseVisitorTests.java
@@ -688,6 +688,52 @@ class ReleaseVisitorTests {
     }
 
     @Test
+    void release_releaseLabel_not_provided_should_preserve_existing() {
+        Bundle bundle = (Bundle) jsonParser.parseResource(
+            ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
+        repo.transaction(bundle);
+
+        ReleaseVisitor releaseVisitor = new ReleaseVisitor(repo);
+
+        // Load and PRE-SET an existing releaseLabel on the resource
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary")).copy();
+        String existingLabel = "existing-release-label";
+
+        Extension existingExtension = new Extension();
+        existingExtension.setUrl(IKnowledgeArtifactAdapter.RELEASE_LABEL_URL);
+        existingExtension.setValue(new StringType(existingLabel));
+        library.addExtension(existingExtension);
+
+        ILibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
+
+        // IMPORTANT: Do NOT include releaseLabel parameter
+        Parameters params = parameters(
+            part("version", "1.2.3"),
+            part("versionBehavior", new CodeType("default")));
+
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, params);
+
+        Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
+            .filter(entry -> entry.getResponse().getLocation().contains("Library/SpecificationLibrary"))
+            .findFirst();
+
+        assertTrue(maybeLib.isPresent());
+
+        Library releasedLibrary =
+            repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+
+        Optional<Extension> maybeReleaseLabel = releasedLibrary.getExtension().stream()
+            .filter(ext -> ext.getUrl().equals(IKnowledgeArtifactAdapter.RELEASE_LABEL_URL))
+            .findFirst();
+
+        // ASSERT: it is still there
+        assertTrue(maybeReleaseLabel.isPresent());
+
+        // ASSERT: value unchanged
+        assertEquals(existingLabel, ((StringType) maybeReleaseLabel.get().getValue()).getValue());
+    }
+
+    @Test
     void release_version_active_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/ReleaseVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/ReleaseVisitorTests.java
@@ -690,13 +690,14 @@ class ReleaseVisitorTests {
     @Test
     void release_releaseLabel_not_provided_should_preserve_existing() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
-            ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
+                ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
         repo.transaction(bundle);
 
         ReleaseVisitor releaseVisitor = new ReleaseVisitor(repo);
 
         // Load and PRE-SET an existing releaseLabel on the resource
-        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary")).copy();
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
+                .copy();
         String existingLabel = "existing-release-label";
 
         Extension existingExtension = new Extension();
@@ -707,24 +708,22 @@ class ReleaseVisitorTests {
         ILibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
 
         // IMPORTANT: Do NOT include releaseLabel parameter
-        Parameters params = parameters(
-            part("version", "1.2.3"),
-            part("versionBehavior", new CodeType("default")));
+        Parameters params = parameters(part("version", "1.2.3"), part("versionBehavior", new CodeType("default")));
 
         Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, params);
 
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
-            .filter(entry -> entry.getResponse().getLocation().contains("Library/SpecificationLibrary"))
-            .findFirst();
+                .filter(entry -> entry.getResponse().getLocation().contains("Library/SpecificationLibrary"))
+                .findFirst();
 
         assertTrue(maybeLib.isPresent());
 
         Library releasedLibrary =
-            repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
 
         Optional<Extension> maybeReleaseLabel = releasedLibrary.getExtension().stream()
-            .filter(ext -> ext.getUrl().equals(IKnowledgeArtifactAdapter.RELEASE_LABEL_URL))
-            .findFirst();
+                .filter(ext -> ext.getUrl().equals(IKnowledgeArtifactAdapter.RELEASE_LABEL_URL))
+                .findFirst();
 
         // ASSERT: it is still there
         assertTrue(maybeReleaseLabel.isPresent());

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r5/ReleaseVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r5/ReleaseVisitorTests.java
@@ -670,6 +670,52 @@ class ReleaseVisitorTests {
     }
 
     @Test
+    void release_releaseLabel_not_provided_should_preserve_existing() {
+        Bundle bundle = (Bundle) jsonParser.parseResource(
+            ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
+        repo.transaction(bundle);
+
+        ReleaseVisitor releaseVisitor = new ReleaseVisitor(repo);
+
+        // Load and PRE-SET an existing releaseLabel on the resource
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary")).copy();
+        String existingLabel = "existing-release-label";
+
+        Extension existingExtension = new Extension();
+        existingExtension.setUrl(IKnowledgeArtifactAdapter.RELEASE_LABEL_URL);
+        existingExtension.setValue(new StringType(existingLabel));
+        library.addExtension(existingExtension);
+
+        ILibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
+
+        // IMPORTANT: Do NOT include releaseLabel parameter
+        Parameters params = parameters(
+            part("version", "1.2.3"),
+            part("versionBehavior", new CodeType("default")));
+
+        Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, params);
+
+        Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
+            .filter(entry -> entry.getResponse().getLocation().contains("Library/SpecificationLibrary"))
+            .findFirst();
+
+        assertTrue(maybeLib.isPresent());
+
+        Library releasedLibrary =
+            repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+
+        Optional<Extension> maybeReleaseLabel = releasedLibrary.getExtension().stream()
+            .filter(ext -> ext.getUrl().equals(IKnowledgeArtifactAdapter.RELEASE_LABEL_URL))
+            .findFirst();
+
+        // ASSERT: it is still there
+        assertTrue(maybeReleaseLabel.isPresent());
+
+        // ASSERT: value unchanged
+        assertEquals(existingLabel, ((StringType) maybeReleaseLabel.get().getValue()).getValue());
+    }
+
+    @Test
     void release_version_active_test() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
                 ReleaseVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r5/ReleaseVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r5/ReleaseVisitorTests.java
@@ -672,13 +672,14 @@ class ReleaseVisitorTests {
     @Test
     void release_releaseLabel_not_provided_should_preserve_existing() {
         Bundle bundle = (Bundle) jsonParser.parseResource(
-            ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
+                ReleaseVisitorTests.class.getResourceAsStream("Bundle-small-approved-draft.json"));
         repo.transaction(bundle);
 
         ReleaseVisitor releaseVisitor = new ReleaseVisitor(repo);
 
         // Load and PRE-SET an existing releaseLabel on the resource
-        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary")).copy();
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
+                .copy();
         String existingLabel = "existing-release-label";
 
         Extension existingExtension = new Extension();
@@ -689,24 +690,22 @@ class ReleaseVisitorTests {
         ILibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
 
         // IMPORTANT: Do NOT include releaseLabel parameter
-        Parameters params = parameters(
-            part("version", "1.2.3"),
-            part("versionBehavior", new CodeType("default")));
+        Parameters params = parameters(part("version", "1.2.3"), part("versionBehavior", new CodeType("default")));
 
         Bundle returnResource = (Bundle) libraryAdapter.accept(releaseVisitor, params);
 
         Optional<BundleEntryComponent> maybeLib = returnResource.getEntry().stream()
-            .filter(entry -> entry.getResponse().getLocation().contains("Library/SpecificationLibrary"))
-            .findFirst();
+                .filter(entry -> entry.getResponse().getLocation().contains("Library/SpecificationLibrary"))
+                .findFirst();
 
         assertTrue(maybeLib.isPresent());
 
         Library releasedLibrary =
-            repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
+                repo.read(Library.class, new IdType(maybeLib.get().getResponse().getLocation()));
 
         Optional<Extension> maybeReleaseLabel = releasedLibrary.getExtension().stream()
-            .filter(ext -> ext.getUrl().equals(IKnowledgeArtifactAdapter.RELEASE_LABEL_URL))
-            .findFirst();
+                .filter(ext -> ext.getUrl().equals(IKnowledgeArtifactAdapter.RELEASE_LABEL_URL))
+                .findFirst();
 
         // ASSERT: it is still there
         assertTrue(maybeReleaseLabel.isPresent());


### PR DESCRIPTION
### Description
This change fixes an issue in the `ReleaseVisitor` where an existing `releaseLabel` extension could be unintentionally cleared when the `releaseLabel` parameter is omitted from the release operation.

#### What changed
- Updated handling of the `releaseLabel` parameter:
  - Previously: defaulted to an empty string (`""`) when not provided.
  - Now: treated as optional and only applied when explicitly present.
- `updateReleaseLabel` is now invoked **only if** a `releaseLabel` value is provided.

#### Why this matters
- Prevents accidental overwriting/removal of an existing `releaseLabel`.
- Aligns behavior with expected partial-update semantics (i.e., absence of a parameter should not mutate existing state).
- Improves safety and predictability of release operations.

#### Tests
- Added new test cases across DSTU3, R4, and R5:
  - `release_releaseLabel_not_provided_should_preserve_existing`
- These verify that:
  - An existing `releaseLabel` remains unchanged when the parameter is omitted.

#### Impact
- Backward-compatible change.
- Only affects scenarios where `releaseLabel` is not supplied.
- No change to behavior when `releaseLabel` **is** provided.