### PR TITLE
Multi-component stratifier loses components that share a scalar value

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureMultiSubjectEvaluator.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureMultiSubjectEvaluator.java
@@ -396,13 +396,6 @@ public class MeasureMultiSubjectEvaluator {
     }
 
     /**
-     * Column key for the subject-results table. Pairs component identity with the stratum value so
-     * two components that resolve to the same value (e.g. Race and Ethnicity both AskedButNoAnswer)
-     * do not overwrite each other in the underlying {@link HashBasedTable} (CDO-789).
-     */
-    private record StratumTableColumnKey(StratifierComponentDef component, StratumValueWrapper value) {}
-
-    /**
      * Builds a Guava Table mapping row keys to stratifier component values for grouping into strata.
      *
      * <p>The table structure is:

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureMultiSubjectEvaluator.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureMultiSubjectEvaluator.java
@@ -353,7 +353,7 @@ public class MeasureMultiSubjectEvaluator {
     private static List<StratumDef> buildValueOrNonSubjectValueStrata(
             FhirContext fhirContext, StratifierDef stratifierDef, GroupDef groupDef) {
 
-        final Table<StratifierRowKey, StratumValueWrapper, StratifierComponentDef> subjectResultTable =
+        final Table<StratifierRowKey, StratumTableColumnKey, StratifierComponentDef> subjectResultTable =
                 buildSubjectResultsTable(stratifierDef.components());
 
         // Stratifiers should be of the same basis as population
@@ -396,11 +396,21 @@ public class MeasureMultiSubjectEvaluator {
     }
 
     /**
+     * Column key for the subject-results table. Pairs component identity with the stratum value so
+     * two components that resolve to the same value (e.g. Race and Ethnicity both AskedButNoAnswer)
+     * do not overwrite each other in the underlying {@link HashBasedTable} (CDO-789).
+     */
+    private record StratumTableColumnKey(StratifierComponentDef component, StratumValueWrapper value) {}
+
+    /**
      * Builds a Guava Table mapping row keys to stratifier component values for grouping into strata.
      *
-     * <p>The table structure is: {@code Table<StratifierRowKey, StratumValueWrapper, StratifierComponentDef>}
-     * where StratifierRowKey identifies the subject (and optionally resource), StratumValueWrapper holds the
-     * component value, and StratifierComponentDef identifies which component produced the value.
+     * <p>The table structure is:
+     * {@code Table<StratifierRowKey, StratumTableColumnKey, StratifierComponentDef>}
+     * where StratifierRowKey identifies the subject (and optionally resource),
+     * {@link StratumTableColumnKey} pairs each component with its value (so equal values across
+     * components do not collide in the underlying HashBasedTable), and the cell value identifies
+     * which component produced the entry.
      *
      * <h3>Supported Expression Types</h3>
      * <ul>
@@ -461,10 +471,10 @@ public class MeasureMultiSubjectEvaluator {
      * @param componentDefs the list of stratifier component definitions with their evaluation results
      * @return a table mapping row keys to component values for grouping
      */
