### PR TITLE
Fix issue with $populate not handling a null context value

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ItemProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ItemProcessor.java
@@ -248,11 +248,15 @@ public class ItemProcessor {
             var extension = item.getExtensionByUrl(Constants.SDC_QUESTIONNAIRE_INITIAL_EXPRESSION);
             // populate using expected initial expression extensions
             if (extension != null) {
-                // pass the context resource(s) as a parameter to the evaluation
-                var rawParams = request.getRawParameters();
-                rawParams.put("%" + contextName, context.get());
-                rawParams.put("%qitem", item.get());
-                populateAnswer(request, responseItem, getInitialValue(request, item, responseItem, rawParams));
+                List<IBase> initialValue = null;
+                if (context != null) {
+                    // pass the context resource(s) as a parameter to the evaluation
+                    var rawParams = request.getRawParameters();
+                    rawParams.put("%" + contextName, context.get());
+                    rawParams.put("%qitem", item.get());
+                    initialValue = getInitialValue(request, item, responseItem, rawParams);
+                }
+                populateAnswer(request, responseItem, initialValue);
             }
         }
         return responseItem;

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ItemProcessorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/questionnaire/populate/ItemProcessorTests.java
@@ -22,6 +22,7 @@ import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.r4.model.Base;
 import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Expression;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Questionnaire;
@@ -253,20 +254,29 @@ class ItemProcessorTests {
         var questionnaire = new Questionnaire();
         doReturn(FhirContext.forR4Cached()).when(repository).fhirContext();
         var populateRequest = newPopulateRequestForVersion(FhirVersionEnum.R4, libraryEngine, questionnaire);
+        var expression = new Expression()
+                .setLanguage("text/cql")
+                .setExpression("%subject.name.given[0]")
+                .setName("PatientName");
+        var cqfExpression = CqfExpression.of(expression, null);
         var questionnaireItem = new QuestionnaireItemComponent()
                 .setLinkId("1")
                 .setType(QuestionnaireItemType.GROUP)
                 .setDefinition("http://hl7.org/fhir/Patient#Patient.name.given");
-        var extensions = List.of(new Extension(Constants.SDC_QUESTIONNAIRE_ITEM_POPULATION_CONTEXT));
+        var extensions = List.of(new Extension(Constants.SDC_QUESTIONNAIRE_ITEM_POPULATION_CONTEXT, expression));
         questionnaireItem.setExtension(extensions);
-        var expression = new CqfExpression().setLanguage("text/cql").setExpression("%subject.name.given[0]");
+        var nestedItem = new QuestionnaireItemComponent().setLinkId("1.1");
+        nestedItem.addExtension(new Extension(
+                Constants.SDC_QUESTIONNAIRE_INITIAL_EXPRESSION,
+                new Expression().setLanguage("text/cql").setExpression("%PatientName.value")));
+        questionnaireItem.addItem(nestedItem);
         List<IBase> expressionResults = new ArrayList<>();
-        doReturn(expression)
+        doReturn(cqfExpression)
                 .when(expressionProcessor)
                 .getCqfExpression(populateRequest, extensions, Constants.SDC_QUESTIONNAIRE_ITEM_POPULATION_CONTEXT);
         doReturn(expressionResults)
                 .when(expressionProcessor)
-                .getExpressionResultForItem(eq(populateRequest), eq(expression), eq("1"), any(), any());
+                .getExpressionResultForItem(eq(populateRequest), eq(cqfExpression), eq("1"), any(), any());
         var adapter = (IQuestionnaireItemComponentAdapter)
                 IAdapterFactory.createAdapterForBase(populateRequest.getFhirVersion(), questionnaireItem);
         var actual = itemProcessor.processContextItem(populateRequest, adapter);


### PR DESCRIPTION
When using the SDC Item Population Context expression, if the expression returns a null value that subsequent initial expression evaluation would fail attempting to resolve a null parameter.  This has been fixed to only attempt evaluation if the context value is not null.

Resolves [EPAS-296](https://simpaticois.atlassian.net/browse/EPAS-296)