### PR TITLE
Ensure $draft floats leaf ValueSet references on the manifest as well as the grouper

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/DraftVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/DraftVisitor.java
@@ -4,8 +4,10 @@ import ca.uhn.fhir.repository.IRepository;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -19,6 +21,7 @@ import org.hl7.fhir.instance.model.api.IDomainResource;
 import org.opencds.cqf.fhir.cr.crmi.KnowledgeArtifactProcessor;
 import org.opencds.cqf.fhir.utility.BundleHelper;
 import org.opencds.cqf.fhir.utility.Canonicals;
+import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.PackageHelper;
 import org.opencds.cqf.fhir.utility.SearchHelper;
 import org.opencds.cqf.fhir.utility.VersionUtilities;
@@ -82,6 +85,10 @@ public class DraftVisitor extends BaseKnowledgeArtifactVisitor {
         }
         // create draft resources
         List<IDomainResource> resourcesToCreate = createDraftsOfArtifactAndRelated(libRes, version, new ArrayList<>());
+        // Draft should float leaf versions, so unpin every reference to them,
+        // the grouper's compose and the manifest's depends-on have to stay in agreement
+        var leafUrlsToFloat = collectLeafUrlsToFloat(resourcesToCreate);
+        resourcesToCreate.forEach(res -> unpinLeafReferences(res, leafUrlsToFloat));
         var transactionBundle = BundleHelper.newBundle(fhirVersion(), null, "transaction");
         List<String> urnList = resourcesToCreate.stream()
                 .map(res -> "urn:uuid:" + UUID.randomUUID().toString())
