### PR TITLE
Fix IG/$data-requirements key ValueSet binding discovery

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/DataRequirementsVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/DataRequirementsVisitor.java
@@ -289,6 +289,17 @@ public class DataRequirementsVisitor extends BaseKnowledgeArtifactVisitor {
             IKnowledgeArtifactAdapter dependencyAdapter,
             ConformanceResourceResolver conformanceResolver) {
         if (dependencyAdapter != null) {
+            var url = dependencyAdapter.getUrl();
+            // External CodeSystems shipped as "stub" entries (CodeSystem.content = not-present)
+            // carry a version field that reflects the publishing package, not the actual
+            // terminology version. NpmRepository excludes these from the version index, so a
+            // present URL with a missing indexed version identifies a stub. Skip the pin.
+            if (conformanceResolver != null
+                    && url != null
+                    && conformanceResolver.getResourceType(url) != null
+                    && conformanceResolver.getVersion(url) == null) {
+                return url;
+            }
             return dependencyAdapter.getCanonical();
         }
         var reference = dependency.getReference();

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/DataRequirementsVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/DataRequirementsVisitor.java
@@ -165,6 +165,14 @@ public class DataRequirementsVisitor extends BaseKnowledgeArtifactVisitor {
 
             gatherDependenciesWithClassification(adapter, new ArrayList<>(), relatedArtifacts, ctx);
 
+            // Surface key bindings the dependency walk missed. Some bindings (e.g., on
+            // sliced elements whose binding lives on a complex element type) aren't
+            // reachable through differential + baseDefinition walking, but the snapshot-based
+            // KeyElementAnalyzer correctly identifies them. Promote each transitiveKeyCanonical
+            // not already in relatedArtifacts to a synthetic depends-on entry with role=key,
+            // matching what the IG-publisher's Key Elements Table would show.
+            synthesizeMissingKeyDependencies(relatedArtifacts, transitiveKeyCanonicals, conformanceResolver);
+
             // Add root IG as a composed-of entry
             if (adapter.get() instanceof org.hl7.fhir.r4.model.ImplementationGuide
                     || adapter.get() instanceof org.hl7.fhir.r5.model.ImplementationGuide) {
@@ -421,6 +429,53 @@ public class DataRequirementsVisitor extends BaseKnowledgeArtifactVisitor {
                 extensionList.add(ExtensionBuilders.buildReferenceSourceExt(
                         fhirVersion(), dependency.getReferenceSource(), path));
             }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends ICompositeType & IBaseHasExtensions> void synthesizeMissingKeyDependencies(
+            List<T> relatedArtifacts,
+            Set<String> transitiveKeyCanonicals,
+            ConformanceResourceResolver conformanceResolver) {
+        if (transitiveKeyCanonicals == null || transitiveKeyCanonicals.isEmpty()) {
+            return;
+        }
+
+        var existingUrls = relatedArtifacts.stream()
+                .map(IKnowledgeArtifactAdapter::getRelatedArtifactReference)
+                .filter(StringUtils::isNotBlank)
+                .map(Canonicals::getUrl)
+                .collect(Collectors.toSet());
+
+        for (var keyCanonical : transitiveKeyCanonicals) {
+            var url = Canonicals.getUrl(keyCanonical);
+            if (url == null || existingUrls.contains(url)) {
+                continue;
+            }
+
+            var indexedVersion = conformanceResolver != null ? conformanceResolver.getVersion(url) : null;
+            var enrichedRef = indexedVersion != null ? url + "|" + indexedVersion : url;
+
+            var newDep = (T) IKnowledgeArtifactAdapter.newRelatedArtifact(
+                    fhirVersion(), Constants.RELATEDARTIFACT_TYPE_DEPENDSON, enrichedRef, null);
+
+            var extensionList = (List<IBaseExtension<?, ?>>) newDep.getExtension();
+            extensionList.add(ExtensionBuilders.buildDependencyRoleExt(fhirVersion(), "key"));
+
+            if (conformanceResolver != null) {
+                var resourceType = conformanceResolver.getResourceType(url);
+                if (resourceType != null) {
+                    addResourceTypeExtension(resourceType, newDep);
+                }
+                var pkgInfo = conformanceResolver.getPackageInfo(url);
+                if (pkgInfo != null) {
+                    extensionList.add(ExtensionBuilders.buildComplexPackageSourceExt(
+                            fhirVersion(), pkgInfo.packageId(), pkgInfo.version(), pkgInfo.canonical()));
+                }
+            }
+
+            relatedArtifacts.add(newDep);
+            existingUrls.add(url);
         }
     }
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/DependencyRoleClassifier.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/DependencyRoleClassifier.java
@@ -90,13 +90,32 @@ public class DependencyRoleClassifier {
     /**
      * Checks if a dependency is in the set of transitive key canonicals discovered
      * via ValueSet compose chain walking.
+     * <p>
+     * Normalizes both sides on version: dependency references and key-set entries are
+     * compared on URL only. The set may contain version-pinned URLs (FHIR core writes
+     * bindings inconsistently — e.g. {@code publication-status|4.0.1} pinned but
+     * {@code library-type} not), and dep references are version-stripped at lookup, so
+     * symmetric stripping is required to avoid spurious misses.
      */
     private static boolean isTransitiveKeyDependency(IDependencyInfo dependency, Set<String> transitiveKeyCanonicals) {
         if (transitiveKeyCanonicals == null || transitiveKeyCanonicals.isEmpty()) {
             return false;
         }
         var canonical = getDependencyCanonical(dependency.getReference());
-        return canonical != null && transitiveKeyCanonicals.contains(canonical);
+        if (canonical == null) {
+            return false;
+        }
+        // Fast path: exact URL hit (covers entries that are already version-stripped).
+        if (transitiveKeyCanonicals.contains(canonical)) {
+            return true;
+        }
+        // Fallback: strip versions on the key-set side and compare URLs.
+        for (var keyEntry : transitiveKeyCanonicals) {
+            if (canonical.equals(getDependencyCanonical(keyEntry))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/DependencyRoleClassifierTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/DependencyRoleClassifierTest.java
@@ -524,4 +524,46 @@ class DependencyRoleClassifierTest {
         assertFalse(roles.contains("key"));
         assertTrue(roles.contains("default"));
     }
+
+    @Test
+    void testTransitiveKeyMatchesWhenSetHasVersionPinAndDepDoesNot() {
+        // FHIR core writes some bindings with version pins (e.g.
+        // "http://hl7.org/fhir/ValueSet/publication-status|4.0.1") and others without.
+        // When KeyElementAnalyzer collects these into the transitive key set, dep
+        // references discovered through other paths may be version-stripped. The
+        // classifier must normalize so set membership is URL-only.
+        var resolver = createResolver();
+
+        var library = new Library();
+        library.setUrl("http://example.org/Library/main");
+        var libraryAdapter = (IKnowledgeArtifactAdapter) adapterFactory.createKnowledgeArtifactAdapter(library);
+
+        var transitiveKeySet = Set.of("http://hl7.org/fhir/ValueSet/publication-status|4.0.1");
+        var dependency = createDependency("http://hl7.org/fhir/ValueSet/publication-status");
+
+        var roles = DependencyRoleClassifier.classifyDependencyRoles(
+                dependency, libraryAdapter, null, resolver, transitiveKeySet);
+
+        assertTrue(
+                roles.contains("key"), "Should match version-pinned set entry against version-stripped dep reference");
+    }
+
+    @Test
+    void testTransitiveKeyMatchesWhenDepHasVersionPinAndSetDoesNot() {
+        // Symmetric case: set entry has no pin, dep reference does. Classifier
+        // strips dep on lookup, so this branch already worked, but lock it down.
+        var resolver = createResolver();
+
+        var library = new Library();
+        library.setUrl("http://example.org/Library/main");
+        var libraryAdapter = (IKnowledgeArtifactAdapter) adapterFactory.createKnowledgeArtifactAdapter(library);
+
+        var transitiveKeySet = Set.of("http://hl7.org/fhir/ValueSet/library-type");
+        var dependency = createDependency("http://hl7.org/fhir/ValueSet/library-type|4.0.1");
+
+        var roles = DependencyRoleClassifier.classifyDependencyRoles(
+                dependency, libraryAdapter, null, resolver, transitiveKeySet);
+
+        assertTrue(roles.contains("key"));
+    }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/Canonicals.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/Canonicals.java
@@ -38,7 +38,10 @@ public class Canonicals {
             return null;
         }
 
-        canonical = canonical.replace(canonical.substring(canonical.lastIndexOf("/")), "");
+        // Drop only the trailing /<id> segment. Using substring rather than replace,
+        // since replace is global and would mangle self-referential URLs like
+        // http://hl7.org/fhir/StructureDefinition/StructureDefinition.
+        canonical = canonical.substring(0, canonical.lastIndexOf("/"));
         return canonical.contains("/") ? canonical.substring(canonical.lastIndexOf("/") + 1) : canonical;
     }
 

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/repository/NpmRepository.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/repository/NpmRepository.java
@@ -1,7 +1,10 @@
 package org.opencds.cqf.fhir.utility.repository;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.IQueryParameterType;
+import ca.uhn.fhir.rest.param.UriParam;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import com.google.common.collect.Multimap;
 import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -10,13 +13,17 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
+import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
 import org.hl7.fhir.utilities.npm.NpmPackage;
+import org.opencds.cqf.fhir.utility.BundleHelper;
 import org.opencds.cqf.fhir.utility.Canonicals;
+import org.opencds.cqf.fhir.utility.Ids;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +48,7 @@ public class NpmRepository extends InMemoryFhirRepository {
     private Map<String, String> resourceTypeIndex; // canonical URL → FHIR resource type
     private Map<String, String> versionIndex; // canonical URL → version
     private Map<String, PackageInfo> packageIndex; // canonical URL → owning package info
+    private Map<String, String> idIndex; // canonical URL → resource id (for canonical-by-URL search)
 
     /** Package provenance information for a resource. */
     public record PackageInfo(String packageId, String version, String canonical) {}
@@ -88,6 +96,70 @@ public class NpmRepository extends InMemoryFhirRepository {
             logger.debug("Resource {}/{} not found in any loaded NPM package", id.getResourceType(), id.getIdPart());
             throw e;
         }
+    }
+
+    /**
+     * Canonical-by-URL search support: when an in-memory search comes up empty and the
+     * search includes a {@code url} parameter, look up the URL in the package index and
+     * trigger {@link #read} to lazy-load the resource. Then re-run the in-memory search.
+     *
+     * <p>Without this override, callers that resolve canonicals via search (e.g.
+     * {@code SearchHelper.searchRepositoryByCanonicalWithPaging}) silently miss
+     * NPM-only resources because lazy loading is only wired into {@code read()}.
+     */
+    @Override
+    public <B extends IBaseBundle, T extends IBaseResource> B search(
+            Class<B> bundleType,
+            Class<T> resourceType,
+            Multimap<String, List<IQueryParameterType>> searchParameters,
+            Map<String, String> headers) {
+
+        var result = super.search(bundleType, resourceType, searchParameters, headers);
+
+        if (!BundleHelper.getEntry(result).isEmpty() || dependsOnPackages.isEmpty()) {
+            return result;
+        }
+
+        var url = extractUrlSearchParam(searchParameters);
+        if (url == null) {
+            return result;
+        }
+
+        ensurePackagesLoaded();
+
+        var indexedType = resourceTypeIndex.get(url);
+        if (indexedType == null || !indexedType.equals(resourceType.getSimpleName())) {
+            return result;
+        }
+
+        var indexedId = idIndex.get(url);
+        if (indexedId == null) {
+            return result;
+        }
+
+        try {
+            IIdType id = Ids.newId(fhirContext(), indexedType, indexedId);
+            read(resourceType, id, headers);
+        } catch (Exception e) {
+            logger.debug("NPM lazy-load by URL '{}' failed: {}", url, e.getMessage());
+            return result;
+        }
+
+        return super.search(bundleType, resourceType, searchParameters, headers);
+    }
+
+    private static String extractUrlSearchParam(Multimap<String, List<IQueryParameterType>> searchParameters) {
+        if (searchParameters == null || !searchParameters.containsKey("url")) {
+            return null;
+        }
+        return searchParameters.get("url").stream()
+                .flatMap(List::stream)
+                .filter(UriParam.class::isInstance)
+                .map(UriParam.class::cast)
+                .map(UriParam::getValue)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
     }
 
     /**
@@ -142,10 +214,11 @@ public class NpmRepository extends InMemoryFhirRepository {
         var typeIndex = new HashMap<String, String>();
         var verIndex = new HashMap<String, String>();
         var pkgIndex = new HashMap<String, PackageInfo>();
+        var idMap = new HashMap<String, String>();
         logger.info("Loading NPM packages from {} seed(s)", dependsOnPackages.size());
         try {
             var mgr = createPackageCacheManager();
-            loadPackagesTransitively(mgr, result, typeIndex, verIndex, pkgIndex);
+            loadPackagesTransitively(mgr, result, typeIndex, verIndex, pkgIndex, idMap);
             logger.info("NPM package loading complete: {} package(s) loaded", result.size());
         } catch (Exception e) {
             logger.warn("Could not initialize NPM package cache manager: {}", e.getMessage(), e);
@@ -153,6 +226,7 @@ public class NpmRepository extends InMemoryFhirRepository {
         resourceTypeIndex = typeIndex;
         versionIndex = verIndex;
         packageIndex = pkgIndex;
+        idIndex = idMap;
         loadedPackages = result;
     }
 
@@ -170,7 +244,8 @@ public class NpmRepository extends InMemoryFhirRepository {
             List<NpmPackage> result,
             Map<String, String> typeIndex,
             Map<String, String> verIndex,
-            Map<String, PackageInfo> pkgIndex) {
+            Map<String, PackageInfo> pkgIndex,
+            Map<String, String> idMap) {
         Set<String> loaded = new HashSet<>();
         Queue<String[]> toLoad = new LinkedList<>(dependsOnPackages);
         while (!toLoad.isEmpty()) {
@@ -182,7 +257,7 @@ public class NpmRepository extends InMemoryFhirRepository {
             if (!loaded.add(key)) {
                 continue;
             }
-            loadSinglePackage(mgr, pkgInfo, key, result, typeIndex, verIndex, pkgIndex, toLoad);
+            loadSinglePackage(mgr, pkgInfo, key, result, typeIndex, verIndex, pkgIndex, idMap, toLoad);
         }
     }
 
@@ -194,6 +269,7 @@ public class NpmRepository extends InMemoryFhirRepository {
             Map<String, String> typeIndex,
             Map<String, String> verIndex,
             Map<String, PackageInfo> pkgIndex,
+            Map<String, String> idMap,
             Queue<String[]> toLoad) {
         try {
             var npmPkg = mgr.loadPackage(pkgInfo[0], pkgInfo[1]);
@@ -204,7 +280,7 @@ public class NpmRepository extends InMemoryFhirRepository {
             result.add(npmPkg);
             logger.info("Loaded NPM package: {}", key);
 
-            indexPackageResources(npmPkg, key, typeIndex, verIndex, pkgIndex);
+            indexPackageResources(npmPkg, key, typeIndex, verIndex, pkgIndex, idMap);
 
             for (var dep : npmPkg.dependencies()) {
                 var parts = dep.split("#", 2);
@@ -222,7 +298,8 @@ public class NpmRepository extends InMemoryFhirRepository {
             String key,
             Map<String, String> typeIndex,
             Map<String, String> verIndex,
-            Map<String, PackageInfo> pkgIndex) {
+            Map<String, PackageInfo> pkgIndex,
+            Map<String, String> idMap) {
         try {
             var owningPackage = new PackageInfo(npmPkg.id(), npmPkg.version(), npmPkg.canonical());
             for (var info : npmPkg.listIndexedResources()) {
@@ -231,6 +308,9 @@ public class NpmRepository extends InMemoryFhirRepository {
                 }
                 if (info.getResourceType() != null) {
                     typeIndex.putIfAbsent(info.getUrl(), info.getResourceType());
+                }
+                if (info.getId() != null) {
+                    idMap.putIfAbsent(info.getUrl(), info.getId());
                 }
                 // Stub CodeSystems (content: not-present) are placeholders —
                 // their version and package provenance are not meaningful.

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/CanonicalsTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/CanonicalsTest.java
@@ -59,6 +59,17 @@ class CanonicalsTest {
     }
 
     @Test
+    void selfReferentialUrlResolvesResourceType() {
+        // Regression: previously String.replace() stripped both occurrences of
+        // "/StructureDefinition" and returned "fhir" for this self-referential URL.
+        String selfRef = "http://hl7.org/fhir/StructureDefinition/StructureDefinition";
+
+        assertEquals("StructureDefinition", Canonicals.getResourceType(selfRef));
+        assertEquals("StructureDefinition", Canonicals.getIdPart(selfRef));
+        assertEquals(selfRef, Canonicals.getUrl(selfRef));
+    }
+
+    @Test
     void canonicalParts() {
         CanonicalType testUrl = new CanonicalType("http://fhir.acme.com/Questionnaire/example|1.0#vs1");
 

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/repository/NpmRepositoryTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/repository/NpmRepositoryTest.java
@@ -16,7 +16,9 @@ import java.util.List;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.ValueSet;
 import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.utility.search.Searches;
 
 class NpmRepositoryTest {
 
@@ -101,6 +103,42 @@ class NpmRepositoryTest {
                 repo.search(org.hl7.fhir.r4.model.Bundle.class, Patient.class, searchParams, Collections.emptyMap());
         assertNotNull(bundle);
         assertEquals(1, bundle.getEntry().size());
+    }
+
+    @Test
+    void searchByUrlReturnsCachedResourceWithoutLoadingPackages() {
+        // Canonical-by-URL search should hit the in-memory cache first, before any
+        // NPM-package work. With no packages configured, this exercises only the
+        // super.search() pass-through.
+        var repo = new NpmRepository(fhirContext, Collections.emptyList());
+
+        var vs = new ValueSet();
+        vs.setId("ValueSet/test-vs");
+        vs.setUrl("http://example.org/ValueSet/test-vs");
+        repo.update(vs);
+
+        var bundle = repo.search(
+                org.hl7.fhir.r4.model.Bundle.class,
+                ValueSet.class,
+                Searches.byUrl("http://example.org/ValueSet/test-vs"),
+                Collections.emptyMap());
+        assertNotNull(bundle);
+        assertEquals(1, bundle.getEntry().size());
+    }
+
+    @Test
+    void searchByUrlReturnsEmptyWhenNotCachedAndNoPackages() {
+        // Without packages and without a prior read, search-by-URL must not throw
+        // or attempt NPM lazy-load.
+        var repo = new NpmRepository(fhirContext, Collections.emptyList());
+
+        var bundle = repo.search(
+                org.hl7.fhir.r4.model.Bundle.class,
+                ValueSet.class,
+                Searches.byUrl("http://example.org/ValueSet/missing"),
+                Collections.emptyMap());
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Make `IG/$data-requirements` emit the same key ValueSet bindings the IG-publisher shows in its "Key Elements Table". For abstract-framework IGs like `hl7.fhir.uv.cql` the operation previously surfaced zero ValueSets in `relatedArtifact[]` and zero entries with `crmi-dependencyRole=key` even though the IG-publisher's published key-elements analysis identifies several per profile. End-to-end verification against `hl7.fhir.uv.cql 2.0.0`: all 27 expected key ValueSets across 8 profiles (`publication-status`, `library-type`, `mimetypes`, `structure-definition-kind`, `defined-types`, `related-artifact-type`, etc.) now surface with `crmi-dependencyRole=key`.

Five independent gaps, each fixed independently:

  1. **`Canonicals.getResourceType` self-referential URL bug** - used `String.replace()` (global) and mangled URLs like `http://hl7.org/fhir/StructureDefinition/StructureDefinition` to return `"fhir"`. Switched to `substring(0, lastIndexOf("/"))`. Without this, search-class lookup mis-routed FHIR meta-types to `CodeSystem` and the visitor never recursed into base FHIR profiles.

  2. **`NpmRepository.search()` lazy-load** - only `read()` was wired to lazy-load NPM packages on miss; `search()` fell through to the in-memory store and returned empty for unloaded resources. `SearchHelper.searchRepositoryByCanonicalWithPaging` therefore failed to resolve, the visitor's `tryResolveDependencyReadOnly` got `null`, and recursion into base FHIR profiles was skipped. Added a `search()` override: on a miss with a `url` param, look up the URL in a new id index, call `read()` to warm the cache, then re-run the in-memory search.

  3. **`DependencyRoleClassifier.isTransitiveKeyDependency` version-asymmetric matching** - stripped the version pin from the dependency reference on lookup but compared against a key set whose entries kept whatever pin the binding URL carried (FHIR core is inconsistent - `publication-status|4.0.1` is pinned, `library-type` isn't). Added symmetric stripping (fast path for already-stripped entries, fallback scan otherwise) so set membership is URL-only and matches in either direction.

  4. **`DataRequirementsVisitor.synthesizeMissingKeyDependencies`** - some key bindings live on slices of complex element types (e.g. `Library.relatedArtifact:dependency.type` -> `related-artifact-type`, where the binding is on the FHIR core `RelatedArtifact` complex type). The differential walk in `StructureDefinitionAdapter.getDependencies()` doesn't follow `type.code` into element types, so these never surfaced as deps. `KeyElementAnalyzer` correctly identifies them via the snapshot. Added a synthesizer step after the dep walk: any `transitiveKeyCanonicals` entry not already in the relatedArtifact list becomes a synthetic depends-on entry with `role=key`, populating `cqf-resourceType` and `package-source` from the conformance resolver.

  5. **`enrichReference` stub-CodeSystem version pin** - once fix 2 made `search()` actually resolve stub CodeSystems (`CodeSystem.content = not-present`), external systems like SNOMED and LOINC picked up the stub's package-version field as a bogus pin (`http://snomed.info/sct|3.2.1`). Re-use the existing stub-detection signal (URL is in the resource-type index but excluded from the version index) at the enrichment point to return the bare URL for stubs and preserve the unversioned external-CodeSystem references the operation produced previously.

  ## Test plan

  - [x] `Canonicals` self-referential URL regression test added
  - [x] `NpmRepository` search-by-URL behavior with and without packages
  - [x] `DependencyRoleClassifier` version normalization in both directions
  - [x] Full `cqf-fhir-cr` visitor test suite - 337 tests, no regressions
  - [x] Full `cqf-fhir-utility` test suite - no regressions
  - [x] `spotlessCheck` passes
  - [x] End-to-end verification against `hl7.fhir.uv.cql 2.0.0` IG: 27/27 expected key ValueSets surface with `crmi-dependencyRole=key`
  - [x] Verify downstream consumer (VSP) sees external CodeSystems without version pins