### PR TITLE
Update CQL to 4.9.0 and HAPI FHIR to 8.10.0

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/EvaluationResultFormatter.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/EvaluationResultFormatter.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.opencds.cqf.cql.engine.execution.EvaluationResult;
@@ -257,7 +256,7 @@ public class EvaluationResultFormatter {
 
         final Set<Object> resources = populationDef.getSubjectResources().get(subjectId);
 
-        if (CollectionUtils.isEmpty(resources)) {
+        if (resources == null || resources.isEmpty()) {
             return subjectId + ": {empty}";
         }
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureEvaluator.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureEvaluator.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
-import org.apache.commons.collections4.CollectionUtils;
 import org.opencds.cqf.cql.engine.execution.EvaluationResult;
 import org.opencds.cqf.cql.engine.execution.ExpressionResult;
 import org.opencds.cqf.fhir.cr.measure.r4.R4MeasureScoringTypePopulations;
@@ -384,7 +383,8 @@ public class MeasureEvaluator {
             String subjectId) {
         // only enabled for subject level reports
         if (reportType == MeasureReportType.INDIVIDUAL
-                && !CollectionUtils.isEmpty(populationDef.getSupportingEvidenceDefs())) {
+                && !(populationDef.getSupportingEvidenceDefs() == null
+                        || populationDef.getSupportingEvidenceDefs().isEmpty())) {
             var extDef = populationDef.getSupportingEvidenceDefs();
             for (SupportingEvidenceDef e : extDef) {
                 var result = evaluationResult.get(e.getExpression());
@@ -557,7 +557,7 @@ public class MeasureEvaluator {
 
             final Set<?> entryValue = entry.getValue();
 
-            if (CollectionUtils.isEmpty(entryValue)) {
+            if (entryValue == null || entryValue.isEmpty()) {
                 continue;
             }
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureMultiSubjectEvaluator.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureMultiSubjectEvaluator.java
@@ -14,7 +14,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
-import org.apache.commons.collections4.CollectionUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.opencds.cqf.fhir.cr.measure.MeasureStratifierType;
 
@@ -572,7 +571,7 @@ public class MeasureMultiSubjectEvaluator {
         // Scalar value: expand to match the alignment row keys produced by any multi-value
         // components (functions or iterables) on this subject, so the scalar lands in every stratum.
         Set<StratifierRowKey> alignmentRowKeys = alignmentRowKeysBySubject.get(qualifiedSubject);
-        if (CollectionUtils.isNotEmpty(alignmentRowKeys)) {
+        if (!(alignmentRowKeys == null || alignmentRowKeys.isEmpty())) {
             return expandScalarToAlignmentRowKeys(alignmentRowKeys, rawValue);
         }
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureObservationHandler.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureObservationHandler.java
@@ -2,7 +2,6 @@ package org.opencds.cqf.fhir.cr.measure.common;
 
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,12 +36,12 @@ public class MeasureObservationHandler {
         }
 
         final Set<Object> exclusionResources = measurePopulationExclusionDef.getResourcesForSubject(subjectId);
-        if (CollectionUtils.isEmpty(exclusionResources)) {
+        if (exclusionResources == null || exclusionResources.isEmpty()) {
             return;
         }
 
         final Set<Object> observationResources = measureObservationDef.getResourcesForSubject(subjectId);
-        if (CollectionUtils.isEmpty(observationResources)) {
+        if (observationResources == null || observationResources.isEmpty()) {
             return;
         }
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureDefBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureDefBuilder.java
@@ -18,7 +18,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
@@ -456,7 +455,7 @@ public class R4MeasureDefBuilder implements MeasureDefBuilder<Measure> {
                     return SDE_USAGE_CODE.equals(code) || RISK_ADJUSTMENT_USAGE_CODE.equals(code);
                 })
                 .toList();
-        if (CollectionUtils.isEmpty(hasUsage)) {
+        if (hasUsage.isEmpty()) {
             throw new InvalidRequestException(
                     "SupplementalDataComponent usage is missing code: %s or %s for Measure: %s"
                             .formatted(SDE_USAGE_CODE, RISK_ADJUSTMENT_USAGE_CODE, measure.getUrl()));

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-hapi = "8.8.1"
-cql = "4.8.0"
+hapi = "8.10.0"
+cql = "4.9.0"
 junit = "5.14.3"
 slf4j = "2.0.17"
 spring-boot = "3.4.11"


### PR DESCRIPTION
Follows the latest release of CQL https://github.com/cqframework/clinical_quality_language/releases/tag/v4.9.0 with the updated HAPI FHIR.