@@ -102,6 +109,53 @@ public class DraftVisitor extends BaseKnowledgeArtifactVisitor {
         // DependencyInfo --document here that there is a need for figuring out how to determine which package the
         // dependency is in.
         // what is dependency, where did it originate? potentially the package?
+    }
+
+    private boolean isGrouper(IDomainResource resource) {
+        return switch (repository.fhirContext().getVersion().getVersion()) {
+            case DSTU3 -> KnowledgeArtifactProcessor.isGrouper((org.hl7.fhir.dstu3.model.MetadataResource) resource);
+            case R4 -> KnowledgeArtifactProcessor.isGrouper((org.hl7.fhir.r4.model.MetadataResource) resource);
+            case R5 -> KnowledgeArtifactProcessor.isGrouper((org.hl7.fhir.r5.model.MetadataResource) resource);
+            default ->
+                throw new UnprocessableEntityException("Unsupported FHIR version: "
+                        + repository.fhirContext().getVersion().getVersion());
+        };
+    }
+
+    /**
+     * Finds grouper referenced leaf ValueSets that draft should float to latest.
+     */
+    private Set<String> collectLeafUrlsToFloat(List<IDomainResource> resources) {
+        return resources.stream()
+                .filter(this::isGrouper)
+                .map(res -> IAdapterFactory.forFhirVersion(fhirVersion()).createKnowledgeArtifactAdapter(res))
+                .flatMap(adapter -> adapter.getDependencies().stream())
+                .map(IDependencyInfo::getReference)
+                .filter(StringUtils::isNotBlank)
+                .map(Canonicals::getUrl)
+                .filter(StringUtils::isNotBlank)
+                .filter(url -> Constants.RESOURCETYPE_VALUESET.equals(Canonicals.getResourceType(url)))
+                .collect(Collectors.toCollection(HashSet::new));
+    }
+
+    /**
+     * Unpins every reference to a floating leaf, so a draft picks up the newest leaf versions while
+     * it is being edited.
+     */
+    private void unpinLeafReferences(IDomainResource resource, Set<String> leafUrlsToFloat) {
+        IAdapterFactory.forFhirVersion(fhirVersion())
+                .createKnowledgeArtifactAdapter(resource)
+                .getDependencies()
+                .forEach(dep -> {
+                    var reference = dep.getReference();
+                    if (StringUtils.isBlank(reference) || !reference.contains("|")) {
+                        return;
+                    }
+                    var url = Canonicals.getUrl(reference);
+                    if (url != null && leafUrlsToFloat.contains(url)) {
+                        dep.setReference(url);
+                    }
+                });
     }
 
     private List<IDomainResource> createDraftsOfArtifactAndRelated(
@@ -133,30 +187,6 @@ public class DraftVisitor extends BaseKnowledgeArtifactVisitor {
                     IAdapterFactory.forFhirVersion(fhirVersion()).createKnowledgeArtifactAdapter(newResource);
             newResourceAdapter.setStatus("draft");
             newResourceAdapter.setVersion(draftVersion);
-
-            // Leaf ValueSet versions should be removed from grouper dependencies
-            var isGrouper =
-                    switch (repository.fhirContext().getVersion().getVersion()) {
-                        case DSTU3 ->
-                            KnowledgeArtifactProcessor.isGrouper(
-                                    (org.hl7.fhir.dstu3.model.MetadataResource) newResource);
-                        case R4 ->
-                            KnowledgeArtifactProcessor.isGrouper((org.hl7.fhir.r4.model.MetadataResource) newResource);
-                        case R5 ->
-                            KnowledgeArtifactProcessor.isGrouper((org.hl7.fhir.r5.model.MetadataResource) newResource);
-                        default ->
-                            throw new UnprocessableEntityException("Unsupported FHIR version: "
-                                    + repository.fhirContext().getVersion().getVersion());
-                    };
-
-            if (isGrouper) {
-                newResourceAdapter.getDependencies().forEach(vs -> {
-                    if (vs.getReference().contains("|")) {
-                        vs.setReference(
-                                vs.getReference().substring(0, vs.getReference().indexOf("|")));
-                    }
-                });
-            }
 
             resourcesToCreate.add(newResource);
             var ownedRelatedArtifacts = sourceResourceAdapter.getOwnedRelatedArtifacts();

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/dstu3/DraftVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/dstu3/DraftVisitorTests.java
@@ -27,6 +27,7 @@ import org.hl7.fhir.dstu3.model.Library;
 import org.hl7.fhir.dstu3.model.Parameters;
 import org.hl7.fhir.dstu3.model.Period;
 import org.hl7.fhir.dstu3.model.PlanDefinition;
+import org.hl7.fhir.dstu3.model.PrimitiveType;
 import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.dstu3.model.RelatedArtifact;
 import org.hl7.fhir.dstu3.model.StringType;
@@ -410,5 +411,72 @@ class DraftVisitorTests {
 
         assertTrue(library.getExtension().isEmpty());
         assertTrue(library.getContained().isEmpty());
+    }
+
+    @Test
+    void library_draft_floats_manifest_and_grouper_leaf_references() {
+        Bundle bundle = (Bundle)
+                jsonParser.parseResource(DraftVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));
+        repo.transaction(bundle);
+        final var leafUrl = "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.6";
+        // Code system versions are pinned deliberately, so the manifest's pinned reference must
+        // not be floated just because the grouper mentions the same system.
+        final var codeSystemUrl = "http://snomed.info/sct";
+        final var pinnedCodeSystem = codeSystemUrl + "|http://snomed.info/sct/731000124108/version/20250901";
+        var grouperToSeed =
+                repo.read(ValueSet.class, new IdType("ValueSet/dxtc")).copy();
+        grouperToSeed.getCompose().addInclude().setSystem(codeSystemUrl);
+        repo.update(grouperToSeed);
+
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
+                .copy();
+        library.addRelatedArtifact()
+                .setType(RelatedArtifact.RelatedArtifactType.DEPENDSON)
+                .setResource(new Reference(pinnedCodeSystem));
+        // the manifest and the grouper both pin this leaf before drafting
+        assertTrue(library.getRelatedArtifact().stream()
+                .anyMatch(ra -> (leafUrl + "|20210526").equals(ra.getResource().getReference())));
+
+        ILibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
+        Parameters params = new Parameters();
+        params.addParameter().setName("version").setValue(new StringType("1.2.3"));
+        Bundle returnedBundle = (Bundle) libraryAdapter.accept(new DraftVisitor(repo), params);
+        assertNotNull(returnedBundle);
+
+        var draftedManifest = returnedBundle.getEntry().stream()
+                .filter(entry -> entry.getResponse().getLocation().contains("Library"))
+                .map(entry ->
+                        repo.read(Library.class, new IdType(entry.getResponse().getLocation())))
+                .filter(lib -> "http://ersd.aimsplatform.org/fhir/Library/SpecificationLibrary".equals(lib.getUrl()))
+                .findFirst();
+        assertTrue(draftedManifest.isPresent());
+
+        var draftedGrouper = returnedBundle.getEntry().stream()
+                .filter(entry -> entry.getResponse().getLocation().contains("ValueSet"))
+                .map(entry ->
+                        repo.read(ValueSet.class, new IdType(entry.getResponse().getLocation())))
+                .filter(vs -> "http://ersd.aimsplatform.org/fhir/ValueSet/dxtc".equals(vs.getUrl()))
+                .findFirst();
+        assertTrue(draftedGrouper.isPresent());
+
+        var grouperLeafReferences = draftedGrouper.get().getCompose().getInclude().stream()
+                .flatMap(include -> include.getValueSet().stream())
+                .map(PrimitiveType::getValueAsString)
+                .filter(resource -> resource.startsWith(leafUrl))
+                .toList();
+        var manifestLeafReferences = draftedManifest.get().getRelatedArtifact().stream()
+                .map(ra -> ra.getResource().getReference())
+                .filter(resource -> resource != null && resource.startsWith(leafUrl))
+                .toList();
+
+        // The grouper floats its leaves to latest, the manifest's depends-on has to float with it.
+        // Assert the pair, not just that each side is individually bare.
+        assertFalse(grouperLeafReferences.isEmpty());
+        assertEquals(grouperLeafReferences, manifestLeafReferences);
+        assertEquals(List.of(leafUrl), manifestLeafReferences);
+
+        // only leaf ValueSets float - the code system keeps its pin
+        assertTrue(draftedManifest.get().getRelatedArtifact().stream()
+                .anyMatch(ra -> pinnedCodeSystem.equals(ra.getResource().getReference())));
     }
 }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/DraftVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/DraftVisitorTests.java
