### PR TITLE
Pre-validate measure libraries before per-subject CQL evaluation

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureEvaluationResultHandler.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureEvaluationResultHandler.java
@@ -7,7 +7,6 @@ import jakarta.annotation.Nonnull;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.opencds.cqf.cql.engine.execution.CqlEngine;
@@ -111,14 +110,30 @@ public class MeasureEvaluationResultHandler {
         // measure -> subject -> results
         var resultsBuilder = CompositeEvaluationResultsPerMeasure.builder();
 
+        // Pre-validate ValueSet references against the terminology provider before any
+        // per-subject evaluation runs. Libraries with unresolvable ValueSets are recorded with
+        // an error and excluded from the per-subject loop entirely — keeping the original
+        // diagnostic ("Unable to locate ValueSet …") and avoiding wasted per-subject work.
+        var preValidationFailedLibraries =
+                new MeasureLibraryPreValidator(context).validate(multiLibraryIdMeasureEngineDetails, resultsBuilder);
+
+        final List<VersionedIdentifier> activeLibraryIdentifiers =
+                multiLibraryIdMeasureEngineDetails.getLibraryIdentifiers().stream()
+                        .filter(id -> !preValidationFailedLibraries.contains(id))
+                        .toList();
+
         // Library $evaluate each subject
         // The goal here is to do each measure/library evaluation within the context of a single subject.
         // This means that we will not switch between subject contexts while evaluating measures.
         // Once we've switched to a different subject context, the previous expression cache is dropped.
 
-        final List<String> libraryIdentIds = multiLibraryIdMeasureEngineDetails.getLibraryIdentifiers().stream()
+        final List<String> libraryIdentIds = activeLibraryIdentifiers.stream()
                 .map(VersionedIdentifier::getId)
                 .toList();
+
+        if (activeLibraryIdentifiers.isEmpty()) {
+            return resultsBuilder.build();
+        }
 
         logger.atDebug()
                 .setMessage(
@@ -150,7 +165,6 @@ public class MeasureEvaluationResultHandler {
             String subjectIdPart = subjectInfo.getRight();
             context.getState().setContextValue(subjectTypePart, subjectIdPart);
             try {
-                var libraryIdentifiers = multiLibraryIdMeasureEngineDetails.getLibraryIdentifiers();
 
                 final long startPerLibraryPerSubject = System.currentTimeMillis();
                 throttledDebug(shouldLog)
@@ -161,7 +175,7 @@ public class MeasureEvaluationResultHandler {
                 var evaluationResultsForMultiLib = multiLibraryIdMeasureEngineDetails
                         .getLibraryEngine()
                         .getEvaluationResult(
-                                libraryIdentifiers,
+                                activeLibraryIdentifiers,
                                 subjectId,
                                 null,
                                 parametersMap,
@@ -177,7 +191,7 @@ public class MeasureEvaluationResultHandler {
                         .addArgument(() -> showSubsetOfTotal(libraryIdentIds))
                         .log();
 
-                for (var libraryVersionedIdentifier : libraryIdentifiers) {
+                for (var libraryVersionedIdentifier : activeLibraryIdentifiers) {
                     validateEvaluationResultExistsForIdentifier(
                             libraryVersionedIdentifier, evaluationResultsForMultiLib);
 
@@ -186,24 +200,28 @@ public class MeasureEvaluationResultHandler {
                     var measureDefs =
                             multiLibraryIdMeasureEngineDetails.getMeasureDefsForLibrary(libraryVersionedIdentifier);
 
-                    // function evaluation
-                    final List<EvaluationResult> functionEvaluationResults =
-                            FunctionEvaluationHandler.cqlFunctionEvaluation(
-                                    context,
-                                    measureDefs,
-                                    libraryVersionedIdentifier,
-                                    evaluationResult,
-                                    subjectTypePart);
+                    final var libraryException =
+                            evaluationResultsForMultiLib.getExceptionFor(libraryVersionedIdentifier);
+
+                    // Skip function evaluation when the base CQL eval already failed for this
+                    // library/subject. Otherwise the function path (e.g. processNonSubValueStratifier)
+                    // observes missing expression results and throws a higher-level
+                    // "Expression result: <pop> is missing" error that masks the underlying
+                    // CqlException ("Unable to locate ValueSet", etc.) and — by escaping the inner
+                    // loop into the outer catch — pollutes sibling libraries' measure defs.
+                    final List<EvaluationResult> functionEvaluationResults = (libraryException == null)
+                            ? FunctionEvaluationHandler.cqlFunctionEvaluation(
+                                    context, measureDefs, libraryVersionedIdentifier, evaluationResult, subjectTypePart)
+                            : List.of();
 
                     resultsBuilder.addResults(measureDefs, subjectId, evaluationResult, functionEvaluationResults);
 
-                    Optional.ofNullable(evaluationResultsForMultiLib.getExceptionFor(libraryVersionedIdentifier))
-                            .ifPresent(exception -> {
-                                var error = EXCEPTION_FOR_SUBJECT_ID_MESSAGE_TEMPLATE.formatted(
-                                        subjectId, exception.getMessage());
-                                resultsBuilder.addErrors(measureDefs, error);
-                                logger.error(error, exception);
-                            });
+                    if (libraryException != null) {
+                        var error = EXCEPTION_FOR_SUBJECT_ID_MESSAGE_TEMPLATE.formatted(
+                                subjectId, libraryException.getMessage());
+                        resultsBuilder.addErrors(measureDefs, error);
+                        logger.error(error, libraryException);
+                    }
                 }
 
             } catch (Exception e) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureLibraryPreValidator.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureLibraryPreValidator.java
@@ -1,0 +1,150 @@
+package org.opencds.cqf.fhir.cr.measure.common;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.cqframework.cql.cql2elm.CqlCompilerException;
+import org.cqframework.cql.cql2elm.LibraryManager;
+import org.cqframework.cql.cql2elm.model.CompiledLibrary;
+import org.hl7.elm.r1.ValueSetDef;
+import org.hl7.elm.r1.VersionedIdentifier;
+import org.opencds.cqf.cql.engine.execution.CqlEngine;
+import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
+import org.opencds.cqf.cql.engine.terminology.ValueSetInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Static pre-validation pass for measure libraries. Resolves each library, captures fatal compile
+ * errors, and walks the compiled ELM ValueSet references to confirm they exist in the terminology
+ * provider — all before any per-subject CQL evaluation runs.
+ *
+ * <p>Libraries with fatal compile errors or unresolvable ValueSet references are recorded as
+ * errors against their bound measure defs and returned in the failed-set so the caller can
+ * exclude them from per-subject CQL evaluation. This avoids two failure modes that would
+ * otherwise occur at runtime:
+ * <ul>
+ *   <li><b>Diagnostic masking</b>: function-based stratifier evaluation observes missing
+ *       expression results when the IP fails and throws a higher-level
+ *       "Expression result: &lt;pop&gt; is missing" error that hides the underlying cause.</li>
+ *   <li><b>Multi-measure pollution</b>: the masked exception escapes the inner library loop in
+ *       {@link MeasureEvaluationResultHandler} and is caught by the outer subject-scoped
+ *       try/catch, which writes the error to <em>every</em> measure def — including unrelated
+ *       libraries that compiled and would have evaluated cleanly.</li>
+ * </ul>
+ *
+ * <p>Hard library-resolution failures (e.g. {@code CqlIncludeException} for a missing CQL source)
+ * still propagate to the runtime CQL path so existing throw-based contracts in
+ * {@code InvalidMeasureTest} are preserved.
+ */
+public class MeasureLibraryPreValidator {
+
+    private static final Logger logger = LoggerFactory.getLogger(MeasureLibraryPreValidator.class);
+    private static final String EXCEPTION_FOR_LIBRARY_TEMPLATE = "Exception for library: %s, Message: %s";
+
+    private final CqlEngine engine;
+
+    public MeasureLibraryPreValidator(CqlEngine engine) {
+        this.engine = engine;
+    }
+
+    /**
+     * Validate compile-time integrity for every library bound to the given measure defs.
+     *
+     * @param details measure-engine details holding the library-to-measure binding
+     * @param resultsBuilder builder to record per-library validation errors against measure defs
+     * @return library identifiers that failed validation (caller should exclude them from
+     *         per-subject CQL evaluation)
+     */
+    public Set<VersionedIdentifier> validate(
+            MultiLibraryIdMeasureEngineDetails details, CompositeEvaluationResultsPerMeasure.Builder resultsBuilder) {
+
+        var libraryManager = engine.getEnvironment().getLibraryManager();
+        var terminologyProvider = engine.getEnvironment().getTerminologyProvider();
+        var failed = new HashSet<VersionedIdentifier>();
+
+        for (var libraryId : details.getLibraryIdentifiers()) {
+            findFirstFailure(libraryManager, terminologyProvider, libraryId)
+                    .ifPresent(error -> recordLibraryFailure(details, resultsBuilder, libraryId, error, failed));
+        }
+        return failed;
+    }
+
+    private static Optional<RuntimeException> findFirstFailure(
+            LibraryManager libraryManager, TerminologyProvider terminologyProvider, VersionedIdentifier libraryId) {
+
+        var compileErrors = new ArrayList<CqlCompilerException>();
+        CompiledLibrary compiled;
+        try {
+            compiled = libraryManager.resolveLibrary(libraryId, compileErrors);
+        } catch (RuntimeException exception) {
+            // Hard failures (missing library source, etc.) preserve the existing throw-at-runtime
+            // contract for callers that rely on the exception type.
+            return Optional.empty();
+        }
+
+        var firstCompileError = firstFatalCompileError(compileErrors);
+        if (firstCompileError.isPresent()) {
+            return firstCompileError;
+        }
+
+        return findFirstUnresolvableValueSet(terminologyProvider, compiled);
+    }
+
+    private static Optional<RuntimeException> firstFatalCompileError(List<CqlCompilerException> errors) {
+        return errors.stream()
+                .filter(exception -> exception.getSeverity() == CqlCompilerException.ErrorSeverity.Error)
+                .map(RuntimeException.class::cast)
+                .findFirst();
+    }
+
+    private static Optional<RuntimeException> findFirstUnresolvableValueSet(
+            TerminologyProvider terminologyProvider, CompiledLibrary compiled) {
+
+        for (var vsDef : valueSetDefs(compiled)) {
+            var info = toValueSetInfo(vsDef);
+            if (info != null) {
+                try {
+                    terminologyProvider.expand(info);
+                } catch (RuntimeException e) {
+                    return Optional.of(e);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static List<ValueSetDef> valueSetDefs(CompiledLibrary compiled) {
+        if (compiled == null || compiled.getLibrary() == null) {
+            return List.of();
+        }
+        var valueSets = compiled.getLibrary().getValueSets();
+        return valueSets == null ? List.of() : valueSets.getDef();
+    }
+
+    private static ValueSetInfo toValueSetInfo(ValueSetDef vsDef) {
+        if (vsDef.getId() == null) {
+            return null;
+        }
+        var info = new ValueSetInfo().withId(vsDef.getId());
+        if (vsDef.getVersion() != null) {
+            info.setVersion(vsDef.getVersion());
+        }
+        return info;
+    }
+
+    private static void recordLibraryFailure(
+            MultiLibraryIdMeasureEngineDetails details,
+            CompositeEvaluationResultsPerMeasure.Builder resultsBuilder,
+            VersionedIdentifier libraryId,
+            RuntimeException error,
+            Set<VersionedIdentifier> failed) {
+        var measureDefs = details.getMeasureDefsForLibrary(libraryId);
+        var formatted = EXCEPTION_FOR_LIBRARY_TEMPLATE.formatted(libraryId.getId(), error.getMessage());
+        resultsBuilder.addErrors(measureDefs, formatted);
+        logger.error(formatted, error);
+        failed.add(libraryId);
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/MeasureLibraryPreValidatorTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/MeasureLibraryPreValidatorTest.java
@@ -1,0 +1,262 @@
+package org.opencds.cqf.fhir.cr.measure.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import org.cqframework.cql.cql2elm.CqlCompilerException;
+import org.cqframework.cql.cql2elm.CqlSemanticException;
+import org.cqframework.cql.cql2elm.LibraryManager;
+import org.cqframework.cql.cql2elm.model.CompiledLibrary;
+import org.hl7.elm.r1.Library;
+import org.hl7.elm.r1.ValueSetDef;
+import org.hl7.elm.r1.VersionedIdentifier;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.ResourceType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.opencds.cqf.cql.engine.execution.CqlEngine;
+import org.opencds.cqf.cql.engine.execution.Environment;
+import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
+import org.opencds.cqf.cql.engine.terminology.ValueSetInfo;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MeasureLibraryPreValidatorTest {
+
+    private static final VersionedIdentifier LIB_A = new VersionedIdentifier().withId("LibA");
+    private static final VersionedIdentifier LIB_B = new VersionedIdentifier().withId("LibB");
+    private static final VersionedIdentifier LIB_C = new VersionedIdentifier().withId("LibC");
+
+    private static final MeasureDef MEASURE_DEF_A = measureDef("MeasureA");
+    private static final MeasureDef MEASURE_DEF_B = measureDef("MeasureB");
+    private static final MeasureDef MEASURE_DEF_C = measureDef("MeasureC");
+
+    @Mock
+    private CqlEngine engine;
+
+    @Mock
+    private Environment environment;
+
+    @Mock
+    private LibraryManager libraryManager;
+
+    @Mock
+    private TerminologyProvider terminologyProvider;
+
+    private MeasureLibraryPreValidator subject;
+
+    @BeforeEach
+    void setUp() {
+        when(engine.getEnvironment()).thenReturn(environment);
+        when(environment.getLibraryManager()).thenReturn(libraryManager);
+        when(environment.getTerminologyProvider()).thenReturn(terminologyProvider);
+        subject = new MeasureLibraryPreValidator(engine);
+    }
+
+    @Test
+    void noLibraries_returnsEmptyFailedSet() {
+        var details = MultiLibraryIdMeasureEngineDetails.builder(null).build();
+        var resultsBuilder = CompositeEvaluationResultsPerMeasure.builder();
+
+        var failed = subject.validate(details, resultsBuilder);
+
+        assertTrue(failed.isEmpty());
+        assertTrue(resultsBuilder.build().getErrorsPerMeasure().isEmpty());
+    }
+
+    @Test
+    void cleanLibrary_withNoValueSets_passes() {
+        var details = detailsFor(LIB_A, MEASURE_DEF_A);
+        when(libraryManager.resolveLibrary(eq(LIB_A), anyList())).thenReturn(compiledWithoutValueSets());
+        var resultsBuilder = CompositeEvaluationResultsPerMeasure.builder();
+
+        var failed = subject.validate(details, resultsBuilder);
+
+        assertTrue(failed.isEmpty());
+        assertTrue(resultsBuilder.build().getErrorsPerMeasure().isEmpty());
+        verify(terminologyProvider, never()).expand(any());
+    }
+
+    @Test
+    void fatalCompileError_flagsLibraryAndRecordsError() {
+        var details = detailsFor(LIB_A, MEASURE_DEF_A);
+        var compileError = new CqlSemanticException(
+                "symbol foo not defined", null, CqlCompilerException.ErrorSeverity.Error, null);
+        when(libraryManager.resolveLibrary(eq(LIB_A), anyList())).thenAnswer(inv -> {
+            List<CqlCompilerException> errors = inv.getArgument(1);
+            errors.add(compileError);
+            return compiledWithoutValueSets();
+        });
+        var resultsBuilder = CompositeEvaluationResultsPerMeasure.builder();
+
+        var failed = subject.validate(details, resultsBuilder);
+
+        assertEquals(Set.of(LIB_A), failed);
+        var errorsForA = resultsBuilder.build().getErrorsPerMeasure().get(MEASURE_DEF_A);
+        assertEquals(1, errorsForA.size());
+        assertTrue(errorsForA.get(0).contains("Exception for library: LibA"));
+        assertTrue(errorsForA.get(0).contains("symbol foo not defined"));
+    }
+
+    @Test
+    void warningOnlyCompileErrors_doNotFlagLibrary() {
+        var details = detailsFor(LIB_A, MEASURE_DEF_A);
+        var warning =
+                new CqlSemanticException("deprecated function", null, CqlCompilerException.ErrorSeverity.Warning, null);
+        var info = new CqlSemanticException("info note", null, CqlCompilerException.ErrorSeverity.Info, null);
+        when(libraryManager.resolveLibrary(eq(LIB_A), anyList())).thenAnswer(inv -> {
+            List<CqlCompilerException> errors = inv.getArgument(1);
+            errors.add(warning);
+            errors.add(info);
+            return compiledWithoutValueSets();
+        });
+        var resultsBuilder = CompositeEvaluationResultsPerMeasure.builder();
+
+        var failed = subject.validate(details, resultsBuilder);
+
+        assertTrue(failed.isEmpty());
+        assertTrue(resultsBuilder.build().getErrorsPerMeasure().isEmpty());
+    }
+
+    @Test
+    void unresolvableValueSet_flagsLibraryAndRecordsError() {
+        var details = detailsFor(LIB_A, MEASURE_DEF_A);
+        when(libraryManager.resolveLibrary(eq(LIB_A), anyList()))
+                .thenReturn(compiledWithValueSets("http://example.com/ValueSet/missing"));
+        when(terminologyProvider.expand(any(ValueSetInfo.class)))
+                .thenThrow(
+                        new IllegalArgumentException("Unable to locate ValueSet http://example.com/ValueSet/missing"));
+        var resultsBuilder = CompositeEvaluationResultsPerMeasure.builder();
+
+        var failed = subject.validate(details, resultsBuilder);
+
+        assertEquals(Set.of(LIB_A), failed);
+        var errorsForA = resultsBuilder.build().getErrorsPerMeasure().get(MEASURE_DEF_A);
+        assertEquals(1, errorsForA.size());
+        assertTrue(errorsForA.get(0).contains("Exception for library: LibA"));
+        assertTrue(errorsForA.get(0).contains("Unable to locate ValueSet"));
+    }
+
+    @Test
+    void resolveLibraryThrowing_fallsThroughToRuntime() {
+        var details = detailsFor(LIB_A, MEASURE_DEF_A);
+        when(libraryManager.resolveLibrary(eq(LIB_A), anyList()))
+                .thenThrow(new IllegalStateException("hard library-resolution failure"));
+        var resultsBuilder = CompositeEvaluationResultsPerMeasure.builder();
+
+        var failed = subject.validate(details, resultsBuilder);
+
+        assertTrue(failed.isEmpty());
+        assertTrue(resultsBuilder.build().getErrorsPerMeasure().isEmpty());
+        verify(terminologyProvider, never()).expand(any());
+    }
+
+    @Test
+    void firstValueSetFailure_shortCircuitsRemainingChecks() {
+        var details = detailsFor(LIB_A, MEASURE_DEF_A);
+        when(libraryManager.resolveLibrary(eq(LIB_A), anyList()))
+                .thenReturn(compiledWithValueSets(
+                        "http://example.com/ValueSet/missing-1", "http://example.com/ValueSet/missing-2"));
+        when(terminologyProvider.expand(any(ValueSetInfo.class)))
+                .thenThrow(new IllegalArgumentException(
+                        "Unable to locate ValueSet http://example.com/ValueSet/missing-1"));
+        var resultsBuilder = CompositeEvaluationResultsPerMeasure.builder();
+
+        var failed = subject.validate(details, resultsBuilder);
+
+        assertEquals(Set.of(LIB_A), failed);
+        // Exactly one error recorded — the validator stops at the first unresolvable ValueSet.
+        var errorsForA = resultsBuilder.build().getErrorsPerMeasure().get(MEASURE_DEF_A);
+        assertEquals(1, errorsForA.size());
+        verify(terminologyProvider).expand(any(ValueSetInfo.class));
+    }
+
+    @Test
+    void valueSetDefWithNullId_isSkippedNotFailed() {
+        var details = detailsFor(LIB_A, MEASURE_DEF_A);
+        var library = new Library();
+        var valueSets = new Library.ValueSets();
+        valueSets.getDef().add(new ValueSetDef()); // id deliberately left null
+        library.setValueSets(valueSets);
+        var compiled = new CompiledLibrary();
+        compiled.setLibrary(library);
+        when(libraryManager.resolveLibrary(eq(LIB_A), anyList())).thenReturn(compiled);
+        var resultsBuilder = CompositeEvaluationResultsPerMeasure.builder();
+
+        var failed = subject.validate(details, resultsBuilder);
+
+        assertTrue(failed.isEmpty());
+        assertTrue(resultsBuilder.build().getErrorsPerMeasure().isEmpty());
+        verify(terminologyProvider, never()).expand(any());
+    }
+
+    @Test
+    void multipleLibraries_isolation_onlyFailingOneFlagged() {
+        var details = MultiLibraryIdMeasureEngineDetails.builder(null)
+                .addLibraryIdToMeasureId(LIB_A, MEASURE_DEF_A)
+                .addLibraryIdToMeasureId(LIB_B, MEASURE_DEF_B)
+                .addLibraryIdToMeasureId(LIB_C, MEASURE_DEF_C)
+                .build();
+        when(libraryManager.resolveLibrary(eq(LIB_A), anyList())).thenReturn(compiledWithoutValueSets());
+        when(libraryManager.resolveLibrary(eq(LIB_B), anyList()))
+                .thenReturn(compiledWithValueSets("http://example.com/ValueSet/b-missing"));
+        when(libraryManager.resolveLibrary(eq(LIB_C), anyList())).thenReturn(compiledWithoutValueSets());
+        when(terminologyProvider.expand(any(ValueSetInfo.class)))
+                .thenThrow(new IllegalArgumentException(
+                        "Unable to locate ValueSet http://example.com/ValueSet/b-missing"));
+        var resultsBuilder = CompositeEvaluationResultsPerMeasure.builder();
+
+        var failed = subject.validate(details, resultsBuilder);
+
+        assertEquals(Set.of(LIB_B), failed);
+        var errorsPerMeasure = resultsBuilder.build().getErrorsPerMeasure();
+        // Only B receives an error; A and C remain untouched.
+        assertFalse(errorsPerMeasure.containsKey(MEASURE_DEF_A));
+        assertFalse(errorsPerMeasure.containsKey(MEASURE_DEF_C));
+        var errorsForB = errorsPerMeasure.get(MEASURE_DEF_B);
+        assertEquals(1, errorsForB.size());
+        assertTrue(errorsForB.get(0).contains("Unable to locate ValueSet"));
+    }
+
+    private static MultiLibraryIdMeasureEngineDetails detailsFor(VersionedIdentifier libraryId, MeasureDef measureDef) {
+        return MultiLibraryIdMeasureEngineDetails.builder(null)
+                .addLibraryIdToMeasureId(libraryId, measureDef)
+                .build();
+    }
+
+    private static MeasureDef measureDef(String id) {
+        return MeasureDef.fromIdAndUrl(new IdType(ResourceType.Measure.name(), id), "http://example.com/Measure/" + id);
+    }
+
+    private static CompiledLibrary compiledWithoutValueSets() {
+        var compiled = new CompiledLibrary();
+        compiled.setLibrary(new Library());
+        return compiled;
+    }
+
+    private static CompiledLibrary compiledWithValueSets(String... urls) {
+        var library = new Library();
+        var valueSets = new Library.ValueSets();
+        for (var url : urls) {
+            valueSets.getDef().add(new ValueSetDef().withId(url));
+        }
+        library.setValueSets(valueSets);
+        var compiled = new CompiledLibrary();
+        compiled.setLibrary(library);
+        return compiled;
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/InvalidMeasureTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/InvalidMeasureTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import org.cqframework.cql.cql2elm.CqlIncludeException;
+import org.hl7.fhir.r4.model.MeasureReport.MeasureReportStatus;
 import org.junit.jupiter.api.Test;
 import org.opencds.cqf.fhir.cr.measure.r4.Measure.Given;
 
@@ -51,5 +52,81 @@ class InvalidMeasureTest {
         assertTrue(e.getMessage().contains("Duplicate population ID"));
         assertTrue(e.getMessage().contains("initial-population"));
         assertTrue(e.getMessage().contains("group-1"));
+    }
+
+    /**
+     * Cohort encounter-basis measure whose CQL references a ValueSet that is not present in the
+     * IG (no vocabulary/valueset entry). Pre-validation in {@link
+     * org.opencds.cqf.fhir.cr.measure.common.MeasureLibraryPreValidator} resolves the library,
+     * walks its ELM ValueSet refs, and surfaces the engine-level "Unable to locate ValueSet"
+     * diagnostic as a contained OperationOutcome with status=ERROR — without ever entering the
+     * per-subject CQL evaluation loop.
+     */
+    @Test
+    void cohortEncounterMissingValueSet() {
+        GIVEN_INVALID_MEASURE_REPO
+                .when()
+                .measureId("CohortEncounterMissingValueSet")
+                .evaluate()
+                .then()
+                .hasStatus(MeasureReportStatus.ERROR)
+                .hasContainedOperationOutcome()
+                .hasContainedOperationOutcomeMsg("Unable to locate ValueSet");
+    }
+
+    /**
+     * Same library/CQL as {@link #cohortEncounterMissingValueSet()} with an added stratifier
+     * referencing a simple scalar expression ("Patient Gender String"). Confirms the
+     * unresolvable-ValueSet diagnostic still surfaces when an otherwise-valid scalar
+     * stratifier is present.
+     */
+    @Test
+    void cohortEncounterMissingValueSetWithScalarStratifier() {
+        GIVEN_INVALID_MEASURE_REPO
+                .when()
+                .measureId("CohortEncounterMissingValueSetStrat")
+                .evaluate()
+                .then()
+                .hasStatus(MeasureReportStatus.ERROR)
+                .hasContainedOperationOutcome()
+                .hasContainedOperationOutcomeMsg("Unable to locate ValueSet");
+    }
+
+    /**
+     * Variant of {@link #cohortEncounterMissingValueSetWithScalarStratifier()} where the
+     * stratifier is expressed as a value/component stratifier (stratifier.component[].criteria)
+     * referencing the same scalar expression instead of a top-level stratifier.criteria.
+     */
+    @Test
+    void cohortEncounterMissingValueSetWithComponentStratifier() {
+        GIVEN_INVALID_MEASURE_REPO
+                .when()
+                .measureId("CohortEncounterMissingValueSetStratComponent")
+                .evaluate()
+                .then()
+                .hasStatus(MeasureReportStatus.ERROR)
+                .hasContainedOperationOutcome()
+                .hasContainedOperationOutcomeMsg("Unable to locate ValueSet");
+    }
+
+    /**
+     * Variant of {@link #cohortEncounterMissingValueSetWithComponentStratifier()} where the
+     * component stratifier expression is a CQL function ("Encounter Status Function") taking an
+     * Encounter parameter, rather than a non-function scalar expression. Without pre-validation,
+     * this case used to mask the underlying CqlException with a higher-level "Expression result:
+     * Initial Population is missing" diagnostic; pre-validation now drops the library before
+     * function evaluation runs, so the engine-level diagnostic surfaces uniformly across all
+     * stratifier shapes.
+     */
+    @Test
+    void cohortEncounterMissingValueSetWithFunctionStratifier() {
+        GIVEN_INVALID_MEASURE_REPO
+                .when()
+                .measureId("CohortEncounterMissingValueSetStratFunction")
+                .evaluate()
+                .then()
+                .hasStatus(MeasureReportStatus.ERROR)
+                .hasContainedOperationOutcome()
+                .hasContainedOperationOutcomeMsg("Unable to locate ValueSet");
     }
 }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasureIsolationTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasureIsolationTest.java
@@ -1,0 +1,77 @@
+package org.opencds.cqf.fhir.cr.measure.r4;
+
+import org.hl7.fhir.r4.model.MeasureReport.MeasureReportStatus;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.cr.measure.common.MeasurePopulationType;
+import org.opencds.cqf.fhir.cr.measure.r4.MultiMeasure.Given;
+
+/**
+ * Verifies multi-measure / multi-library isolation when one library has unresolvable dependencies
+ * (here: a missing ValueSet) and the others are clean. The failing measure must surface its
+ * underlying CqlException as a contained OperationOutcome with status=ERROR; the clean measures
+ * must complete normally with COMPLETE status, no contained OperationOutcome, and their
+ * function-based stratifier strata populated.
+ */
+@SuppressWarnings("squid:S2699")
+class MultiMeasureIsolationTest {
+
+    private static final Given GIVEN_REPO = MultiMeasure.given().repositoryFor("MeasureStratifierTest");
+
+    /**
+     * Three measures share an evaluation:
+     * - A (clean): MultiMeasureCleanA, encounter basis, function-component stratifier.
+     * - B (broken): MultiMeasureBrokenLibraryB — IP references a ValueSet not present in the IG;
+     *   component stratifier expression is a CQL function taking an Encounter.
+     * - C (clean): MultiMeasureCleanC, identical shape to A.
+     *
+     * <p>Asserts:
+     * - A's MeasureReport is COMPLETE with no contained OperationOutcome and a populated stratifier.
+     * - B's MeasureReport is ERROR with a contained OperationOutcome whose diagnostic contains
+     *   "Unable to locate ValueSet" — i.e. B's failure must surface the engine-level message,
+     *   not the masking "Expression result: Initial Population is missing" diagnostic.
+     * - C's MeasureReport is COMPLETE with no contained OperationOutcome and a populated stratifier.
+     *
+     * <p>This guards both: (1) the diagnostic-shape fix for function-based stratifiers, and (2) the
+     * multi-measure isolation property — a failure in one library must not poison sibling reports
+     * or short-circuit their evaluation.
+     */
+    @Test
+    void oneFailingLibraryDoesNotPoisonSiblings() {
+        var when = GIVEN_REPO
+                .when()
+                .measureId("MultiMeasureCleanA")
+                .measureId("MultiMeasureBrokenLibraryB")
+                .measureId("MultiMeasureCleanC")
+                .periodStart("2024-01-01")
+                .periodEnd("2024-12-31")
+                .reportType("population")
+                .evaluate();
+
+        var then = when.then().hasMeasureReportCount(3);
+
+        // Measure A: clean — must complete without errors and populate stratifier strata.
+        then.measureReport("http://example.com/Measure/MultiMeasureCleanA")
+                .hasMeasureReportStatus(MeasureReportStatus.COMPLETE)
+                .hasContainedResourceCount(0)
+                .firstGroup()
+                .population(MeasurePopulationType.INITIALPOPULATION)
+                .up()
+                .firstStratifier();
+
+        // Measure B: broken — must surface the underlying CqlException via contained OperationOutcome.
+        then.measureReport("http://example.com/Measure/MultiMeasureBrokenLibraryB")
+                .hasMeasureReportStatus(MeasureReportStatus.ERROR)
+                .hasContainedOperationOutcome()
+                .hasContainedOperationOutcomeMsg("Unable to locate ValueSet");
+
+        // Measure C: clean — must complete without errors and populate stratifier strata,
+        // proving the loop did not short-circuit on Measure B.
+        then.measureReport("http://example.com/Measure/MultiMeasureCleanC")
+                .hasMeasureReportStatus(MeasureReportStatus.COMPLETE)
+                .hasContainedResourceCount(0)
+                .firstGroup()
+                .population(MeasurePopulationType.INITIALPOPULATION)
+                .up()
+                .firstStratifier();
+    }
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/InvalidMeasure/input/cql/CohortEncounterMissingValueSet.cql
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/InvalidMeasure/input/cql/CohortEncounterMissingValueSet.cql
@@ -1,0 +1,22 @@
+library CohortEncounterMissingValueSet
+
+using FHIR version '4.0.1'
+
+include FHIRHelpers version '4.0.1' called FHIRHelpers
+
+valueset "Encounter Status Missing": 'http://example.com/ValueSet/encounter-status-missing'
+
+parameter "Measurement Period" Interval<DateTime>
+  default Interval[@2024-01-01T00:00:00, @2024-12-31T23:59:59]
+
+context Patient
+
+define "Initial Population":
+  [Encounter] E
+    where E.status in "Encounter Status Missing"
+
+define "Patient Gender String":
+  Patient.gender.value
+
+define function "Encounter Status Function"(encounter Encounter):
+  encounter.status.value

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/InvalidMeasure/input/resources/library/CohortEncounterMissingValueSet.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/InvalidMeasure/input/resources/library/CohortEncounterMissingValueSet.json
@@ -1,0 +1,21 @@
+{
+  "resourceType": "Library",
+  "id": "CohortEncounterMissingValueSet",
+  "url": "http://example.com/Library/CohortEncounterMissingValueSet",
+  "name": "CohortEncounterMissingValueSet",
+  "status": "active",
+  "type": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/library-type",
+        "code": "logic-library"
+      }
+    ]
+  },
+  "content": [
+    {
+      "contentType": "text/cql",
+      "url": "../../cql/CohortEncounterMissingValueSet.cql"
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/InvalidMeasure/input/resources/measure/CohortEncounterMissingValueSet.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/InvalidMeasure/input/resources/measure/CohortEncounterMissingValueSet.json
@@ -1,0 +1,47 @@
+{
+  "resourceType": "Measure",
+  "id": "CohortEncounterMissingValueSet",
+  "url": "http://example.com/Measure/CohortEncounterMissingValueSet",
+  "name": "CohortEncounterMissingValueSet",
+  "status": "active",
+  "library": [
+    "http://example.com/Library/CohortEncounterMissingValueSet"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "Encounter"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/InvalidMeasure/input/resources/measure/CohortEncounterMissingValueSetStrat.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/InvalidMeasure/input/resources/measure/CohortEncounterMissingValueSetStrat.json
@@ -1,0 +1,59 @@
+{
+  "resourceType": "Measure",
+  "id": "CohortEncounterMissingValueSetStrat",
+  "url": "http://example.com/Measure/CohortEncounterMissingValueSetStrat",
+  "name": "CohortEncounterMissingValueSetStrat",
+  "status": "active",
+  "library": [
+    "http://example.com/Library/CohortEncounterMissingValueSet"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "Encounter"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population"
+          }
+        }
+      ],
+      "stratifier": [
+        {
+          "id": "stratifier-gender",
+          "code": {
+            "text": "Patient Gender"
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Patient Gender String"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/InvalidMeasure/input/resources/measure/CohortEncounterMissingValueSetStratComponent.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/InvalidMeasure/input/resources/measure/CohortEncounterMissingValueSetStratComponent.json
@@ -1,0 +1,67 @@
+{
+  "resourceType": "Measure",
+  "id": "CohortEncounterMissingValueSetStratComponent",
+  "url": "http://example.com/Measure/CohortEncounterMissingValueSetStratComponent",
+  "name": "CohortEncounterMissingValueSetStratComponent",
+  "status": "active",
+  "library": [
+    "http://example.com/Library/CohortEncounterMissingValueSet"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "Encounter"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population"
+          }
+        }
+      ],
+      "stratifier": [
+        {
+          "id": "stratifier-gender",
+          "code": {
+            "text": "Patient Gender"
+          },
+          "component": [
+            {
+              "id": "stratifier-gender-comp-1",
+              "code": {
+                "text": "Patient Gender"
+              },
+              "criteria": {
+                "language": "text/cql-identifier",
+                "expression": "Patient Gender String"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/InvalidMeasure/input/resources/measure/CohortEncounterMissingValueSetStratFunction.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/InvalidMeasure/input/resources/measure/CohortEncounterMissingValueSetStratFunction.json
@@ -1,0 +1,67 @@
+{
+  "resourceType": "Measure",
+  "id": "CohortEncounterMissingValueSetStratFunction",
+  "url": "http://example.com/Measure/CohortEncounterMissingValueSetStratFunction",
+  "name": "CohortEncounterMissingValueSetStratFunction",
+  "status": "active",
+  "library": [
+    "http://example.com/Library/CohortEncounterMissingValueSet"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "Encounter"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population"
+          }
+        }
+      ],
+      "stratifier": [
+        {
+          "id": "stratifier-encounter-status",
+          "code": {
+            "text": "Encounter Status"
+          },
+          "component": [
+            {
+              "id": "stratifier-encounter-status-comp-1",
+              "code": {
+                "text": "Encounter Status"
+              },
+              "criteria": {
+                "language": "text/cql-identifier",
+                "expression": "Encounter Status Function"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/cql/MultiMeasureBrokenLibraryB.cql
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/cql/MultiMeasureBrokenLibraryB.cql
@@ -1,0 +1,19 @@
+library MultiMeasureBrokenLibraryB
+
+using FHIR version '4.0.1'
+
+include FHIRHelpers version '4.0.1' called FHIRHelpers
+
+valueset "Encounter Status Missing": 'http://example.com/ValueSet/multi-measure-broken-b-missing'
+
+parameter "Measurement Period" Interval<DateTime>
+  default Interval[@2024-01-01T00:00:00, @2024-12-31T23:59:59]
+
+context Patient
+
+define "Initial Population":
+  [Encounter] E
+    where E.status in "Encounter Status Missing"
+
+define function "Encounter Status Function"(encounter Encounter):
+  encounter.status.value

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/cql/MultiMeasureCleanA.cql
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/cql/MultiMeasureCleanA.cql
@@ -1,0 +1,16 @@
+library MultiMeasureCleanA
+
+using FHIR version '4.0.1'
+
+include FHIRHelpers version '4.0.1' called FHIRHelpers
+
+parameter "Measurement Period" Interval<DateTime>
+  default Interval[@2024-01-01T00:00:00, @2024-12-31T23:59:59]
+
+context Patient
+
+define "Initial Population":
+  [Encounter] E
+
+define function "Encounter Status Function"(encounter Encounter):
+  encounter.status.value

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/cql/MultiMeasureCleanC.cql
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/cql/MultiMeasureCleanC.cql
@@ -1,0 +1,16 @@
+library MultiMeasureCleanC
+
+using FHIR version '4.0.1'
+
+include FHIRHelpers version '4.0.1' called FHIRHelpers
+
+parameter "Measurement Period" Interval<DateTime>
+  default Interval[@2024-01-01T00:00:00, @2024-12-31T23:59:59]
+
+context Patient
+
+define "Initial Population":
+  [Encounter] E
+
+define function "Encounter Status Function"(encounter Encounter):
+  encounter.status.value

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/library/MultiMeasureBrokenLibraryB.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/library/MultiMeasureBrokenLibraryB.json
@@ -1,0 +1,21 @@
+{
+  "resourceType": "Library",
+  "id": "MultiMeasureBrokenLibraryB",
+  "url": "http://example.com/Library/MultiMeasureBrokenLibraryB",
+  "name": "MultiMeasureBrokenLibraryB",
+  "status": "active",
+  "type": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/library-type",
+        "code": "logic-library"
+      }
+    ]
+  },
+  "content": [
+    {
+      "contentType": "text/cql",
+      "url": "../../cql/MultiMeasureBrokenLibraryB.cql"
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/library/MultiMeasureCleanA.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/library/MultiMeasureCleanA.json
@@ -1,0 +1,21 @@
+{
+  "resourceType": "Library",
+  "id": "MultiMeasureCleanA",
+  "url": "http://example.com/Library/MultiMeasureCleanA",
+  "name": "MultiMeasureCleanA",
+  "status": "active",
+  "type": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/library-type",
+        "code": "logic-library"
+      }
+    ]
+  },
+  "content": [
+    {
+      "contentType": "text/cql",
+      "url": "../../cql/MultiMeasureCleanA.cql"
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/library/MultiMeasureCleanC.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/library/MultiMeasureCleanC.json
@@ -1,0 +1,21 @@
+{
+  "resourceType": "Library",
+  "id": "MultiMeasureCleanC",
+  "url": "http://example.com/Library/MultiMeasureCleanC",
+  "name": "MultiMeasureCleanC",
+  "status": "active",
+  "type": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/library-type",
+        "code": "logic-library"
+      }
+    ]
+  },
+  "content": [
+    {
+      "contentType": "text/cql",
+      "url": "../../cql/MultiMeasureCleanC.cql"
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/measure/MultiMeasureBrokenLibraryB.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/measure/MultiMeasureBrokenLibraryB.json
@@ -1,0 +1,67 @@
+{
+  "resourceType": "Measure",
+  "id": "MultiMeasureBrokenLibraryB",
+  "url": "http://example.com/Measure/MultiMeasureBrokenLibraryB",
+  "name": "MultiMeasureBrokenLibraryB",
+  "status": "active",
+  "library": [
+    "http://example.com/Library/MultiMeasureBrokenLibraryB"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "Encounter"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population"
+          }
+        }
+      ],
+      "stratifier": [
+        {
+          "id": "stratifier-encounter-status",
+          "code": {
+            "text": "Encounter Status"
+          },
+          "component": [
+            {
+              "id": "stratifier-encounter-status-comp-1",
+              "code": {
+                "text": "Encounter Status"
+              },
+              "criteria": {
+                "language": "text/cql-identifier",
+                "expression": "Encounter Status Function"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/measure/MultiMeasureCleanA.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/measure/MultiMeasureCleanA.json
@@ -1,0 +1,67 @@
+{
+  "resourceType": "Measure",
+  "id": "MultiMeasureCleanA",
+  "url": "http://example.com/Measure/MultiMeasureCleanA",
+  "name": "MultiMeasureCleanA",
+  "status": "active",
+  "library": [
+    "http://example.com/Library/MultiMeasureCleanA"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "Encounter"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population"
+          }
+        }
+      ],
+      "stratifier": [
+        {
+          "id": "stratifier-encounter-status",
+          "code": {
+            "text": "Encounter Status"
+          },
+          "component": [
+            {
+              "id": "stratifier-encounter-status-comp-1",
+              "code": {
+                "text": "Encounter Status"
+              },
+              "criteria": {
+                "language": "text/cql-identifier",
+                "expression": "Encounter Status Function"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/measure/MultiMeasureCleanC.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/measure/MultiMeasureCleanC.json
@@ -1,0 +1,67 @@
+{
+  "resourceType": "Measure",
+  "id": "MultiMeasureCleanC",
+  "url": "http://example.com/Measure/MultiMeasureCleanC",
+  "name": "MultiMeasureCleanC",
+  "status": "active",
+  "library": [
+    "http://example.com/Library/MultiMeasureCleanC"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "Encounter"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population"
+          }
+        }
+      ],
+      "stratifier": [
+        {
+          "id": "stratifier-encounter-status",
+          "code": {
+            "text": "Encounter Status"
+          },
+          "component": [
+            {
+              "id": "stratifier-encounter-status-comp-1",
+              "code": {
+                "text": "Encounter Status"
+              },
+              "criteria": {
+                "language": "text/cql-identifier",
+                "expression": "Encounter Status Function"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Measures whose CQL referenced an unresolvable ValueSet (or had other fatal compile errors) failed in two awkward ways. With a function-based component stratifier, `FunctionEvaluationHandler.processNonSubValueStratifier` observed missing expression results when the IP failed and threw `"Expression result: Initial Population is missing"` — masking the underlying `CqlException`. In a multi-measure evaluation that masking exception then escaped the per-library inner loop in `MeasureEvaluationResultHandler` and was caught by the outer subject-scoped `try/catch`, which wrote the error to **every** measure def — poisoning unrelated libraries that would otherwise have evaluated cleanly. This MR introduces an upfront library-validation pass and a complementary runtime safety net so library failures are isolated and the engine-level diagnostic surfaces uniformly across all stratifier shapes.

1. **Library pre-validation before per-subject evaluation**: A new `MeasureLibraryPreValidator` resolves each library via `LibraryManager.resolveLibrary(id, errors)`, surfaces any severity=Error compile diagnostics, and walks the compiled ELM `valueSetDef` references against the engine's `TerminologyProvider`. Libraries that fail are recorded with the engine-level diagnostic and removed from the per-subject loop entirely. Hard library-resolution failures (`CqlIncludeException`, etc.) are deliberately allowed to propagate so the existing throw-based contracts in `InvalidMeasureTest.evaluateThrowsErrorWhenLibraryIsMissingContent` are preserved.

2. **Per-library exception check before function-evaluation handler**: In `MeasureEvaluationResultHandler.getEvaluationResults`, the per-library inner loop now reads `evaluationResultsForMultiLib.getExceptionFor(libraryVersionedIdentifier)` *before* calling `FunctionEvaluationHandler.cqlFunctionEvaluation`. Function evaluation is skipped when the base CQL eval already failed, so any per-subject exception that slips past pre-validation reaches the existing per-subject error path instead of being masked by the function handler — and crucially, no longer escapes to the outer subject-scoped catch where it would pollute sibling measure defs.

3. **Multi-measure isolation guarantee**: When one library in a multi-measure evaluation has unresolvable references, only that library's measure(s) are flagged. Sibling measures continue to evaluate normally — including their function-based stratifiers — and produce `status=COMPLETE` reports without spurious contained `OperationOutcome` entries.


Closes:  https://github.com/cqframework/clinical-reasoning/issues/1022