### PR TITLE
Filter unversioned canonical refs from $package expansion parameters

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/PackageVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/PackageVisitor.java
@@ -303,6 +303,13 @@ public class PackageVisitor extends BaseKnowledgeArtifactVisitor {
         var params = (IParametersAdapter) createAdapterForResource(
                 createAdapterForResource(expansionParams).copy());
 
+        // Drop any expansion-parameter whose value is an unversioned canonical URL.
+        // Terminology servers reject expansions when system-version / canonicalVersion
+        // entries lack a `|version` pin (the expansion would be non-deterministic),
+        // so excluding them here keeps the Tx call viable. Non-URL-valued params
+        // (booleans, codes, etc.) pass through unchanged.
+        filterUnversionedCanonicalParams(params);
+
         var valueSets = BundleHelper.getEntryResources(packagedBundle).stream()
                 .filter(r -> r.fhirType().equals(VALUESET_FHIR_TYPE))
                 .map(v -> (IValueSetAdapter) createAdapterForResource(v))
@@ -357,6 +364,39 @@ public class PackageVisitor extends BaseKnowledgeArtifactVisitor {
                 addMessageIssue("warning", e.getMessage());
             }
         });
+    }
+
+    /**
+     * Removes expansion-parameter entries whose values are unversioned canonical URLs.
+     * Logs a warning per dropped entry. Non-URL-valued params (booleans, codes, etc.)
+     * are kept. A value is considered a canonical URL if it looks like a URI scheme
+     * (contains "://") and is considered versioned if it contains a "|" version pin.
+     */
+    private void filterUnversionedCanonicalParams(IParametersAdapter params) {
+        if (params == null || params.getParameter() == null) {
+            return;
+        }
+        var kept = params.getParameter().stream()
+                .filter(p -> {
+                    if (!p.hasValue()) {
+                        return true;
+                    }
+                    var value = p.getPrimitiveValue();
+                    if (value == null || !value.contains("://")) {
+                        return true;
+                    }
+                    if (value.contains("|")) {
+                        return true;
+                    }
+                    myLogger.warn(
+                            "Excluding unversioned canonical from $package expansion parameters: {}={}",
+                            p.getName(),
+                            value);
+                    return false;
+                })
+                .map(IParametersParameterComponentAdapter::get)
+                .toList();
+        params.setParameter(kept);
     }
 
     // Helper to surface expansion parameter warnings as OperationOutcome issues

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/PackageVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/PackageVisitor.java
@@ -368,9 +368,11 @@ public class PackageVisitor extends BaseKnowledgeArtifactVisitor {
 
     /**
      * Removes expansion-parameter entries whose values are unversioned canonical URLs.
-     * Logs a warning per dropped entry. Non-URL-valued params (booleans, codes, etc.)
-     * are kept. A value is considered a canonical URL if it looks like a URI scheme
-     * (contains "://") and is considered versioned if it contains a "|" version pin.
+     * Logs a warning per dropped entry. Non-canonical-valued params (booleans, codes,
+     * language tags, etc.) are kept. A value is treated as canonical when
+     * {@link Canonicals#getUrl(String)} parses it (handles http/https URLs plus
+     * urn:uuid / urn:oid forms) and versioned when {@link Canonicals#getVersion(String)}
+     * returns non-null.
      */
     private void filterUnversionedCanonicalParams(IParametersAdapter params) {
         if (params == null || params.getParameter() == null) {
@@ -382,10 +384,10 @@ public class PackageVisitor extends BaseKnowledgeArtifactVisitor {
                         return true;
                     }
                     var value = p.getPrimitiveValue();
-                    if (value == null || !value.contains("://")) {
+                    if (value == null || Canonicals.getUrl(value) == null) {
                         return true;
                     }
-                    if (value.contains("|")) {
+                    if (Canonicals.getVersion(value) != null) {
                         return true;
                     }
                     myLogger.warn(

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/PackageVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/PackageVisitorTests.java
@@ -1424,18 +1424,18 @@ class PackageVisitorTests {
         var params = parameters();
         params.addParameter("system-version", "http://snomed.info/sct"); // unversioned canonical — drop
         params.addParameter("system-version", "http://loinc.org|2.81"); // versioned — keep
-        params.addParameter(
-                "canonicalVersion", "http://example.org/ValueSet/foo"); // unversioned canonical — drop
+        params.addParameter("canonicalVersion", "http://example.org/ValueSet/foo"); // unversioned canonical — drop
         params.addParameter("canonicalVersion", "http://example.org/ValueSet/bar|1.0.0"); // versioned — keep
         params.addParameter("system-version", "urn:oid:1.2.3.4"); // unversioned urn canonical — drop
         params.addParameter("system-version", "urn:oid:1.2.3.4|2024"); // versioned urn canonical — keep
         params.addParameter("displayLanguage", "en-US"); // non-canonical — keep
         params.addParameter("activeOnly", true); // boolean — keep
 
-        var adapter = (IParametersAdapter) IAdapterFactory.forFhirVersion(FhirVersionEnum.R4)
-                .createParameters(params);
+        var adapter = (IParametersAdapter)
+                IAdapterFactory.forFhirVersion(FhirVersionEnum.R4).createParameters(params);
 
-        var method = PackageVisitor.class.getDeclaredMethod("filterUnversionedCanonicalParams", IParametersAdapter.class);
+        var method =
+                PackageVisitor.class.getDeclaredMethod("filterUnversionedCanonicalParams", IParametersAdapter.class);
         method.setAccessible(true);
         method.invoke(visitor, adapter);
 
@@ -1458,15 +1458,16 @@ class PackageVisitorTests {
     @Test
     void filterUnversionedCanonicalParams_handlesNullAndEmptyInputs() throws Exception {
         var visitor = new PackageVisitor(repo);
-        var method = PackageVisitor.class.getDeclaredMethod("filterUnversionedCanonicalParams", IParametersAdapter.class);
+        var method =
+                PackageVisitor.class.getDeclaredMethod("filterUnversionedCanonicalParams", IParametersAdapter.class);
         method.setAccessible(true);
 
         // Null adapter — should not throw
         method.invoke(visitor, new Object[] {null});
 
         // Empty parameters — should not throw, no-op
-        var empty = (IParametersAdapter) IAdapterFactory.forFhirVersion(FhirVersionEnum.R4)
-                .createParameters(parameters());
+        var empty = (IParametersAdapter)
+                IAdapterFactory.forFhirVersion(FhirVersionEnum.R4).createParameters(parameters());
         method.invoke(visitor, empty);
         assertTrue(empty.getParameter().isEmpty());
     }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/PackageVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/PackageVisitorTests.java
@@ -1416,4 +1416,54 @@ class PackageVisitorTests {
         byte[] bytes = Base64.getDecoder().decode(base64);
         return new String(bytes, StandardCharsets.UTF_8);
     }
+
+    @Test
+    void filterUnversionedCanonicalParams_dropsUrlsWithoutPin_keepsOthers() throws Exception {
+        var visitor = new PackageVisitor(repo);
+
+        var params = parameters();
+        params.addParameter("system-version", "http://snomed.info/sct"); // unversioned canonical — drop
+        params.addParameter("system-version", "http://loinc.org|2.81"); // versioned — keep
+        params.addParameter(
+                "canonicalVersion", "http://example.org/ValueSet/foo"); // unversioned canonical — drop
+        params.addParameter("canonicalVersion", "http://example.org/ValueSet/bar|1.0.0"); // versioned — keep
+        params.addParameter("displayLanguage", "en-US"); // non-URL — keep
+        params.addParameter("activeOnly", true); // boolean — keep
+
+        var adapter = (IParametersAdapter) IAdapterFactory.forFhirVersion(FhirVersionEnum.R4)
+                .createParameters(params);
+
+        var method = PackageVisitor.class.getDeclaredMethod("filterUnversionedCanonicalParams", IParametersAdapter.class);
+        method.setAccessible(true);
+        method.invoke(visitor, adapter);
+
+        var remainingValues = adapter.getParameter().stream()
+                .map(p -> p.getName() + "=" + (p.hasValue() ? p.getPrimitiveValue() : "<no-value>"))
+                .toList();
+
+        assertEquals(4, remainingValues.size(), "should drop both unversioned canonical entries");
+        assertTrue(remainingValues.contains("system-version=http://loinc.org|2.81"));
+        assertTrue(remainingValues.contains("canonicalVersion=http://example.org/ValueSet/bar|1.0.0"));
+        assertTrue(remainingValues.contains("displayLanguage=en-US"));
+        assertTrue(remainingValues.contains("activeOnly=true"));
+        assertFalse(remainingValues.stream().anyMatch(v -> v.equals("system-version=http://snomed.info/sct")));
+        assertFalse(
+                remainingValues.stream().anyMatch(v -> v.equals("canonicalVersion=http://example.org/ValueSet/foo")));
+    }
+
+    @Test
+    void filterUnversionedCanonicalParams_handlesNullAndEmptyInputs() throws Exception {
+        var visitor = new PackageVisitor(repo);
+        var method = PackageVisitor.class.getDeclaredMethod("filterUnversionedCanonicalParams", IParametersAdapter.class);
+        method.setAccessible(true);
+
+        // Null adapter — should not throw
+        method.invoke(visitor, new Object[] {null});
+
+        // Empty parameters — should not throw, no-op
+        var empty = (IParametersAdapter) IAdapterFactory.forFhirVersion(FhirVersionEnum.R4)
+                .createParameters(parameters());
+        method.invoke(visitor, empty);
+        assertTrue(empty.getParameter().isEmpty());
+    }
 }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/PackageVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/PackageVisitorTests.java
@@ -1427,7 +1427,9 @@ class PackageVisitorTests {
         params.addParameter(
                 "canonicalVersion", "http://example.org/ValueSet/foo"); // unversioned canonical — drop
         params.addParameter("canonicalVersion", "http://example.org/ValueSet/bar|1.0.0"); // versioned — keep
-        params.addParameter("displayLanguage", "en-US"); // non-URL — keep
+        params.addParameter("system-version", "urn:oid:1.2.3.4"); // unversioned urn canonical — drop
+        params.addParameter("system-version", "urn:oid:1.2.3.4|2024"); // versioned urn canonical — keep
+        params.addParameter("displayLanguage", "en-US"); // non-canonical — keep
         params.addParameter("activeOnly", true); // boolean — keep
 
         var adapter = (IParametersAdapter) IAdapterFactory.forFhirVersion(FhirVersionEnum.R4)
@@ -1441,14 +1443,16 @@ class PackageVisitorTests {
                 .map(p -> p.getName() + "=" + (p.hasValue() ? p.getPrimitiveValue() : "<no-value>"))
                 .toList();
 
-        assertEquals(4, remainingValues.size(), "should drop both unversioned canonical entries");
+        assertEquals(5, remainingValues.size(), "should drop all three unversioned canonical entries");
         assertTrue(remainingValues.contains("system-version=http://loinc.org|2.81"));
         assertTrue(remainingValues.contains("canonicalVersion=http://example.org/ValueSet/bar|1.0.0"));
+        assertTrue(remainingValues.contains("system-version=urn:oid:1.2.3.4|2024"));
         assertTrue(remainingValues.contains("displayLanguage=en-US"));
         assertTrue(remainingValues.contains("activeOnly=true"));
         assertFalse(remainingValues.stream().anyMatch(v -> v.equals("system-version=http://snomed.info/sct")));
         assertFalse(
                 remainingValues.stream().anyMatch(v -> v.equals("canonicalVersion=http://example.org/ValueSet/foo")));
+        assertFalse(remainingValues.stream().anyMatch(v -> v.equals("system-version=urn:oid:1.2.3.4")));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Manifests can carry expansion parameters whose values are unversioned canonical URLs (e.g. `system-version=http://snomed.info/sct` or `canonicalVersion=http://example.org/ValueSet/foo` with no `|version` pin). Most terminology servers reject expansions when `system-version` / `canonicalVersion` entries lack a pin. The expansion would be non-deterministic so the resulting `$package` call fails for the entire manifest instead of just the offending entries.

Add a guard in `PackageVisitor.handleValueSets`: after copying the manifest's `cqf-expansionParameters` into the working params adapter, drop any entry whose value is a canonical URL without a version pin. Each dropped entry produces a `logger.warn` with the param name and value so authors can see which entries need pinning. Non-canonical-valued params (booleans, codes like `displayLanguage`, language tags, etc.) pass through unchanged.

The persisted manifest in the repository is untouched - the filter applies only to the in-memory copy used for Tx expansion and the manifest copy included in the response bundle. This keeps `$package` idempotent on stored state.

## Test plan

  - [x] Unit test: mixed-input case - unversioned `http://` canonical dropped, unversioned `urn:oid:` canonical dropped, versioned http canonical kept, versioned urn canonical kept, language code + boolean kept
  - [x] Unit test: defensive null / empty-params inputs don't throw
  - [x] Full `cqf-fhir-cr` `PackageVisitor` test suite - no regressions
  - [x] End-to-end verification against a real manifest in jpaserver-starter - `$package` completes; warnings appear for unversioned entries; Tx server no longer errors