@@ -27,6 +27,7 @@ import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Period;
 import org.hl7.fhir.r4.model.PlanDefinition;
+import org.hl7.fhir.r4.model.PrimitiveType;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.RelatedArtifact;
 import org.hl7.fhir.r4.model.StringType;
@@ -400,5 +401,72 @@ class DraftVisitorTests {
 
         assertTrue(library.getExtension().isEmpty());
         assertTrue(library.getContained().isEmpty());
+    }
+
+    @Test
+    void library_draft_floats_manifest_and_grouper_leaf_references() {
+        Bundle bundle = (Bundle)
+                jsonParser.parseResource(DraftVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));
+        repo.transaction(bundle);
+        final var leafUrl = "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.6";
+        // Code system versions are pinned deliberately, so the manifest's pinned reference must
+        // not be floated just because the grouper mentions the same system.
+        final var codeSystemUrl = "http://snomed.info/sct";
+        final var pinnedCodeSystem = codeSystemUrl + "|http://snomed.info/sct/731000124108/version/20250901";
+        var grouperToSeed =
+                repo.read(ValueSet.class, new IdType("ValueSet/dxtc")).copy();
+        grouperToSeed.getCompose().addInclude().setSystem(codeSystemUrl);
+        repo.update(grouperToSeed);
+
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
+                .copy();
+        library.addRelatedArtifact()
+                .setType(RelatedArtifact.RelatedArtifactType.DEPENDSON)
+                .setResource(pinnedCodeSystem);
+        // the manifest and the grouper both pin this leaf before drafting
+        assertTrue(
+                library.getRelatedArtifact().stream().anyMatch(ra -> (leafUrl + "|20210526").equals(ra.getResource())));
+
+        ILibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
+        Parameters params = new Parameters();
+        params.addParameter("version", "1.2.3");
+        Bundle returnedBundle = (Bundle) libraryAdapter.accept(new DraftVisitor(repo), params);
+        assertNotNull(returnedBundle);
+
+        var draftedManifest = returnedBundle.getEntry().stream()
+                .filter(entry -> entry.getResponse().getLocation().contains("Library"))
+                .map(entry ->
+                        repo.read(Library.class, new IdType(entry.getResponse().getLocation())))
+                .filter(lib -> "http://ersd.aimsplatform.org/fhir/Library/SpecificationLibrary".equals(lib.getUrl()))
+                .findFirst();
+        assertTrue(draftedManifest.isPresent());
+
+        var draftedGrouper = returnedBundle.getEntry().stream()
+                .filter(entry -> entry.getResponse().getLocation().contains("ValueSet"))
+                .map(entry ->
+                        repo.read(ValueSet.class, new IdType(entry.getResponse().getLocation())))
+                .filter(vs -> "http://ersd.aimsplatform.org/fhir/ValueSet/dxtc".equals(vs.getUrl()))
+                .findFirst();
+        assertTrue(draftedGrouper.isPresent());
+
+        var grouperLeafReferences = draftedGrouper.get().getCompose().getInclude().stream()
+                .flatMap(include -> include.getValueSet().stream())
+                .map(PrimitiveType::getValueAsString)
+                .filter(resource -> resource.startsWith(leafUrl))
+                .toList();
+        var manifestLeafReferences = draftedManifest.get().getRelatedArtifact().stream()
+                .map(RelatedArtifact::getResource)
+                .filter(resource -> resource != null && resource.startsWith(leafUrl))
+                .toList();
+
+        // The grouper floats its leaves to latest, the manifest's depends-on has to float with it.
+        // Assert the pair, not just that each side is individually bare.
+        assertFalse(grouperLeafReferences.isEmpty());
+        assertEquals(grouperLeafReferences, manifestLeafReferences);
+        assertEquals(List.of(leafUrl), manifestLeafReferences);
+
+        // only leaf ValueSets float, the code system keeps its pin
+        assertTrue(draftedManifest.get().getRelatedArtifact().stream()
+                .anyMatch(ra -> pinnedCodeSystem.equals(ra.getResource())));
     }
 }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r5/DraftVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r5/DraftVisitorTests.java
