### PR TITLE
Make the CompartmentAssignment and ResourcePathResolver public

### DIFF
--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/repository/ig/CompartmentAssigner.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/repository/ig/CompartmentAssigner.java
@@ -24,7 +24,7 @@ import org.opencds.cqf.fhir.utility.repository.ig.IgConventions.CompartmentIsola
  * Determines the compartment assignment for a resource based on repository conventions
  * and resource references.
  */
-class CompartmentAssigner {
+public class CompartmentAssigner {
 
     // Search parameters that likely reference compartments,
     // in order of priority to use to determine compartment membership
@@ -35,7 +35,7 @@ class CompartmentAssigner {
     private final CompartmentMode compartmentMode;
     private final CompartmentIsolation compartmentIsolation;
 
-    CompartmentAssigner(
+    public CompartmentAssigner(
             FhirContext fhirContext, CompartmentMode compartmentMode, CompartmentIsolation compartmentIsolation) {
         this.fhirContext = Objects.requireNonNull(fhirContext, "fhirContext cannot be null");
         this.compartmentMode = Objects.requireNonNull(compartmentMode, "compartmentMode cannot be null");
@@ -103,7 +103,7 @@ class CompartmentAssigner {
      * - UNKNOWN: Resource belongs to the current compartment type, but the specific compartment cannot be determined
      * @return The compartment assignment for the resource
      */
-    CompartmentAssignment fromId(String resourceType, IIdType id) {
+    public CompartmentAssignment fromId(String resourceType, IIdType id) {
         requireNonNull(resourceType, "resourceType cannot be null");
         requireNonNull(id, "id cannot be null");
 

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/repository/ig/CompartmentAssignment.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/repository/ig/CompartmentAssignment.java
@@ -7,7 +7,7 @@ import java.util.function.Supplier;
  * Represents the compartment directory segments that should be applied when
  * resolving a filesystem location for a resource.
  */
-record CompartmentAssignment(String compartmentType, String compartmentId) {
+public record CompartmentAssignment(String compartmentType, String compartmentId) {
 
     static final String SHARED_COMPARTMENT = "shared";
 

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/repository/ig/ResourcePathResolver.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/repository/ig/ResourcePathResolver.java
@@ -21,7 +21,7 @@ import org.opencds.cqf.fhir.utility.repository.ig.IgConventions.CompartmentIsola
 /**
  * Resolves filesystem locations for resources according to IG/KALM conventions.
  */
-class ResourcePathResolver {
+public class ResourcePathResolver {
 
     static final String EXTERNAL_DIRECTORY = "external";
 
@@ -71,7 +71,7 @@ class ResourcePathResolver {
     private final Path root;
     private final IgConventions conventions;
 
-    ResourcePathResolver(Path root, IgConventions conventions) {
+    public ResourcePathResolver(Path root, IgConventions conventions) {
         this.root = Objects.requireNonNull(root, "root cannot be null");
         this.conventions = Objects.requireNonNull(conventions, "conventions cannot be null");
     }
@@ -113,7 +113,7 @@ class ResourcePathResolver {
      * @param assignment the compartment assignment
      * @return a list of directories to search
      */
-    List<Path> directories(Class<? extends IBaseResource> resourceType, CompartmentAssignment assignment) {
+    public List<Path> directories(Class<? extends IBaseResource> resourceType, CompartmentAssignment assignment) {
         requireNonNull(resourceType, "resourceType cannot be null");
         requireNonNull(assignment, "assignment cannot be null");
         validateAssignment(resourceType, assignment);
@@ -133,10 +133,13 @@ class ResourcePathResolver {
             for (var path : expanded) {
                 var typedPath = typeSegment != null ? path.resolve(typeSegment) : path;
                 paths.add(typedPath);
-                // Terminology resources may also be found in an 'external' directory for some conventions
-                if (category == ResourceCategory.TERMINOLOGY
-                        && conventions.categoryLayout() != CategoryLayout.DEFINITIONAL_AND_DATA) {
-                    paths.add(typedPath.resolve(EXTERNAL_DIRECTORY));
+                if (category == ResourceCategory.TERMINOLOGY) {
+                    if (conventions.categoryLayout() == CategoryLayout.DEFINITIONAL_AND_DATA
+                            && base.equals(bases.get(0))) {
+                        paths.add(basePath.resolve(EXTERNAL_DIRECTORY));
+                    } else if (conventions.categoryLayout() != CategoryLayout.DEFINITIONAL_AND_DATA) {
+                        paths.add(typedPath.resolve(EXTERNAL_DIRECTORY));
+                    }
                 }
             }
         }
@@ -162,7 +165,7 @@ class ResourcePathResolver {
         }
     }
 
-    List<Path> candidates(
+    public List<Path> candidates(
             Class<? extends IBaseResource> resourceType, String idPart, CompartmentAssignment assignment) {
         requireNonNull(resourceType, "resourceType cannot be null");
         requireNonNull(idPart, "idPart cannot be null");
@@ -187,7 +190,7 @@ class ResourcePathResolver {
         return FILE_EXTENSIONS.inverse().get(fileExtension(path));
     }
 
-    Predicate<Path> fileMatcher(Class<? extends IBaseResource> resourceType) {
+    public Predicate<Path> fileMatcher(Class<? extends IBaseResource> resourceType) {
         var typeName = resourceType.getSimpleName().toLowerCase();
         return switch (conventions.filenameMode()) {
             case ID_ONLY -> path -> hasKnownExtension(path);
@@ -199,9 +202,12 @@ class ResourcePathResolver {
         };
     }
 
-    boolean isExternalPath(Path path) {
-        return path.getParent() != null
-                && path.getParent().toString().toLowerCase().endsWith(EXTERNAL_DIRECTORY);
+    public boolean isExternalPath(Path path) {
+        return isExternalDirectory(path) || (path.getParent() != null && isExternalDirectory(path.getParent()));
+    }
+
+    private boolean isExternalDirectory(Path path) {
+        return path.getFileName() != null && path.getFileName().toString().equalsIgnoreCase(EXTERNAL_DIRECTORY);
     }
 
     // Helper to get the base directories for a given category and the current layout conventions.

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/repository/ig/ResourcePathResolverTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/repository/ig/ResourcePathResolverTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.ValueSet;
@@ -79,6 +81,27 @@ class ResourcePathResolverTest {
         assertEquals(tempDir.resolve("src/fhir/valueset"), directories.get(0));
         assertTrue(directories.contains(tempDir.resolve("tests/data/fhir/shared/valueset")));
         assertFalse(directories.contains(tempDir.resolve("tests/data/fhir/valueset")));
+    }
+
+    @Test
+    void directoriesForTerminologyInKalmIncludeExternalSource(@TempDir Path tempDir) {
+        var resolver = new ResourcePathResolver(tempDir, IgConventions.KALM);
+        var external = tempDir.resolve("src/fhir/external");
+
+        assertEquals(
+                List.of(
+                        tempDir.resolve("src/fhir/valueset"),
+                        external,
+                        tempDir.resolve("tests/data/fhir/shared/valueset")),
+                resolver.directories(ValueSet.class, CompartmentAssignment.shared()));
+        assertEquals(
+                List.of(
+                        tempDir.resolve("src/fhir/codesystem"),
+                        tempDir.resolve("src/fhir/external"),
+                        tempDir.resolve("tests/data/fhir/shared/codesystem")),
+                resolver.directories(CodeSystem.class, CompartmentAssignment.shared()));
+        assertTrue(resolver.isExternalPath(external));
+        assertTrue(resolver.isExternalPath(external.resolve("example.json")));
     }
 
     @Test


### PR DESCRIPTION
This is to support extension work that would like to leverage CR path resolution to enforce a single source of truth for IgConventions and path resolution.  'external' is also supported by the KALM schema, so there is an update to allow src/fhir/external path resolution for valuesets and codesystems and a test to prove it.