### PR TITLE
Update $ersd-v2-import to preserve 'reporting' intendedUsageContext

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/ecr/r4/R4ImportBundleProducer.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/ecr/r4/R4ImportBundleProducer.java
@@ -112,27 +112,31 @@ public class R4ImportBundleProducer {
                 switch (resource.getResourceType()) {
                     case ValueSet:
                         var valueSet = (ValueSet) resource;
-                        List<UsageContext> conditionsList = new ArrayList<>();
+                        List<UsageContext> genericContextList = new ArrayList<>();
                         List<UsageContext> priorityList = new ArrayList<>();
                         valueSet.setIdentifier(fixIdentifiers(valueSet.getIdentifier()));
                         var valueSetCanonicalUrl = adapterFactory
                                 .createKnowledgeArtifactAdapter(valueSet)
                                 .getCanonical();
-                        extractPrioritiesAndConditions(
-                                valueSet.getUseContext(), priorityList, conditionsList, valueSetCanonicalUrl);
+                        extractUsageContexts(
+                                valueSet.getUseContext(), priorityList, genericContextList, valueSetCanonicalUrl);
                         if (hasGrouperCompose(valueSet)) {
                             prepareGrouperValueSet(valueSet, appAuthoritativeUrl);
-                            groupers.add(
-                                    relatedArtifactFromGrouperUrl(valueSetCanonicalUrl, conditionsList, priorityList));
+                            groupers.add(relatedArtifactFromGrouperUrl(
+                                    valueSetCanonicalUrl, genericContextList, priorityList));
                         } else {
                             prepareLeafValueSet(valueSet);
-                            leafs.add(relatedArtifactFromLeafUrl(valueSetCanonicalUrl, conditionsList, priorityList));
+                            leafs.add(
+                                    relatedArtifactFromLeafUrl(valueSetCanonicalUrl, genericContextList, priorityList));
                         }
                         // Remove conditions and priority from useContext of leaf valuesets and groupers
                         var cleanedContext = valueSet.getUseContext().stream()
                                 .filter(ctx -> ctx.hasCode()
-                                        && !(ctx.getCode().getCode().equals("focus")
-                                                || ctx.getCode().getCode().equals("priority")))
+                                                && !(ctx.getCode().getCode().equals("focus")
+                                                        || ctx.getCode()
+                                                                .getCode()
+                                                                .equals("priority"))
+                                        || ctx.getCode().getCode().equals("reporting"))
                                 .collect(Collectors.toList());
                         valueSet.setUseContext(cleanedContext);
                         // Check if ValueSet already exists
@@ -249,10 +253,10 @@ public class R4ImportBundleProducer {
                 .collect(Collectors.toList());
     }
 
-    static void extractPrioritiesAndConditions(
+    static void extractUsageContexts(
             List<UsageContext> contexts,
             List<UsageContext> priorityList,
-            List<UsageContext> conditionsList,
+            List<UsageContext> genericContextList,
             String valueSetCanonicalUrl) {
 
         if (contexts == null || contexts.isEmpty()) return;
@@ -262,7 +266,7 @@ public class R4ImportBundleProducer {
             if (!isValidUsageContext) continue;
 
             switch (context.getCode().getCode()) {
-                case "focus" -> conditionsList.add(context);
+                case "focus", "reporting" -> genericContextList.add(context);
                 case "priority" -> handlePriorityContext(context, priorityList, valueSetCanonicalUrl);
                 default -> {
                     /* ignore other usage contexts */
@@ -360,7 +364,7 @@ public class R4ImportBundleProducer {
     }
 
     private static RelatedArtifact relatedArtifactFromGrouperUrl(
-            String grouperUrl, List<UsageContext> conditions, List<UsageContext> priorities) {
+            String grouperUrl, List<UsageContext> genericContexts, List<UsageContext> priorities) {
         var relatedArtifact = new RelatedArtifact();
         relatedArtifact.setType(RelatedArtifact.RelatedArtifactType.COMPOSEDOF);
         relatedArtifact.setResource(grouperUrl);
@@ -368,8 +372,8 @@ public class R4ImportBundleProducer {
         isOwnedExtension.setUrl(TransformProperties.crmiIsOwned);
         isOwnedExtension.setValue(new BooleanType(true));
         var extensions = new ArrayList<Extension>();
-        extensions.addAll(
-                processUsageContextMapForLibrary(conditions, TransformProperties.CRMI_INTENDED_USAGE_CONTEXT_EXT_URL));
+        extensions.addAll(processUsageContextMapForLibrary(
+                genericContexts, TransformProperties.CRMI_INTENDED_USAGE_CONTEXT_EXT_URL));
         extensions.addAll(
                 processUsageContextMapForLibrary(priorities, TransformProperties.CRMI_INTENDED_USAGE_CONTEXT_EXT_URL));
         extensions.add(isOwnedExtension);
@@ -378,13 +382,13 @@ public class R4ImportBundleProducer {
     }
 
     private static RelatedArtifact relatedArtifactFromLeafUrl(
-            String leafUrl, List<UsageContext> conditions, List<UsageContext> priorities) {
+            String leafUrl, List<UsageContext> genericContexts, List<UsageContext> priorities) {
         var relatedArtifact = new RelatedArtifact();
         relatedArtifact.setType(RelatedArtifact.RelatedArtifactType.DEPENDSON);
         relatedArtifact.setResource(leafUrl);
         var extensions = new ArrayList<Extension>();
-        extensions.addAll(
-                processUsageContextMapForLibrary(conditions, TransformProperties.CRMI_INTENDED_USAGE_CONTEXT_EXT_URL));
+        extensions.addAll(processUsageContextMapForLibrary(
+                genericContexts, TransformProperties.CRMI_INTENDED_USAGE_CONTEXT_EXT_URL));
         extensions.addAll(
                 processUsageContextMapForLibrary(priorities, TransformProperties.CRMI_INTENDED_USAGE_CONTEXT_EXT_URL));
         relatedArtifact.setExtension(extensions);

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/ecr/r4/R4ImportBundleProducer.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/ecr/r4/R4ImportBundleProducer.java
@@ -132,11 +132,9 @@ public class R4ImportBundleProducer {
                         // Remove conditions and priority from useContext of leaf valuesets and groupers
                         var cleanedContext = valueSet.getUseContext().stream()
                                 .filter(ctx -> ctx.hasCode()
-                                                && !(ctx.getCode().getCode().equals("focus")
-                                                        || ctx.getCode()
-                                                                .getCode()
-                                                                .equals("priority"))
-                                        || ctx.getCode().getCode().equals("reporting"))
+                                        && !(ctx.getCode().getCode().equals("focus")
+                                                || ctx.getCode().getCode().equals("priority")
+                                                || ctx.getCode().getCode().equals("reporting")))
                                 .collect(Collectors.toList());
                         valueSet.setUseContext(cleanedContext);
                         // Check if ValueSet already exists

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/ecr/r4/R4ImportBundleProducerTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/ecr/r4/R4ImportBundleProducerTest.java
@@ -147,7 +147,7 @@ class R4ImportBundleProducerTest {
                 conditionUsageContext.getValueCodeableConcept().getText());
 
         UsageContext priorityUsageContext =
-                (UsageContext) ra.get(0).getExtension().get(1).getValue();
+                (UsageContext) ra.get(0).getExtension().get(2).getValue();
         assertEquals("priority", priorityUsageContext.getCode().getCode());
         assertEquals(
                 "routine",
@@ -248,8 +248,8 @@ class R4ImportBundleProducerTest {
     }
 
     @Test
-    void testExtractPrioritiesAndConditionsPopulatesLists() {
-        // focus usage context goes to conditions
+    void testExtractUsageContextsPopulatesLists() {
+        // focus usage context goes to genericUseContexts
         UsageContext context1 = new UsageContext();
         context1.setCode(new Coding().setCode("focus"));
         context1.setValue(new CodeableConcept().setText("Condition1").addCoding(new Coding().setCode("condition1")));
@@ -259,24 +259,38 @@ class R4ImportBundleProducerTest {
         context2.setCode(new Coding().setCode("priority"));
         context2.setValue(new CodeableConcept().addCoding(new Coding().setCode("routine")));
 
+        // reporting usage context goes to genericUseContexts
+        UsageContext context3 = new UsageContext();
+        context3.setCode(new Coding().setCode("reporting"));
+        context3.setValue(new CodeableConcept().addCoding(new Coding().setCode("triggering")));
+
         List<UsageContext> priorities = new ArrayList<>();
-        List<UsageContext> conditions = new ArrayList<>();
+        List<UsageContext> genericUseContexts = new ArrayList<>();
 
         // Execute
-        R4ImportBundleProducer.extractPrioritiesAndConditions(
-                Arrays.asList(context1, context2), priorities, conditions, "fakeUrl");
+        R4ImportBundleProducer.extractUsageContexts(
+                Arrays.asList(context1, context2, context3), priorities, genericUseContexts, "fakeUrl");
 
         // Verify
         assertEquals(1, priorities.size());
         assertEquals(
                 "routine",
                 priorities.get(0).getValueCodeableConcept().getCodingFirstRep().getCode());
-        assertEquals(1, conditions.size());
-        assertEquals("Condition1", conditions.get(0).getValueCodeableConcept().getText());
+        assertEquals(2, genericUseContexts.size());
+        assertEquals(
+                "Condition1",
+                genericUseContexts.get(0).getValueCodeableConcept().getText());
+        assertEquals(
+                "triggering",
+                genericUseContexts
+                        .get(1)
+                        .getValueCodeableConcept()
+                        .getCodingFirstRep()
+                        .getCode());
     }
 
     @Test
-    void testExtractPrioritiesAndConditionsConflictingPrioritiesThrows() {
+    void testExtractUsageContextsConflictingPrioritiesThrows() {
         UsageContext context1 = new UsageContext();
         context1.setCode(new Coding().setCode("priority"));
         context1.setValue(new CodeableConcept().addCoding(new Coding().setCode("urgent")));
@@ -285,13 +299,17 @@ class R4ImportBundleProducerTest {
         context2.setCode(new Coding().setCode("priority"));
         context2.setValue(new CodeableConcept().addCoding(new Coding().setCode("routine")));
 
+        UsageContext context3 = new UsageContext();
+        context3.setCode(new Coding().setCode("reporting"));
+        context3.setValue(new CodeableConcept().addCoding(new Coding().setCode("triggering")));
+
         List<UsageContext> priorities = new ArrayList<>();
-        List<UsageContext> conditions = new ArrayList<>();
+        List<UsageContext> genericUseContexts = new ArrayList<>();
 
         assertThrows(
                 UnprocessableEntityException.class,
-                () -> R4ImportBundleProducer.extractPrioritiesAndConditions(
-                        Arrays.asList(context1, context2), priorities, conditions, "http://example.com/fhir"));
+                () -> R4ImportBundleProducer.extractUsageContexts(
+                        Arrays.asList(context1, context2), priorities, genericUseContexts, "http://example.com/fhir"));
     }
 
     @Test


### PR DESCRIPTION
$ersd-v2-import was only forwarding 'focus' and 'priority' usage contexts from a leaf/grouper ValueSet onto the corresponding relatedArtifact reference in the root Library. Any other usage context authored on the ValueSet was silently dropped.

This change ensures that the 'reporting' usage context (if present on a ValueSet) is included in the root Library relatedArtifact reference.

Tests updated to reflect.