@@ -401,4 +401,71 @@ class DraftVisitorTests {
         assertTrue(library.getExtension().isEmpty());
         assertTrue(library.getContained().isEmpty());
     }
+
+    @Test
+    void library_draft_floats_manifest_and_grouper_leaf_references() {
+        Bundle bundle = (Bundle)
+                jsonParser.parseResource(DraftVisitorTests.class.getResourceAsStream("Bundle-ersd-small-active.json"));
+        repo.transaction(bundle);
+        final var leafUrl = "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.6";
+        // Code system versions are pinned deliberately, so the manifest's pinned reference must
+        // not be floated just because the grouper mentions the same system.
+        final var codeSystemUrl = "http://snomed.info/sct";
+        final var pinnedCodeSystem = codeSystemUrl + "|http://snomed.info/sct/731000124108/version/20250901";
+        var grouperToSeed =
+                repo.read(ValueSet.class, new IdType("ValueSet/dxtc")).copy();
+        grouperToSeed.getCompose().addInclude().setSystem(codeSystemUrl);
+        repo.update(grouperToSeed);
+
+        Library library = repo.read(Library.class, new IdType("Library/SpecificationLibrary"))
+                .copy();
+        library.addRelatedArtifact()
+                .setType(RelatedArtifact.RelatedArtifactType.DEPENDSON)
+                .setResource(pinnedCodeSystem);
+        // the manifest and the grouper both pin this leaf before drafting
+        assertTrue(
+                library.getRelatedArtifact().stream().anyMatch(ra -> (leafUrl + "|20210526").equals(ra.getResource())));
+
+        ILibraryAdapter libraryAdapter = new AdapterFactory().createLibrary(library);
+        Parameters params = new Parameters();
+        params.addParameter("version", "1.2.3");
+        Bundle returnedBundle = (Bundle) libraryAdapter.accept(new DraftVisitor(repo), params);
+        assertNotNull(returnedBundle);
+
+        var draftedManifest = returnedBundle.getEntry().stream()
+                .filter(entry -> entry.getResponse().getLocation().contains("Library"))
+                .map(entry ->
+                        repo.read(Library.class, new IdType(entry.getResponse().getLocation())))
+                .filter(lib -> "http://ersd.aimsplatform.org/fhir/Library/SpecificationLibrary".equals(lib.getUrl()))
+                .findFirst();
+        assertTrue(draftedManifest.isPresent());
+
+        var draftedGrouper = returnedBundle.getEntry().stream()
+                .filter(entry -> entry.getResponse().getLocation().contains("ValueSet"))
+                .map(entry ->
+                        repo.read(ValueSet.class, new IdType(entry.getResponse().getLocation())))
+                .filter(vs -> "http://ersd.aimsplatform.org/fhir/ValueSet/dxtc".equals(vs.getUrl()))
+                .findFirst();
+        assertTrue(draftedGrouper.isPresent());
+
+        var grouperLeafReferences = draftedGrouper.get().getCompose().getInclude().stream()
+                .flatMap(include -> include.getValueSet().stream())
+                .map(canonical -> canonical.getValueAsString())
+                .filter(resource -> resource.startsWith(leafUrl))
+                .toList();
+        var manifestLeafReferences = draftedManifest.get().getRelatedArtifact().stream()
+                .map(RelatedArtifact::getResource)
+                .filter(resource -> resource != null && resource.startsWith(leafUrl))
+                .toList();
+
+        // The grouper floats its leaves to latest, the manifest's depends-on has to float with it.
+        // Assert the pair, not just that each side is individually bare.
+        assertFalse(grouperLeafReferences.isEmpty());
+        assertEquals(grouperLeafReferences, manifestLeafReferences);
+        assertEquals(List.of(leafUrl), manifestLeafReferences);
+
+        // only leaf ValueSets float, the code system keeps its pin
+        assertTrue(draftedManifest.get().getRelatedArtifact().stream()
+                .anyMatch(ra -> pinnedCodeSystem.equals(ra.getResource())));
+    }
 }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r5/DraftVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r5/DraftVisitorTests.java