-    private static Table<StratifierRowKey, StratumValueWrapper, StratifierComponentDef> buildSubjectResultsTable(
+    private static Table<StratifierRowKey, StratumTableColumnKey, StratifierComponentDef> buildSubjectResultsTable(
             List<StratifierComponentDef> componentDefs) {
 
-        final Table<StratifierRowKey, StratumValueWrapper, StratifierComponentDef> subjectResultTable =
+        final Table<StratifierRowKey, StratumTableColumnKey, StratifierComponentDef> subjectResultTable =
                 HashBasedTable.create();
 
         // First pass: Collect alignment row keys from multi-value components (function Maps and
@@ -476,7 +486,9 @@ public class MeasureMultiSubjectEvaluator {
         for (StratifierComponentDef componentDef : componentDefs) {
             for (StratumTableRow stratumTableRow : mapToListOfTableEntries(componentDef, alignmentRowKeysBySubject)) {
                 subjectResultTable.put(
-                        stratumTableRow.stratifierRowKey(), stratumTableRow.stratumValueWrapper(), componentDef);
+                        stratumTableRow.stratifierRowKey(),
+                        new StratumTableColumnKey(componentDef, stratumTableRow.stratumValueWrapper()),
+                        componentDef);
             }
         }
 
@@ -743,15 +755,16 @@ public class MeasureMultiSubjectEvaluator {
      * Subject lists are derived from the row keys.
      */
     private static Map<Set<StratumValueDef>, List<StratifierRowKey>> groupSubjectsByValueDefSet(
-            Table<StratifierRowKey, StratumValueWrapper, StratifierComponentDef> table) {
+            Table<StratifierRowKey, StratumTableColumnKey, StratifierComponentDef> table) {
 
         // Step 1: Build Map<RowKey, Set<ValueDef>>
         final Map<StratifierRowKey, Set<StratumValueDef>> rowKeyToValueDefs = new HashMap<>();
 
-        for (Table.Cell<StratifierRowKey, StratumValueWrapper, StratifierComponentDef> cell : table.cellSet()) {
+        for (Table.Cell<StratifierRowKey, StratumTableColumnKey, StratifierComponentDef> cell : table.cellSet()) {
+            StratumTableColumnKey columnKey = cell.getColumnKey();
             rowKeyToValueDefs
                     .computeIfAbsent(cell.getRowKey(), k -> new HashSet<>())
-                    .add(new StratumValueDef(cell.getColumnKey(), cell.getValue()));
+                    .add(new StratumValueDef(columnKey.value(), columnKey.component()));
         }
 
         // Step 2: Invert to Map<Set<ValueDef>, List<RowKey>>

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/StratumTableColumnKey.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/StratumTableColumnKey.java
@@ -1,0 +1,10 @@
+package org.opencds.cqf.fhir.cr.measure.common;
+
+import com.google.common.collect.HashBasedTable;
+
+/**
+ * Column key for the subject-results table. Pairs component identity with the stratum value so two
+ * components that resolve to the same value (e.g. Race and Ethnicity both AskedButNoAnswer) do not
+ * overwrite each other in the underlying {@link HashBasedTable} (CDO-789).
+ */
+record StratumTableColumnKey(StratifierComponentDef component, StratumValueWrapper value) {}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/MeasureMultiSubjectEvaluatorTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/MeasureMultiSubjectEvaluatorTest.java
@@ -632,12 +632,10 @@ class MeasureMultiSubjectEvaluatorTest {
             var pop = initialPopulation(basis);
             pop.addResource("p1", Boolean.TRUE);
 
-            var componentA =
-                    new StratifierComponentDef("component-a", textConcept("Component A"), "Expression A");
+            var componentA = new StratifierComponentDef("component-a", textConcept("Component A"), "Expression A");
             componentA.putResult("p1", "shared-value", Set.of());
 
-            var componentB =
-                    new StratifierComponentDef("component-b", textConcept("Component B"), "Expression B");
+            var componentB = new StratifierComponentDef("component-b", textConcept("Component B"), "Expression B");
             componentB.putResult("p1", "shared-value", Set.of());
 
             var stratifierDef = new StratifierDef(
@@ -669,16 +667,13 @@ class MeasureMultiSubjectEvaluatorTest {
             var pop = initialPopulation(basis);
             pop.addResource("p1", Boolean.TRUE);
 
-            var componentA =
-                    new StratifierComponentDef("component-a", textConcept("Component A"), "Expression A");
+            var componentA = new StratifierComponentDef("component-a", textConcept("Component A"), "Expression A");
             componentA.putResult("p1", "distinct-value", Set.of());
 
-            var componentB =
-                    new StratifierComponentDef("component-b", textConcept("Component B"), "Expression B");
+            var componentB = new StratifierComponentDef("component-b", textConcept("Component B"), "Expression B");
             componentB.putResult("p1", "shared-value", Set.of());
 
-            var componentC =
-                    new StratifierComponentDef("component-c", textConcept("Component C"), "Expression C");
+            var componentC = new StratifierComponentDef("component-c", textConcept("Component C"), "Expression C");
             componentC.putResult("p1", "shared-value", Set.of());
 
             var stratifierDef = new StratifierDef(

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/MeasureMultiSubjectEvaluatorTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/MeasureMultiSubjectEvaluatorTest.java
@@ -618,6 +618,85 @@ class MeasureMultiSubjectEvaluatorTest {
     }
 
     /**
+     * CDO-789: when two scalar components on the same stratifier resolve to the same value for the
+     * same subject, both must appear in the resulting stratum. They must not collapse into one
+     * because the assembly step keyed its table cells by value alone.
+     */
+    @Nested
+    class DuplicateValueAcrossComponents {
+
+        @Test
+        void twoScalarComponents_sameValue_bothAppearInStratum() {
+            var basis = basisCode("boolean");
+
+            var pop = initialPopulation(basis);
+            pop.addResource("p1", Boolean.TRUE);
+
+            var componentA =
+                    new StratifierComponentDef("component-a", textConcept("Component A"), "Expression A");
+            componentA.putResult("p1", "shared-value", Set.of());
+
+            var componentB =
+                    new StratifierComponentDef("component-b", textConcept("Component B"), "Expression B");
+            componentB.putResult("p1", "shared-value", Set.of());
+
+            var stratifierDef = new StratifierDef(
+                    "stratifier-1",
+                    textConcept("Multi-component stratifier"),
+                    "Multi-component stratifier",
+                    MeasureStratifierType.VALUE,
+                    List.of(componentA, componentB));
+            var groupDef = cohortGroup(basis, pop, stratifierDef);
+
+            MeasureMultiSubjectEvaluator.postEvaluationMultiSubject(FHIR_CONTEXT, measureDefWith(groupDef));
+
+            assertEquals(1, stratifierDef.getStratum().size());
+            StratumDef stratum = stratifierDef.getStratum().get(0);
+            assertEquals(2, stratum.valueDefs().size());
+            assertTrue(stratum.valueDefs().stream()
+                    .anyMatch(v -> "component-a".equals(v.def().id())
+                            && "shared-value".equals(v.value().getValueAsString())));
+            assertTrue(stratum.valueDefs().stream()
+                    .anyMatch(v -> "component-b".equals(v.def().id())
+                            && "shared-value".equals(v.value().getValueAsString())));
+            assertEquals(1, stratum.getPopulationCount(pop));
+        }
+
+        @Test
+        void threeScalarComponents_twoShareValue_allThreeAppearInStratum() {
+            var basis = basisCode("boolean");
+
+            var pop = initialPopulation(basis);
+            pop.addResource("p1", Boolean.TRUE);
+
+            var componentA =
+                    new StratifierComponentDef("component-a", textConcept("Component A"), "Expression A");
+            componentA.putResult("p1", "distinct-value", Set.of());
+
+            var componentB =
+                    new StratifierComponentDef("component-b", textConcept("Component B"), "Expression B");
+            componentB.putResult("p1", "shared-value", Set.of());
+
+            var componentC =
+                    new StratifierComponentDef("component-c", textConcept("Component C"), "Expression C");
+            componentC.putResult("p1", "shared-value", Set.of());
+
+            var stratifierDef = new StratifierDef(
+                    "stratifier-1",
+                    textConcept("Multi-component stratifier"),
+                    "Multi-component stratifier",
+                    MeasureStratifierType.VALUE,
+                    List.of(componentA, componentB, componentC));
+            var groupDef = cohortGroup(basis, pop, stratifierDef);
+
+            MeasureMultiSubjectEvaluator.postEvaluationMultiSubject(FHIR_CONTEXT, measureDefWith(groupDef));
+
+            assertEquals(1, stratifierDef.getStratum().size());
+            assertEquals(3, stratifierDef.getStratum().get(0).valueDefs().size());
+        }
+    }
+
+    /**
      * Criteria stratifiers: {@code stratifierDef.results} (subject → CriteriaResult) is intersected
      * against the population's per-subject resources. Two cases:
      * <ul>

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest.java
@@ -225,6 +225,59 @@ class MeasureStratifierTest {
     }
 
     /**
+     * CDO-789: Multi-component stratifier where two components resolve to the same scalar value
+     * for the same patient. Both components must appear in every stratum — they must not collapse
+     * because the assembly step keyed table cells by value alone.
+     *
+     * <p>Components: Sex-Code-A and Sex-Code-B both evaluate "Gender Stratification" (same Code
+     * value per patient); Age differs. Each stratum therefore carries Sex-Code-A=M/F,
+     * Sex-Code-B=M/F, and Age=35/38 — three components, not two.
+     */
+    @Test
+    void cohortBooleanValueStratComponentStratSameValueAcrossComponents() {
+        GIVEN_MEASURE_STRATIFIER_TEST
+                .when()
+                .measureId("CohortBooleanStratSameValueComponents")
+                .evaluate()
+                .then()
+            .report()
+            .logReportJson()
+                .hasStatus(MeasureReportStatus.COMPLETE)
+                .group("group-1")
+                .stratifierById("stratifier-1")
+                .hasCodeText("Sex-A and Sex-B and Age")
+                .hasStratumCount(2)
+                .stratumByComponentValueText("38")
+                .hasComponentStratifierCount(3)
+                .stratumComponentWithCodeText("Sex-Code-A")
+                .hasValueText("M")
+                .up()
+                .stratumComponentWithCodeText("Sex-Code-B")
+                .hasValueText("M")
+                .up()
+                .stratumComponentWithCodeText("Age")
+                .hasValueText("38")
+                .up()
+                .firstPopulation()
+                .hasCount(5)
+                .up()
+                .up()
+                .stratumByComponentValueText("35")
+                .hasComponentStratifierCount(3)
+                .stratumComponentWithCodeText("Sex-Code-A")
+                .hasValueText("F")
+                .up()
+                .stratumComponentWithCodeText("Sex-Code-B")
+                .hasValueText("F")
+                .up()
+                .stratumComponentWithCodeText("Age")
+                .hasValueText("35")
+                .up()
+                .firstPopulation()
+                .hasCount(5);
+    }
+
+    /**
      * Ratio Measure with Resource (Encounter) Basis where Stratifier uses stratifier.component[].criteria
      * with a non-function expression "Age". This is classified as NON_SUBJECT_VALUE stratifier because:
      * - hasCriteria=false (no stratifier.criteria)

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest.java
@@ -230,18 +230,17 @@ class MeasureStratifierTest {
      * because the assembly step keyed table cells by value alone.
      *
      * <p>Components: Sex-Code-A and Sex-Code-B both evaluate "Gender Stratification" (same Code
-     * value per patient); Age differs. Each stratum therefore carries Sex-Code-A=M/F,
-     * Sex-Code-B=M/F, and Age=35/38 — three components, not two.
+     * value per patient); Age differs. Each stratum therefore carries Sex-Code-A and Sex-Code-B
+     * with the same gender code, plus the Age — three components, not two.
      */
     @Test
     void cohortBooleanValueStratComponentStratSameValueAcrossComponents() {
+        // Fixture: 5 female patients (1985-06-16 → age 38) and 5 male patients (1988-01-11 → age 35).
         GIVEN_MEASURE_STRATIFIER_TEST
                 .when()
                 .measureId("CohortBooleanStratSameValueComponents")
                 .evaluate()
                 .then()
-            .report()
-            .logReportJson()
                 .hasStatus(MeasureReportStatus.COMPLETE)
                 .group("group-1")
                 .stratifierById("stratifier-1")
@@ -250,10 +249,10 @@ class MeasureStratifierTest {
                 .stratumByComponentValueText("38")
                 .hasComponentStratifierCount(3)
                 .stratumComponentWithCodeText("Sex-Code-A")
-                .hasValueText("M")
+                .hasValueText("F")
                 .up()
                 .stratumComponentWithCodeText("Sex-Code-B")
-                .hasValueText("M")
+                .hasValueText("F")
                 .up()
                 .stratumComponentWithCodeText("Age")
                 .hasValueText("38")
@@ -265,10 +264,10 @@ class MeasureStratifierTest {
                 .stratumByComponentValueText("35")
                 .hasComponentStratifierCount(3)
                 .stratumComponentWithCodeText("Sex-Code-A")
-                .hasValueText("F")
+                .hasValueText("M")
                 .up()
                 .stratumComponentWithCodeText("Sex-Code-B")
-                .hasValueText("F")
+                .hasValueText("M")
                 .up()
                 .stratumComponentWithCodeText("Age")
                 .hasValueText("35")

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasureServiceTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasureServiceTest.java
@@ -1114,7 +1114,8 @@ class MultiMeasureServiceTest {
             assertEquals(
                     3,
                     stratum.getComponent().size(),
-                    "expected 3 components in stratum but got " + stratum.getComponent().size());
+                    "expected 3 components in stratum but got "
+                            + stratum.getComponent().size());
         }
     }
 

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasureServiceTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasureServiceTest.java
@@ -1,5 +1,6 @@
 package org.opencds.cqf.fhir.cr.measure.r4;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -16,6 +17,7 @@ import org.opencds.cqf.fhir.cr.measure.r4.MultiMeasure.Given;
 @SuppressWarnings({"java:S2699"})
 class MultiMeasureServiceTest {
     private static final Given GIVEN_REPO = MultiMeasure.given().repositoryFor("MinimalMeasureEvaluation");
+    private static final Given GIVEN_STRATIFIER_REPO = MultiMeasure.given().repositoryFor("MeasureStratifierTest");
 
     @Test
     void MultiMeasure_AllSubjects_MeasureIdentifier() {
@@ -1085,6 +1087,35 @@ class MultiMeasureServiceTest {
                 .hasMeasureReportStatus(MeasureReportStatus.ERROR)
                 .hasContainedOperationOutcome()
                 .hasContainedOperationOutcomeMsg("Patient/female-1988-2");
+    }
+
+    /**
+     * CDO-789: multi-component stratifier where two components resolve to the same scalar value
+     * must not collapse those components in the MeasureReport stratum, even when reached via the
+     * multi-measure orchestration path.
+     */
+    @Test
+    void MultiMeasure_MultiComponentStratifier_SameValueAcrossComponents_KeepsAllComponents() {
+        var stratifier = GIVEN_STRATIFIER_REPO
+                .when()
+                .measureId("CohortBooleanStratSameValueComponents")
+                .periodStart("2024-01-01")
+                .periodEnd("2024-12-31")
+                .reportType("population")
+                .evaluate()
+                .then()
+                .measureReport("http://example.com/Measure/CohortBooleanStratSameValueComponents")
+                .firstGroup()
+                .firstStratifier()
+                .value();
+
+        assertEquals(2, stratifier.getStratum().size());
+        for (var stratum : stratifier.getStratum()) {
+            assertEquals(
+                    3,
+                    stratum.getComponent().size(),
+                    "expected 3 components in stratum but got " + stratum.getComponent().size());
+        }
     }
 
     @Test

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/measure/CohortBooleanStratSameValueComponents.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureStratifierTest/input/resources/measure/CohortBooleanStratSameValueComponents.json
@@ -1,0 +1,85 @@
+{
+  "id": "CohortBooleanStratSameValueComponents",
+  "resourceType": "Measure",
+  "url": "http://example.com/Measure/CohortBooleanStratSameValueComponents",
+  "library": [
+    "http://example.com/Library/LibrarySimple"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "boolean"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population Boolean"
+          }
+        }
+      ],
+      "stratifier": [
+        {
+          "id": "stratifier-1",
+          "code": {
+            "text": "Sex-A and Sex-B and Age"
+          },
+          "component": [
+            {
+              "id": "stratifier-comp-1",
+              "code": {
+                "text": "Sex-Code-A"
+              },
+              "criteria": {
+                "language": "text/cql.identifier",
+                "expression": "Gender Stratification"
+              }
+            },
+            {
+              "id": "stratifier-comp-2",
+              "code": {
+                "text": "Sex-Code-B"
+              },
+              "criteria": {
+                "language": "text/cql.identifier",
+                "expression": "Gender Stratification"
+              }
+            },
+            {
+              "id": "stratifier-comp-3",
+              "code": {
+                "text": "Age"
+              },
+              "criteria": {
+                "language": "text/cql.identifier",
+                "expression": "Age"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes a silent data-loss bug in measure-report assembly where stratifier components could be dropped from the output stratum when two of them happened to evaluate to the same scalar value for the same subject. The bug was reported against a real-world RDM measure where a three-component `RaceEthnicity` stratifier (`ProductLine`, `Race`, `Ethnicity`) produced strata missing the `Race` component whenever `Race` and `Ethnicity` both resolved to `AskedButNoAnswer` for the same patient. The CQL output already contained all values; the loss happened inside `MeasureMultiSubjectEvaluator` because its accumulation table was keyed on the value alone, so the second `put` for the same `(row, value)` cell overwrote the first.

1. **Root-cause fix in the multi-subject stratifier accumulator.** Promote the table's column key from `StratumValueWrapper` to a small `StratumTableColumnKey(component, value)` record so that two distinct components emitting equal values for the same row key land in distinct cells instead of overwriting each other.
2. **Failing-first regression coverage at three levels.** Added an integration test in `MeasureStratifierTest` (driven by a new `CohortBooleanStratSameValueComponents` measure fixture), two evaluator-level unit tests in `MeasureMultiSubjectEvaluatorTest`, and a defense-in-depth check in `MultiMeasureServiceTest` to confirm the multi-measure orchestration path inherits the fix.

## Example: the RDM-Reporting scenario end-to-end

The snippets below are the colleague's original reproduction for patient `2025.hpdi.0.115003`, walking from CQL output → Measure definition → buggy MeasureReport → corrected MeasureReport. They show why the assembly-layer key change matters: the CQL already computes all three component values; the loss is purely in `MeasureMultiSubjectEvaluator`.

### 1. CQL results for the patient (input to assembly)

```text
Initial population=true
Product lines=[Code { code: PPO, system: https://ncqa.org/fhir/CodeSystem/hedis-coverage-type },
               Code { code: POS, system: https://ncqa.org/fhir/CodeSystem/hedis-coverage-type }]
Race=AskedButNoAnswer
Ethnicity=AskedButNoAnswer
```

Note the collision: `Race` and `Ethnicity` are distinct stratifier components but both resolve to the same scalar `AskedButNoAnswer` for this patient. `Product lines` is multi-valued, so each value yields its own stratum (`PPO` and `POS`).

### 2. Measure stratifier definition (RDM-Reporting.json, three components)

```json
"stratifier": [{
  "id": "RaceEthnicity-Stratifier",
  "code": { "text": "RaceEthnicity-Stratifier" },
  "component": [
    {
      "id": "RaceEthnicity-StratifierComponent-ProductLine",
      "code": { "text": "ProductLine" },
      "criteria": { "language": "text/cql-identifier", "expression": "Product lines" }
    },
    {
      "id": "RaceEthnicity-StratifierComponent-Race",
      "code": { "text": "Race" },
      "criteria": { "language": "text/cql-identifier", "expression": "Race" }
    },
    {
      "id": "RaceEthnicity-StratifierComponent-Ethnicity",
      "code": { "text": "Ethnicity" },
      "criteria": { "language": "text/cql-identifier", "expression": "Ethnicity" }
    }
  ]
}]
```

### 3. Before the fix — MeasureReport stratum is missing the `Race` component

```json
"stratum": [
  {
    "component": [
      { "id": "RaceEthnicity-StratifierComponent-ProductLine",
        "code": { "text": "ProductLine" }, "value": { "text": "POS" } },
      { "id": "RaceEthnicity-StratifierComponent-Ethnicity",
        "code": { "text": "Ethnicity" },   "value": { "text": "AskedButNoAnswer" } }
    ],
    "population": [
      { "id": "RaceEthnicity-initial-population", "count": 1 }
    ]
  },
  {
    "component": [
      { "id": "RaceEthnicity-StratifierComponent-Ethnicity",
        "code": { "text": "Ethnicity" },   "value": { "text": "AskedButNoAnswer" } },
      { "id": "RaceEthnicity-StratifierComponent-ProductLine",
        "code": { "text": "ProductLine" }, "value": { "text": "PPO" } }
    ],
    "population": [
      { "id": "RaceEthnicity-initial-population", "count": 1 }
    ]
  }
]
```

`Race` is silently absent from both strata because, inside `buildSubjectResultsTable`, the cell `(rowKey, "AskedButNoAnswer") → Race` got overwritten by `(rowKey, "AskedButNoAnswer") → Ethnicity` when only the value was used as the column key.

### 4. After the fix — all three components survive in each stratum

```json
"stratum": [
  {
    "component": [
      { "code": { "text": "ProductLine" }, "value": { "text": "PPO" } },
      { "code": { "text": "Race" },        "value": { "text": "AskedButNoAnswer" } },
      { "code": { "text": "Ethnicity" },   "value": { "text": "AskedButNoAnswer" } }
    ],
    "population": [
      { "code": { "coding": [{ "system": "http://hl7.org/fhir/CodeSystem/measure-population",
                               "code": "initial-population" }] },
        "count": 1 }
    ]
  },
  {
    "component": [
      { "code": { "text": "ProductLine" }, "value": { "text": "POS" } },
      { "code": { "text": "Race" },        "value": { "text": "AskedButNoAnswer" } },
      { "code": { "text": "Ethnicity" },   "value": { "text": "AskedButNoAnswer" } }
    ],
    "population": [
      { "code": { "coding": [{ "system": "http://hl7.org/fhir/CodeSystem/measure-population",
                               "code": "initial-population" }] },
        "count": 1 }
    ]
  }
]
```
