### PR TITLE
Fix resolvePath throwing exception on array indexes ≥ 10

### DIFF
--- a/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/common/HapiCreateChangelogProcessor.java
+++ b/cqf-fhir-cr-hapi/src/main/java/org/opencds/cqf/fhir/cr/hapi/common/HapiCreateChangelogProcessor.java
@@ -239,7 +239,7 @@ public class HapiCreateChangelogProcessor implements ICreateChangelogProcessor {
             // Parameters object
             try {
                 if (originalValue.isEmpty() && !type.equals("insert") && sourceResource != null && path.isPresent()) {
-                    originalValue = Optional.of(IAdapterFactory.createAdapterForResource(sourceResource)
+                    originalValue = Optional.ofNullable(IAdapterFactory.createAdapterForResource(sourceResource)
                             .resolvePath(sourceResource, path.get()));
                 }
             } catch (Exception e) {

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/BaseAdapter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/adapter/BaseAdapter.java
@@ -59,9 +59,12 @@ public abstract class BaseAdapter {
         for (String identifier : identifiers) {
             // handling indexes: i.e. item[0].code
             if (identifier.contains("[")) {
-                int index = Character.getNumericValue(identifier.charAt(identifier.indexOf("[") + 1));
-                target = resolveProperty(target, identifier.replaceAll("\\[\\d]", ""));
-                target = ((ArrayList<?>) target).get(index);
+                int index = parseInt(identifier.substring(identifier.indexOf("[") + 1, identifier.indexOf("]")));
+                target = resolveProperty(target, identifier.replaceAll("\\[\\d+]", ""));
+                if (!(target instanceof List<?> list) || index >= list.size()) {
+                    return null;
+                }
+                target = list.get(index);
             } else {
                 target = resolveProperty(target, identifier);
             }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/AdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/AdapterTest.java
@@ -3,6 +3,7 @@ package org.opencds.cqf.fhir.utility.adapter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -14,6 +15,7 @@ import org.hl7.fhir.r4.model.CommunicationRequest;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +40,27 @@ class AdapterTest {
         library.setDate(new Date());
         var adapter = IAdapterFactory.createAdapterForResource(library);
         assertThrows(UnprocessableEntityException.class, () -> adapter.resolvePathString(library, "date"));
+    }
+
+    @Test
+    void testResolvePath_resolvesDoubleDigitIndex() {
+        var parameters = new Parameters();
+        for (int i = 0; i < 15; i++) {
+            parameters.addParameter().setName("param" + i).setValue(new StringType("value" + i));
+        }
+        var adapter = IAdapterFactory.createAdapterForResource(parameters);
+
+        assertEquals("param12", adapter.resolvePathString(parameters, "parameter[12].name"));
+        assertEquals("value12", adapter.resolvePathString(parameters, "parameter[12].value"));
+    }
+
+    @Test
+    void testResolvePath_returnsNullForOutOfRangeIndex() {
+        var parameters = new Parameters();
+        parameters.addParameter().setName("param0").setValue(new StringType("value0"));
+        var adapter = IAdapterFactory.createAdapterForResource(parameters);
+        
+        assertNull(adapter.resolvePath(parameters, "parameter[10]"));
     }
 
     @Test

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/AdapterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/adapter/AdapterTest.java
@@ -59,7 +59,7 @@ class AdapterTest {
         var parameters = new Parameters();
         parameters.addParameter().setName("param0").setValue(new StringType("value0"));
         var adapter = IAdapterFactory.createAdapterForResource(parameters);
-        
+
         assertNull(adapter.resolvePath(parameters, "parameter[10]"));
     }
 


### PR DESCRIPTION
`BaseAdapter.resolvePath` only handled single-digit list indexes.

For parameter[10] and beyond, the index extraction and the regex both silently failed, leaving the malformed literal "parameter[10]" passed through as a field name. That resolved to null, which was then force-cast and indexed, throwing an NPE.

Updated the logic to handle double-digit (or greater) indexes and return null instead of throwing NPE when the resolved value isnt a list or the index is out of range.

Updated HapiCreateChangelogProcessor to make sourceValue nullable.

Added unit tests to validate.