@@ -27,6 +27,7 @@ import org.hl7.fhir.r5.model.Library;
 import org.hl7.fhir.r5.model.Parameters;
 import org.hl7.fhir.r5.model.Period;
 import org.hl7.fhir.r5.model.PlanDefinition;
+import org.hl7.fhir.r5.model.PrimitiveType;
 import org.hl7.fhir.r5.model.Reference;
 import org.hl7.fhir.r5.model.RelatedArtifact;
 import org.hl7.fhir.r5.model.StringType;
@@ -450,7 +451,7 @@ class DraftVisitorTests {
 
         var grouperLeafReferences = draftedGrouper.get().getCompose().getInclude().stream()
                 .flatMap(include -> include.getValueSet().stream())
-                .map(canonical -> canonical.getValueAsString())
+                .map(PrimitiveType::getValueAsString)
                 .filter(resource -> resource.startsWith(leafUrl))
                 .toList();
         var manifestLeafReferences = draftedManifest.get().getRelatedArtifact().stream()


### PR DESCRIPTION
## Problem

A leaf ValueSet is referenced from two places in eRSD:
- the grouper ValueSet's `compose.include[].valueSet`
- the root manifest Library's `relatedArtifact` `depends-on`

`$draft` unpinned the grouper's references (dropping `|version` so a draft picks up the
newest leaf while it is being edited) but left the manifest's `depends-on` pinned.

The manifest references and the grouper references therefore agree after import and diverge after draft.
Any consumer that matches the two sides by exact canonical string then fails to find the
leaf.

## Solution

Move the unpinning out of the per resource clone loop and apply it once across the whole
draft set:

1. `collectLeafUrlsToFloat` walks the drafted groupers and collects the URLs of the leaf
   ValueSets they reference.
2. `unpinLeafReferences` then strips `|version` from *every* reference to those URLs across
   *all* drafted resources.

Both sides now float the version together, restoring the drift between the manifest's `depends-on`
and the grouper's `compose` references to the same canonical.


## Tests

`library_draft_floats_manifest_and_grouper_leaf_references` added to `DraftVisitorTests`
for dstu3, r4 and r5. Each seeds a grouper with a bare `compose.include.system` plus a
pinned code-system `depends-on` on the manifest, then asserts the grouper and manifest
leaf reference sets are non empty, equal to each other, and unversioned. Also ensures the code-system keeps its pin.

Verified end to end against a real eRSD import in VSM: pinned and in agreement after
import, unversioned and in agreement after clone.