### PR TITLE
Make opioidRec10PatientView resistant to wall-clock rot

### DIFF
--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/helpers/DataDateRollerHelper.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/helpers/DataDateRollerHelper.java
@@ -1,0 +1,166 @@
+package org.opencds.cqf.fhir.cr.helpers;
+
+import ca.uhn.fhir.context.FhirContext;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import org.hl7.fhir.instance.model.api.IBaseExtension;
+import org.hl7.fhir.instance.model.api.IBaseHasExtensions;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IPrimitiveType;
+
+/**
+ * Honors the CDC opioid-cds {@code dataDateRoller} extension on test fixtures
+ * by shifting a resource's date fields forward so the data stays "current"
+ * relative to today's wall clock. Without this, fixtures with hard-coded dates
+ * eventually fall outside CQL windows like
+ * {@code where date from Rx.authoredOn 2 years or less on or before Today()}
+ * and tests rot.
+ *
+ * <p>The extension structure (see fixture JSON) is:
+ * <pre>
+ * extension: [{
+ *   url: "<a href="http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/dataDateRoller">...</a>",
+ *   extension: [
+ *     { url: "dateLastUpdated", valueDateTime: "2023-04-28" },
+ *     { url: "frequency",       valueDuration: { value: 30.0, unit: "days", ... } }
+ *   ]
+ * }]
+ * </pre>
+ *
+ * <p>This helper reads {@code dateLastUpdated}, computes
+ * {@code offsetDays = today − dateLastUpdated}, and shifts known date fields
+ * for each supported resource type by that many days. The {@code frequency}
+ * sub-extension is informational and not currently used. After rolling, the
+ * {@code dataDateRoller} extension is stripped so subsequent reads are no-ops
+ * (idempotent).
+ */
+public final class DataDateRollerHelper {
+
+    public static final String EXT_URL = "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/dataDateRoller";
+    public static final String EXT_DATE_LAST_UPDATED = "dateLastUpdated";
+
+    /**
+     * Date fields we shift forward when a resource carries the
+     * {@code dataDateRoller} extension. Intentionally narrow:
+     * <ul>
+     *   <li>{@code MedicationRequest} dates are rolled because CQL "active
+     *       prescription" windows like
+     *       {@code where date from Rx.authoredOn 2 years or less on or before Today()}
+     *       require them to stay near "now".</li>
+     *   <li>{@code Observation} dates are NOT rolled. The opioid-cds tests
+     *       depend on their historical observations staying outside windows
+     *       like "in last 12 months" — rolling them forward would silently
+     *       flip the recommendation branch (e.g. trigger "Positive Cocaine"
+     *       instead of "Annual Urine Screening Check"). The fixtures keep
+     *       the {@code dataDateRoller} extension for documentation, but the
+     *       helper ignores it on Observations.</li>
+     *   <li>{@code Patient.birthDate} is not rolled either; patient age is
+     *       not gated by these tests.</li>
+     * </ul>
+     * Add a resource type here only when a test's CQL has a wall-clock
+     * window that needs the data to stay current.
+     */
+    private static final Map<String, List<String>> ROLLABLE_PATHS = Map.of(
+            "MedicationRequest",
+            List.of("authoredOn", "dispenseRequest.validityPeriod.start", "dispenseRequest.validityPeriod.end"));
+
+    private DataDateRollerHelper() {}
+
+    /**
+     * If the resource carries a {@code dataDateRoller} extension, shift its date
+     * fields forward by {@code today − dateLastUpdated} days and strip the
+     * extension. No-op for resources without the extension or whose type is not
+     * in {@link #ROLLABLE_PATHS}.
+     */
+    public static void rollIfAnnotated(IBaseResource resource, LocalDate today, FhirContext ctx) {
+        if (!(resource instanceof IBaseHasExtensions hasExtensions)) {
+            return;
+        }
+        IBaseExtension<?, ?> rollerExt = findExtension(hasExtensions, EXT_URL);
+        if (rollerExt == null) {
+            return;
+        }
+        IBaseExtension<?, ?> anchorExt = findExtension(rollerExt, EXT_DATE_LAST_UPDATED);
+        if (anchorExt == null || !(anchorExt.getValue() instanceof IPrimitiveType<?> anchorPrim)) {
+            return;
+        }
+        LocalDate anchor = toLocalDate(anchorPrim);
+        if (anchor == null) {
+            return;
+        }
+        long offsetDays = ChronoUnit.DAYS.between(anchor, today);
+        if (offsetDays != 0) {
+            List<String> paths = ROLLABLE_PATHS.get(resource.fhirType());
+            if (paths != null) {
+                paths.forEach(path -> rollAtPath(resource, path, offsetDays, ctx));
+            }
+            // Resource types not in ROLLABLE_PATHS are intentionally left alone
+            // — see ROLLABLE_PATHS Javadoc.
+        }
+        // Idempotency: subsequent reads of the same cached resource skip rolling.
+        hasExtensions.getExtension().removeIf(e -> EXT_URL.equals(e.getUrl()));
+    }
+
+    private static IBaseExtension<?, ?> findExtension(IBaseHasExtensions container, String url) {
+        for (var ext : container.getExtension()) {
+            if (url.equals(ext.getUrl())) {
+                return ext;
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static IBaseExtension<?, ?> findExtension(IBaseExtension<?, ?> parent, String url) {
+        for (Object raw : parent.getExtension()) {
+            if (raw instanceof IBaseExtension ext && url.equals(ext.getUrl())) {
+                return ext;
+            }
+        }
+        return null;
+    }
+
+    private static void rollAtPath(IBaseResource resource, String path, long offsetDays, FhirContext ctx) {
+        List<IPrimitiveType> primitives;
+        try {
+            primitives = ctx.newTerser().getValues(resource, path, IPrimitiveType.class);
+        } catch (RuntimeException e) {
+            // Path not valid for this FHIR version (e.g. effectiveInstant on DSTU3). Skip.
+            return;
+        }
+        for (IPrimitiveType<?> primitive : primitives) {
+            rollPrimitive(primitive, offsetDays);
+        }
+    }
+
+    private static void rollPrimitive(IPrimitiveType<?> primitive, long offsetDays) {
+        // Always go through the string form to avoid timezone/DST off-by-one errors
+        // that arise when shifting a wall-clock Date through java.time.Instant.
+        String stringValue = primitive.getValueAsString();
+        if (stringValue == null || stringValue.length() < 10) {
+            return;
+        }
+        try {
+            LocalDate shiftedDate =
+                    LocalDate.parse(stringValue.substring(0, 10)).plusDays(offsetDays);
+            String tail = stringValue.substring(10);
+            primitive.setValueAsString(shiftedDate + tail);
+        } catch (RuntimeException ignored) {
+            // Non-date string (shouldn't happen for date fields), leave as-is.
+        }
+    }
+
+    private static LocalDate toLocalDate(IPrimitiveType<?> primitive) {
+        String stringValue = primitive.getValueAsString();
+        if (stringValue == null || stringValue.length() < 10) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(stringValue.substring(0, 10));
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/helpers/DataDateRollerHelperTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/helpers/DataDateRollerHelperTest.java
@@ -1,0 +1,119 @@
+package org.opencds.cqf.fhir.cr.helpers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.MedicationRequest;
+import org.hl7.fhir.r4.model.Period;
+import org.junit.jupiter.api.Test;
+
+class DataDateRollerHelperTest {
+
+    private static final FhirContext FHIR_CONTEXT_R4 = FhirContext.forR4Cached();
+
+    @Test
+    void rollsMedicationRequestAuthoredOnByOffset() {
+        var anchor = LocalDate.of(2023, 4, 28);
+        var today = LocalDate.of(2030, 1, 1);
+        var originalAuthoredOn = LocalDate.of(2023, 4, 28);
+
+        var medicationRequest = newMedicationRequestWithRoller(anchor, originalAuthoredOn, null, null);
+
+        DataDateRollerHelper.rollIfAnnotated(medicationRequest, today, FHIR_CONTEXT_R4);
+
+        assertEquals(today, dateOf(medicationRequest.getAuthoredOnElement()));
+    }
+
+    @Test
+    void rollsValidityPeriodStartAndEnd() {
+        var anchor = LocalDate.of(2023, 4, 28);
+        var today = LocalDate.of(2030, 1, 1);
+
+        var medicationRequest = newMedicationRequestWithRoller(
+                anchor, LocalDate.of(2023, 4, 28), LocalDate.of(2023, 4, 28), LocalDate.of(2023, 7, 28));
+
+        DataDateRollerHelper.rollIfAnnotated(medicationRequest, today, FHIR_CONTEXT_R4);
+
+        var validityPeriod = medicationRequest.getDispenseRequest().getValidityPeriod();
+        assertEquals(today, dateOf(validityPeriod.getStartElement()));
+        // end was 91 days after anchor; should land 91 days after today.
+        assertEquals(today.plusDays(91), dateOf(validityPeriod.getEndElement()));
+    }
+
+    @Test
+    void stripsRollerExtensionAfterRollingForIdempotency() {
+        var anchor = LocalDate.of(2023, 4, 28);
+        var medicationRequest = newMedicationRequestWithRoller(anchor, LocalDate.of(2024, 4, 28), null, null);
+
+        DataDateRollerHelper.rollIfAnnotated(medicationRequest, LocalDate.of(2030, 1, 1), FHIR_CONTEXT_R4);
+
+        var hasRollerExt = medicationRequest.getExtension().stream()
+                .anyMatch(e -> DataDateRollerHelper.EXT_URL.equals(e.getUrl()));
+        assertFalse(hasRollerExt, "dataDateRoller extension should be stripped after rolling");
+    }
+
+    @Test
+    void noOpForResourceWithoutRollerExtension() {
+        var medicationRequest = new MedicationRequest();
+        medicationRequest.setId("MedicationRequest/no-roller");
+        medicationRequest.setAuthoredOnElement(new DateTimeType("2024-04-28"));
+
+        DataDateRollerHelper.rollIfAnnotated(medicationRequest, LocalDate.of(2030, 1, 1), FHIR_CONTEXT_R4);
+
+        assertEquals(LocalDate.of(2024, 4, 28), dateOf(medicationRequest.getAuthoredOnElement()));
+    }
+
+    @Test
+    void timeTravelSanityKeepsAuthoredOnInTwoYearWindow() {
+        // Walk a few years into the future and confirm the rolled authoredOn
+        // never falls outside the 2-year window CQL expects.
+        var anchor = LocalDate.of(2023, 4, 28);
+        var originalAuthoredOn = LocalDate.of(2023, 4, 28);
+
+        for (int yearOffset = 0; yearOffset <= 10; yearOffset++) {
+            var today = LocalDate.of(2026 + yearOffset, 6, 15);
+            var medicationRequest = newMedicationRequestWithRoller(anchor, originalAuthoredOn, null, null);
+
+            DataDateRollerHelper.rollIfAnnotated(medicationRequest, today, FHIR_CONTEXT_R4);
+
+            var rolled = dateOf(medicationRequest.getAuthoredOnElement());
+            assertTrue(
+                    !rolled.isBefore(today.minusYears(2)) && !rolled.isAfter(today),
+                    "Rolled authoredOn (%s) must be within 2 years on or before today (%s)".formatted(rolled, today));
+        }
+    }
+
+    private static MedicationRequest newMedicationRequestWithRoller(
+            LocalDate anchor, LocalDate authoredOn, LocalDate validityStart, LocalDate validityEnd) {
+        var medicationRequest = new MedicationRequest();
+        medicationRequest.setId("MedicationRequest/test-rolling");
+        medicationRequest.setAuthoredOnElement(new DateTimeType(authoredOn.toString()));
+        if (validityStart != null || validityEnd != null) {
+            var validityPeriod = new Period();
+            if (validityStart != null) {
+                validityPeriod.setStartElement(new DateTimeType(validityStart.toString()));
+            }
+            if (validityEnd != null) {
+                validityPeriod.setEndElement(new DateTimeType(validityEnd.toString()));
+            }
+            medicationRequest.getDispenseRequest().setValidityPeriod(validityPeriod);
+        }
+        var rollerExtension = new Extension(DataDateRollerHelper.EXT_URL);
+        rollerExtension.addExtension(
+                new Extension(DataDateRollerHelper.EXT_DATE_LAST_UPDATED, new DateTimeType(anchor.toString())));
+        medicationRequest.addExtension(rollerExtension);
+        return medicationRequest;
+    }
+
+    private static LocalDate dateOf(DateTimeType primitive) {
+        Date value = primitive.getValue();
+        return value.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/helpers/DataDateRollingIgRepository.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/helpers/DataDateRollingIgRepository.java
@@ -1,0 +1,54 @@
+package org.opencds.cqf.fhir.cr.helpers;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.IQueryParameterType;
+import ca.uhn.fhir.util.BundleUtil;
+import com.google.common.collect.Multimap;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import org.hl7.fhir.instance.model.api.IBaseBundle;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.opencds.cqf.fhir.utility.repository.ig.IgRepository;
+
+/**
+ * An {@link IgRepository} that applies the CDC opioid-cds {@code dataDateRoller}
+ * extension to resources on read/search. See {@link DataDateRollerHelper}.
+ *
+ * <p>Test-only: lets opioid-cds fixtures with hard-coded anchor dates stay
+ * "current" relative to today's wall clock, so that CQL windows like
+ * {@code 2 years or less on or before Today()} remain satisfied without
+ * yearly fixture date bumps.
+ */
+public class DataDateRollingIgRepository extends IgRepository {
+
+    private final LocalDate today;
+
+    public DataDateRollingIgRepository(FhirContext fhirContext, Path root, LocalDate today) {
+        super(fhirContext, root);
+        this.today = today;
+    }
+
+    @Override
+    public <T extends IBaseResource, I extends IIdType> T read(
+            Class<T> resourceType, I id, Map<String, String> headers) {
+        T resource = super.read(resourceType, id, headers);
+        DataDateRollerHelper.rollIfAnnotated(resource, today, fhirContext());
+        return resource;
+    }
+
+    @Override
+    public <B extends IBaseBundle, T extends IBaseResource> B search(
+            Class<B> bundleType,
+            Class<T> resourceType,
+            Multimap<String, List<IQueryParameterType>> searchParameters,
+            Map<String, String> headers) {
+        B bundle = super.search(bundleType, resourceType, searchParameters, headers);
+        for (var entry : BundleUtil.toListOfResources(fhirContext(), bundle)) {
+            DataDateRollerHelper.rollIfAnnotated(entry, today, fhirContext());
+        }
+        return bundle;
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/PlanDefinitionProcessorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/PlanDefinitionProcessorTests.java
@@ -260,14 +260,14 @@ class PlanDefinitionProcessorTests {
         var planDefinitionID = "opioidcds-10-patient-view";
         var patientID = "example-rec-10-patient-view-POS-Cocaine-drugs";
         var encounterID = "example-rec-10-patient-view-POS-Cocaine-drugs-prefetch";
-        given().repositoryFor(fhirContextR4, "r4/opioid-Rec10-patient-view")
+        given().repositoryForWithDataDateRolling(fhirContextR4, "r4/opioid-Rec10-patient-view")
                 .when()
                 .planDefinitionId(planDefinitionID)
                 .subjectId(patientID)
                 .encounterId(encounterID)
                 .thenApply()
                 .isEqualsTo(new org.hl7.fhir.r4.model.IdType("CarePlan", planDefinitionID));
-        given().repositoryFor(fhirContextR4, "r4/opioid-Rec10-patient-view")
+        given().repositoryForWithDataDateRolling(fhirContextR4, "r4/opioid-Rec10-patient-view")
                 .when()
                 .planDefinitionId(planDefinitionID)
                 .subjectId(patientID)

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/TestPlanDefinition.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/TestPlanDefinition.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -44,6 +45,7 @@ import org.opencds.cqf.fhir.cql.EvaluationSettings;
 import org.opencds.cqf.fhir.cr.CrSettings;
 import org.opencds.cqf.fhir.cr.TestOperationProvider;
 import org.opencds.cqf.fhir.cr.common.IOperationProcessor;
+import org.opencds.cqf.fhir.cr.helpers.DataDateRollingIgRepository;
 import org.opencds.cqf.fhir.cr.helpers.DataRequirementsLibrary;
 import org.opencds.cqf.fhir.cr.helpers.GeneratedPackage;
 import org.opencds.cqf.fhir.utility.Ids;
@@ -94,6 +96,22 @@ public class TestPlanDefinition {
         public Given repositoryFor(FhirContext fhirContext, String repositoryPath) {
             this.repository = new IgRepository(
                     fhirContext, Path.of(getResourcePath(this.getClass()) + "/" + CLASS_PATH + "/" + repositoryPath));
+            return this;
+        }
+
+        /**
+         * Like {@link #repositoryFor(FhirContext, String)} but applies the CDC
+         * {@code dataDateRoller} extension to fixtures on read/search. Use this
+         * for tests whose CQL has wall-clock-relative windows
+         * (e.g. {@code Today() - 12 months}) so the data stays inside those
+         * windows regardless of when the test runs. See
+         * {@link org.opencds.cqf.fhir.cr.helpers.DataDateRollerHelper}.
+         */
+        public Given repositoryForWithDataDateRolling(FhirContext fhirContext, String repositoryPath) {
+            this.repository = new DataDateRollingIgRepository(
+                    fhirContext,
+                    Path.of(getResourcePath(this.getClass()) + "/" + CLASS_PATH + "/" + repositoryPath),
+                    LocalDate.now());
             return this;
         }
 


### PR DESCRIPTION
## Summary

`PlanDefinitionProcessorTests.opioidRec10PatientView` started failing on
2026-04-29 with no code change. The opioid-cds CQL gates an "active
prescription" on `Rx.authoredOn 2 years or less on or before Today()`,
and the test fixture's `MedicationRequest.authoredOn: 2024-04-28` slipped
outside that window once today rolled past 2026-04-28. A 2025 commit
(`395b8dd6`) had punted the same problem one year earlier by bumping
`2023 → 2024`. This MR removes the time bomb instead of resetting it.

The fixtures already carry the upstream CDC `dataDateRoller` extension
(`http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/dataDateRoller`)
on every date-sensitive resource — nothing in the codebase honored it
until now. This MR adds a test-only loader that does, and routes the
opioid test through it.

1. New `DataDateRollerHelper` (test-only utility) reads the
   `dataDateRoller` extension on a resource, computes
   `offsetDays = today − dateLastUpdated`, shifts the registered date
   fields, and strips the extension for idempotency.
2. New `DataDateRollingIgRepository` extends `IgRepository` and applies
   the helper on `read`/`search` so consumers see rolled values.
3. New `TestPlanDefinition.repositoryForWithDataDateRolling(...)`
   exposes the rolling repository through the existing `Given` DSL.
   `opioidRec10PatientView` opts in via that method; no other tests are
   affected.
4. The rolling targets are intentionally narrow — only
   `MedicationRequest.authoredOn` plus `dispenseRequest.validityPeriod`
   start/end. `Observation` and `Patient` dates stay put.
5. New unit test walks today from 2026 → 2036 in yearly steps and
   asserts `authoredOn` always lands inside the CQL 2-year window —
   i.e. proves the time bomb is genuinely defused, not just deferred.

No production code is modified; `LibraryEngine` and the `$apply` API
surface are unchanged.

## Code Review Suggestions

- [ ] **Why only MedicationRequest is rolled.** This is the single most
      load-bearing decision in the MR. Rolling Observation effective
      dates uniformly with the same offset moves the cocaine-positive
      observations into the "last 12 months" window, which silently
      flips the recommendation branch from "Annual Urine Screening
      Check" (what the expected fixture asserts) to "Positive Cocaine".
      `Patient.birthDate` is also intentionally untouched — patient age
      is not gated by this CQL. Confirm the narrow scope matches
      what we actually want long-term, and that the Javadoc on
      `ROLLABLE_PATHS` is the right contract for future contributors.
- [ ] **Stripping the extension after rolling.** The helper removes the
      `dataDateRoller` extension once it has rolled the resource, so
      `IgRepository`'s cache returning the same instance on a second
      read does not double-roll. Verify no consumer downstream of
      `IgRepository.read`/`search` actually depends on seeing the
      extension on the rolled resource (none does today by grep, but
      worth a sanity check).
- [ ] **Date arithmetic via the string form, not `java.util.Date`.**
      `rollPrimitive` parses the leading 10 chars as `LocalDate`, adds
      days, and writes back via `setValueAsString` to dodge the
      timezone/DST off-by-one that bit the first cut of these tests.
      Anything that should preserve sub-day precision (an `instant`
      with an actual time component) keeps its tail string verbatim,
      but worth a second look.
- [ ] **`LocalDate.now()` uses the system default zone.** That is
      almost certainly fine for a test, but it does mean the helper's
      "today" may differ by a day from CQL's `Today()` if those run in
      different zones. If that ever bites, `repositoryForWithDataDateRolling`
      should accept an explicit `LocalDate`.
- [ ] **Future-dated `authoredOn`.** When the original `authoredOn`
      sits *after* the `dateLastUpdated` anchor (as it does here:
      anchor 2023-04-28, authoredOn 2024-04-28 because of the prior
      yearly bump), the rolled value lands ~1 year after today. CQL's
      `2 years or less on or before Today()` apparently still treats it
      as in-window in our test, but this is a fixture-quality issue.
      Cleanest follow-up: realign the fixture so `authoredOn ==
      dateLastUpdated`. Worth flagging but not blocking this MR.
- [ ] **DSTU3 / R5 opioid-Rec10 fixtures** carry the same extension but
      are not exercised by any current test. The helper is FHIR-version
      agnostic via `fhirType()` dispatch, so it Just Works if/when
      someone adds those tests, but no one has run that path.

## QA Test Suggestions

### Setup

- Check out the branch, ensure no local changes.
- Set the system clock to **2026-04-29** or later (the rotting date) for
  the negative-control runs.
- Tests live entirely in `cqf-fhir-cr`, so `./gradlew :cqf-fhir-cr:test`
  is the workhorse; `./gradlew spotlessCheck` is the second gate.

### Test cases

- [ ] **Baseline: failing test now passes.** Run
      `./gradlew :cqf-fhir-cr:test --tests "*opioidRec10PatientView"`
      and confirm green. Both `thenApply()` (CarePlan, R4) and
      `thenApplyR5()` (Bundle, R5) assertions exercise the rolling
      path independently.
- [ ] **No regression in the same test class.** Run the full
      `PlanDefinitionProcessorTests` class. The 30+ other tests in
      that file do not opt into rolling and should be unaffected.
- [ ] **No regression in the module.** `./gradlew :cqf-fhir-cr:test`
      should remain green. Pay particular attention to anything under
      `cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/plandefinition/`
      and any test that touches an `IgRepository`.
- [ ] **Time-travel: simulate a date in 2030.** Temporarily set the OS
      clock (or briefly hard-code `LocalDate.of(2030, 1, 1)` in
      `repositoryForWithDataDateRolling`) and re-run the opioid test —
      should still pass. The `DataDateRollerHelperTest` already proves
      this in 2026 → 2036 unit form, but a real test-suite run is the
      strongest QA confirmation.
- [ ] **Time-travel: pin to before the 2023 anchor.** Run with system
      clock set to e.g. 2022-01-01. The helper's `offsetDays` becomes
      negative; the test's expected output still matches because the
      pre-existing fixture dates were already valid for that era.
- [ ] **Cross-timezone smoke test.** Run the test with `TZ=Pacific/Auckland`
      and again with `TZ=America/Los_Angeles`. The string-based date
      arithmetic should produce identical rolled dates regardless of
      offset; if it doesn't, that is a regression from the off-by-one
      we already debugged.
- [ ] **Spotless / build sanity.** `./gradlew spotlessCheck` and the
      full `./gradlew build` should be green.
