### PR TITLE
Add cohort measure test with patient-id stratifier

### DIFF
--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasurePatientIdSdeTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasurePatientIdSdeTest.java
@@ -1,0 +1,58 @@
+package org.opencds.cqf.fhir.cr.measure.r4;
+
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureConstants.EXT_SDE_REFERENCE_URL;
+
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.cr.measure.common.MeasurePopulationType;
+import org.opencds.cqf.fhir.cr.measure.r4.Measure.Given;
+
+/**
+ * Companion to {@link MeasurePatientIdStratifierTest} that demonstrates the supplemental-data-element
+ * (SDE) approach to emitting the initial-population patient ids, rather than the stratifier approach.
+ *
+ * <p>The SDE expression re-uses the InitialPopulation logic and returns {@code Patient.id.value} only
+ * for the members of the initial population ({@code if "InitialPopulation" then Patient.id.value else
+ * null}). Patients outside the population evaluate to null and are dropped during SDE accumulation, so
+ * they never appear in the report.
+ *
+ * <p>In a "population" (Summary) report each distinct SDE value becomes its own contained
+ * {@code Observation}, whose code carries the patient id and whose value is the count (1 per id). Only
+ * the 3 female patients are emitted; the 2 male patients are absent.
+ */
+@SuppressWarnings("squid:S2699")
+class MeasurePatientIdSdeTest {
+
+    private static final Given GIVEN_FEASIBILITY_SDE = Measure.given().repositoryFor("FeasibilityMeasureSde");
+
+    @Test
+    void cohortPatientIdSdePopulationReportListsInitialPopulationMembers() {
+        GIVEN_FEASIBILITY_SDE
+                .when()
+                .measureId("FeasibilityMeasureSde")
+                .reportType("population")
+                .evaluate()
+                .then()
+                .hasReportType("Summary")
+                .firstGroup()
+                // Only the 3 female patients are in the cohort's initial population.
+                .population(MeasurePopulationType.INITIALPOPULATION)
+                .hasCount(3)
+                .up()
+                .up()
+                // One contained Observation per initial-population member (3 ids), and no others.
+                .hasContainedResourceCount(3)
+                .containedObservationsHaveMatchingExtension()
+                // Each id appears as the Observation code, with a count of 1.
+                .containedByCoding("patient-1")
+                .observationCount(1)
+                .up()
+                .containedByCoding("patient-3")
+                .observationCount(1)
+                .up()
+                .containedByCoding("patient-5")
+                .observationCount(1)
+                .up()
+                // The report links each contained Observation via a supplementalData extension.
+                .hasExtension(EXT_SDE_REFERENCE_URL, 3);
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasurePatientIdStratifierTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasurePatientIdStratifierTest.java
@@ -1,0 +1,71 @@
+package org.opencds.cqf.fhir.cr.measure.r4;
+
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.cr.measure.common.MeasurePopulationType;
+import org.opencds.cqf.fhir.cr.measure.r4.Measure.Given;
+
+/**
+ * Integration-style test for a cohort Measure whose stratifier is driven by a CQL expression that
+ * returns the Patient id ({@code define PatientIdStratifier: Patient.id.value}).
+ *
+ * <p>There are 5 patients in the repository, but the initial population CQL only selects the 3
+ * female patients. A "population" (Summary) report still evaluates the stratifier for every subject,
+ * so each patient id gets its own stratum: the 3 patients in the initial population have a count of
+ * 1, and the 2 excluded patients have a count of 0.
+ */
+@SuppressWarnings("squid:S2699")
+class MeasurePatientIdStratifierTest {
+
+    private static final Given GIVEN_FEASIBILITY = Measure.given().repositoryFor("FeasibilityMeasure");
+
+    @Test
+    void cohortPatientIdStratifierPopulationReportOneStratumPerPatient() {
+        GIVEN_FEASIBILITY
+                .when()
+                .measureId("FeasibilityMeasure")
+                .reportType("population")
+                .evaluate()
+                .then()
+                .hasReportType("Summary")
+                .firstGroup()
+                // Only the 3 female patients are in the cohort's initial population.
+                .population(MeasurePopulationType.INITIALPOPULATION)
+                .hasCount(3)
+                .up()
+                .hasStratifierCount(1)
+                .firstStratifier()
+                .hasCodeText("PatientIdStratifier")
+                // Every evaluated patient id gets its own stratum, including the 2 not in the population.
+                .hasStratumCount(5)
+                // The 3 patients in the initial population each have a count of 1.
+                .stratumByComponentValueText("patient-1")
+                .hasComponentValueText("patient-1")
+                .population(MeasurePopulationType.INITIALPOPULATION)
+                .hasCount(1)
+                .up()
+                .up()
+                .stratumByComponentValueText("patient-3")
+                .hasComponentValueText("patient-3")
+                .population(MeasurePopulationType.INITIALPOPULATION)
+                .hasCount(1)
+                .up()
+                .up()
+                .stratumByComponentValueText("patient-5")
+                .hasComponentValueText("patient-5")
+                .population(MeasurePopulationType.INITIALPOPULATION)
+                .hasCount(1)
+                .up()
+                .up()
+                // The 2 male patients are excluded from the population, so their strata have a count of 0.
+                .stratumByComponentValueText("patient-2")
+                .hasComponentValueText("patient-2")
+                .population(MeasurePopulationType.INITIALPOPULATION)
+                .hasCount(0)
+                .up()
+                .up()
+                .stratumByComponentValueText("patient-4")
+                .hasComponentValueText("patient-4")
+                .population(MeasurePopulationType.INITIALPOPULATION)
+                .hasCount(0);
+    }
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasure/input/cql/FeasibilityMeasure.cql
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasure/input/cql/FeasibilityMeasure.cql
@@ -1,0 +1,14 @@
+library FeasibilityMeasure version '1.0.0'
+
+using FHIR version '4.0.1'
+
+include FHIRHelpers version '4.0.1' called FHIRHelpers
+
+context Patient
+
+// Only female patients qualify, so 3 of the 5 patients land in the initial population.
+define "InitialPopulation":
+  Patient.gender = 'female'
+
+define "PatientIdStratifier":
+  Patient.id.value

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasure/input/resources/library/FeasibilityMeasure.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasure/input/resources/library/FeasibilityMeasure.json
@@ -1,0 +1,18 @@
+{
+  "resourceType": "Library",
+  "id": "FeasibilityMeasure",
+  "url": "https://research.balgrist.ch/Library/FeasibilityMeasure",
+  "version": "1.0.0",
+  "name": "FeasibilityMeasure",
+  "status": "active",
+  "type": {
+    "coding": [ {
+      "system": "http://terminology.hl7.org/CodeSystem/library-type",
+      "code": "logic-library"
+    } ]
+  },
+  "content": [ {
+    "contentType": "text/cql",
+    "url": "../../cql/FeasibilityMeasure.cql"
+  } ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasure/input/resources/measure/FeasibilityMeasure.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasure/input/resources/measure/FeasibilityMeasure.json
@@ -1,0 +1,71 @@
+{
+  "resourceType": "Measure",
+  "id": "FeasibilityMeasure",
+  "url": "https://research.balgrist.ch/Measure/FeasibilityMeasure",
+  "version": "1.0.0",
+  "name": "FeasibilityMeasure",
+  "title": "Patient and Imaging Study Feasibility Measure",
+  "status": "active",
+  "description": "Counts patients matching specified demographic and imaging study inclusion/exclusion criteria.",
+  "library": [
+    "https://research.balgrist.ch/Library/FeasibilityMeasure|1.0.0"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "boolean"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/measure-scoring",
+        "code": "cohort",
+        "display": "Cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "feasibility-cohort",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "InitialPopulation"
+          }
+        }
+      ],
+      "stratifier": [
+        {
+          "id": "patient-id-stratifier",
+          "code": {
+            "text": "PatientIdStratifier"
+          },
+          "component": [
+            {
+              "id": "patient-id-stratifier-component",
+              "code": {
+                "text": "PatientId"
+              },
+              "criteria": {
+                "language": "text/cql-identifier",
+                "expression": "PatientIdStratifier"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasure/input/tests/patient/patient-1.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasure/input/tests/patient/patient-1.json
@@ -1,0 +1,6 @@
+{
+  "resourceType": "Patient",
+  "id": "patient-1",
+  "gender": "female",
+  "birthDate": "1980-05-12"
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasure/input/tests/patient/patient-2.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasure/input/tests/patient/patient-2.json
@@ -1,0 +1,6 @@
+{
+  "resourceType": "Patient",
+  "id": "patient-2",
+  "gender": "male",
+  "birthDate": "1975-11-03"
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasure/input/tests/patient/patient-3.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasure/input/tests/patient/patient-3.json
@@ -1,0 +1,6 @@
+{
+  "resourceType": "Patient",
+  "id": "patient-3",
+  "gender": "female",
+  "birthDate": "1990-02-20"
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasure/input/tests/patient/patient-4.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasure/input/tests/patient/patient-4.json
@@ -1,0 +1,6 @@
+{
+  "resourceType": "Patient",
+  "id": "patient-4",
+  "gender": "male",
+  "birthDate": "1968-07-30"
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasure/input/tests/patient/patient-5.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasure/input/tests/patient/patient-5.json
@@ -1,0 +1,6 @@
+{
+  "resourceType": "Patient",
+  "id": "patient-5",
+  "gender": "female",
+  "birthDate": "2001-09-14"
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasureSde/input/cql/FeasibilityMeasureSde.cql
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasureSde/input/cql/FeasibilityMeasureSde.cql
@@ -1,0 +1,18 @@
+library FeasibilityMeasureSde version '1.0.0'
+
+using FHIR version '4.0.1'
+
+include FHIRHelpers version '4.0.1' called FHIRHelpers
+
+context Patient
+
+// Only female patients qualify, so 3 of the 5 patients land in the initial population.
+define "InitialPopulation":
+  Patient.gender = 'female'
+
+// Supplemental data element that emits the Patient id, but only for the members of the
+// initial population. It re-uses the InitialPopulation define so the list stays consistent
+// with the cohort. Patients not in the population evaluate to null and are dropped during
+// SDE accumulation (CriteriaResult.nonNullValues), so they never appear in the report.
+define "InitialPopulationIds":
+  if "InitialPopulation" then Patient.id.value else null

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasureSde/input/resources/library/FeasibilityMeasureSde.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasureSde/input/resources/library/FeasibilityMeasureSde.json
@@ -1,0 +1,18 @@
+{
+  "resourceType": "Library",
+  "id": "FeasibilityMeasureSde",
+  "url": "https://research.balgrist.ch/Library/FeasibilityMeasureSde",
+  "version": "1.0.0",
+  "name": "FeasibilityMeasureSde",
+  "status": "active",
+  "type": {
+    "coding": [ {
+      "system": "http://terminology.hl7.org/CodeSystem/library-type",
+      "code": "logic-library"
+    } ]
+  },
+  "content": [ {
+    "contentType": "text/cql",
+    "url": "../../cql/FeasibilityMeasureSde.cql"
+  } ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasureSde/input/resources/measure/FeasibilityMeasureSde.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasureSde/input/resources/measure/FeasibilityMeasureSde.json
@@ -1,0 +1,71 @@
+{
+  "resourceType": "Measure",
+  "id": "FeasibilityMeasureSde",
+  "url": "https://research.balgrist.ch/Measure/FeasibilityMeasureSde",
+  "version": "1.0.0",
+  "name": "FeasibilityMeasureSde",
+  "title": "Patient Feasibility Measure with Initial Population Id SDE",
+  "status": "active",
+  "description": "Counts patients matching demographic inclusion criteria and emits the initial-population patient ids as a supplemental data element.",
+  "library": [
+    "https://research.balgrist.ch/Library/FeasibilityMeasureSde|1.0.0"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "boolean"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/measure-scoring",
+        "code": "cohort",
+        "display": "Cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "feasibility-cohort",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "InitialPopulation"
+          }
+        }
+      ]
+    }
+  ],
+  "supplementalData": [
+    {
+      "id": "sde-initial-population-ids",
+      "usage": [
+        {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/measure-data-usage",
+              "code": "supplemental-data"
+            }
+          ]
+        }
+      ],
+      "description": "Patient ids of the initial population members",
+      "criteria": {
+        "language": "text/cql-identifier",
+        "expression": "InitialPopulationIds"
+      }
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasureSde/input/tests/patient/patient-1.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasureSde/input/tests/patient/patient-1.json
@@ -1,0 +1,6 @@
+{
+  "resourceType": "Patient",
+  "id": "patient-1",
+  "gender": "female",
+  "birthDate": "1980-05-12"
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasureSde/input/tests/patient/patient-2.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasureSde/input/tests/patient/patient-2.json
@@ -1,0 +1,6 @@
+{
+  "resourceType": "Patient",
+  "id": "patient-2",
+  "gender": "male",
+  "birthDate": "1975-11-03"
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasureSde/input/tests/patient/patient-3.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasureSde/input/tests/patient/patient-3.json
@@ -1,0 +1,6 @@
+{
+  "resourceType": "Patient",
+  "id": "patient-3",
+  "gender": "female",
+  "birthDate": "1990-02-20"
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasureSde/input/tests/patient/patient-4.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasureSde/input/tests/patient/patient-4.json
@@ -1,0 +1,6 @@
+{
+  "resourceType": "Patient",
+  "id": "patient-4",
+  "gender": "male",
+  "birthDate": "1968-07-30"
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasureSde/input/tests/patient/patient-5.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/FeasibilityMeasureSde/input/tests/patient/patient-5.json
@@ -1,0 +1,6 @@
+{
+  "resourceType": "Patient",
+  "id": "patient-5",
+  "gender": "female",
+  "birthDate": "2001-09-14"
+}


### PR DESCRIPTION
Adds an integration-style Measure evaluation test (FeasibilityMeasure) exercising a cohort-scored measure whose stratifier is keyed by the patient id via a component criteria expression (Patient.id.value). The initial population selects 3 of 5 patients; a population (Summary) report produces one stratum per patient id, with population counts of 1 for the in-cohort patients and 0 for the excluded ones.