### PR TITLE
When a `Code` without system is passed in to `in`, check only the code value and throw if the resolved value set contains codes from multiple code systems

### DIFF
--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/terminology/RepositoryTerminologyProvider.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/terminology/RepositoryTerminologyProvider.java
@@ -97,12 +97,22 @@ public class RepositoryTerminologyProvider implements TerminologyProvider {
 
         List<Code> codes = this.expand(valueSet);
 
+        if (code.getSystem() == null) {
+            // If the system is not provided and the resolved value set contains codes from multiple code systems, a
+            // run-time error is thrown because the operation is ambiguous
+            var distinctSystems = codes.stream().map(Code::getSystem).distinct().count();
+            if (distinctSystems > 1) {
+                throw new IllegalArgumentException(
+                        "The 'in' operation is ambiguous because the the code system is not provided and the resolved value set contains codes from multiple code systems");
+            }
+        }
+
         // This range includes all codes that have an equivalent code value,
         // So we only need to check the code system.
         Range range = this.getSearchRange(code, codes);
         for (int i = range.start; i < range.end; i++) {
             var c = codes.get(i);
-            if (c.getSystem().equals(code.getSystem())) {
+            if (code.getSystem() == null || c.getSystem().equals(code.getSystem())) {
                 return true;
             }
         }

--- a/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/engine/terminology/RepositoryTerminologyProviderTest.java
+++ b/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/engine/terminology/RepositoryTerminologyProviderTest.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.fhir.cql.engine.terminology;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -24,6 +25,7 @@ class RepositoryTerminologyProviderTest {
     private static final String VALID_VALUE_SET_URL = "http://example.com/ValueSet/ValidValueSet";
     private static final String MISSING_SYSTEM_VALUE_SET_URL = "http://example.com/ValueSet/MissingSystemValueSet";
     private static final String MISSING_CODE_VALUE_SET_URL = "http://example.com/ValueSet/MissingCodeValueSet";
+    private static final String MULTIPLE_SYSTEMS_VALUE_SET_URL = "http://example.com/ValueSet/MultipleSystemsValueSet";
 
     @Test
     void validCodesInValueSet() {
@@ -38,6 +40,15 @@ class RepositoryTerminologyProviderTest {
     }
 
     @Test
+    void failOnCodeWithoutSystemAndMultiSystemValueSet() {
+        var terminologyProvider = terminologyProviderWith("MultipleSystemsValueSet");
+        var vsInfo = new ValueSetInfo().withId(MULTIPLE_SYSTEMS_VALUE_SET_URL);
+
+        var code = new Code().withCode("123");
+        assertThrows(IllegalArgumentException.class, () -> terminologyProvider.in(code, vsInfo));
+    }
+
+    @Test
     void missingCodeValueSetMatches() {
         var terminologyProvider = terminologyProviderWith("MissingCodeValueSet");
         var vsInfo = new ValueSetInfo().withId(MISSING_CODE_VALUE_SET_URL);
@@ -49,7 +60,7 @@ class RepositoryTerminologyProviderTest {
         assertFalse(terminologyProvider.in(codeMissingCode, vsInfo));
 
         var codeMissingSystem = new Code().withCode("123");
-        assertFalse(terminologyProvider.in(codeMissingSystem, vsInfo));
+        assertTrue(terminologyProvider.in(codeMissingSystem, vsInfo));
     }
 
     @Test
@@ -64,7 +75,7 @@ class RepositoryTerminologyProviderTest {
         assertFalse(terminologyProvider.in(codeMissingCode, vsInfo));
 
         var codeMissingSystem = new Code().withCode("123");
-        assertFalse(terminologyProvider.in(codeMissingSystem, vsInfo));
+        assertTrue(terminologyProvider.in(codeMissingSystem, vsInfo));
     }
 
     IRepository mockRepositoryFor(String id) {

--- a/cqf-fhir-cql/src/test/resources/org/opencds/cqf/fhir/cql/engine/terminology/MultipleSystemsValueSet.json
+++ b/cqf-fhir-cql/src/test/resources/org/opencds/cqf/fhir/cql/engine/terminology/MultipleSystemsValueSet.json
@@ -1,0 +1,21 @@
+{
+  "resourceType": "ValueSet",
+  "id": "MultipleSystemsValueSet",
+  "url": "http://example.com/ValueSet/MultipleSystemsValueSet",
+  "expansion": {
+    "contains": [
+      {
+        "system": "http://example.com/CodeSystem/Codes1",
+        "code": "123"
+      },
+      {
+        "system": "http://example.com/CodeSystem/Codes2",
+        "code": "456"
+      },
+      {
+        "system": "http://example.com/CodeSystem/Codes3",
+        "code": "789"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Fix the terminology provider implementation following the [spec](https://cql.hl7.org/09-b-cqlreference.html#in-valueset):

> For the String overload, if the given valueset contains a code with an equivalent code element, the result is true. Note that for this overload, because the code being tested cannot specify code system information, if the resolved value set contains codes from multiple code systems, a run-time error is thrown because the operation is ambiguous.