### PR TITLE
Ensure Changelog code entries carry a CodeCystem version

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/crmi/changelog/ChangeLog.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/crmi/changelog/ChangeLog.java
@@ -127,6 +127,10 @@ public class ChangeLog {
             ValueSet valueSet,
             ArtifactDiffProcessor.DiffCache cache,
             ValueSetChild.Leaf leafData) {
+        // compose.include carries no code system version in practice, so fallback to the versions the
+        // ValueSet's expansion recorded per code. Without this the changelog cannot show which code
+        // system version a code came from, which is the only thing that explains a repin's insert/delete pairs.
+        var codeSystemVersions = collectCodeSystemVersionsFromExpansion(valueSet);
         valueSet.getCompose().getInclude().forEach(concept -> {
             if (concept.hasConcept()) {
                 updateLeafData(concept.getSystem(), leafData);
@@ -136,7 +140,8 @@ public class ChangeLog {
                         Canonicals.getIdPart(valueSet.getUrl()),
                         valueSet.getName(),
                         valueSet.getTitle(),
-                        valueSet.getUrl());
+                        valueSet.getUrl(),
+                        codeSystemVersions);
             }
             if (concept.hasValueSet()) {
                 concept.getValueSet().stream()
@@ -220,14 +225,28 @@ public class ChangeLog {
         codeMap.put(codeValue, code);
     }
 
-    // can this be done with a fhir operation? tx server work?
+    // Collects the code system version the expansion recorded for each code.
+    private Map<String, String> collectCodeSystemVersionsFromExpansion(ValueSet valueSet) {
+        if (!valueSet.getExpansion().hasContains()) {
+            return Map.of();
+        }
+        Map<String, String> versionsByCode = new HashMap<>();
+        valueSet.getExpansion().getContains().forEach(contained -> {
+            if (contained.hasCode() && contained.hasVersion()) {
+                versionsByCode.putIfAbsent(contained.getCode(), contained.getVersion());
+            }
+        });
+        return versionsByCode;
+    }
+
     private void mapConceptSetToCodeMap(
             Map<String, ValueSetChild.Code> codeMap,
             ValueSet.ConceptSetComponent concept,
             String source,
             String name,
             String title,
-            String url) {
+            String url,
+            Map<String, String> codeSystemVersions) {
         var system = concept.getSystem();
         var id = concept.getId();
         var version = concept.getVersion();
@@ -239,7 +258,9 @@ public class ChangeLog {
                                 id,
                                 system,
                                 conceptReference.getCode(),
-                                version,
+                                version == null || version.isBlank()
+                                        ? codeSystemVersions.get(conceptReference.getCode())
+                                        : version,
                                 conceptReference.getDisplay(),
                                 source,
                                 name,

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/crmi/changelog/ChangeLogTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/crmi/changelog/ChangeLogTest.java
@@ -1,0 +1,74 @@
+package org.opencds.cqf.fhir.cr.crmi.changelog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.hl7.fhir.r4.model.ValueSet;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.cr.common.ArtifactDiffProcessor;
+
+class ChangeLogTest {
+
+    private static final String LEAF_URL = "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.560";
+    private static final String LOINC = "http://loinc.org";
+    private static final String CODE = "103721-7";
+
+    /**
+     * Builds a leaf ValueSet the way eRSD content actually arrives: compose.include lists the concepts
+     * but carries no version, while the expansion records the code system version per code.
+     *
+     * @param composeVersion version to put on compose.include, or null to leave it off
+     * @param expansionVersion version to put on expansion.contains, or null to leave it off
+     */
+    private static ValueSet leaf(String composeVersion, String expansionVersion) {
+        var valueSet = new ValueSet();
+        valueSet.setUrl(LEAF_URL);
+        valueSet.setVersion("20240619");
+        valueSet.setName("WestNileVirusRNA");
+        valueSet.setTitle("West Nile Virus RNA");
+
+        var include = valueSet.getCompose().addInclude().setSystem(LOINC);
+        include.addConcept().setCode(CODE);
+        if (composeVersion != null) {
+            include.setVersion(composeVersion);
+        }
+
+        var contains = valueSet.getExpansion().addContains().setSystem(LOINC).setCode(CODE);
+        if (expansionVersion != null) {
+            contains.setVersion(expansionVersion);
+        }
+        return valueSet;
+    }
+
+    private static ValueSetChild.Code getChangelogCode(ValueSet valueSet) {
+        var page = new ChangeLog(LEAF_URL).addPage(valueSet, valueSet.copy(), (ArtifactDiffProcessor.DiffCache) null);
+        var newData = page.getNewData();
+        assertNotNull(newData);
+        assertEquals(1, newData.getCodes().size());
+        return newData.getCodes().get(0);
+    }
+
+    /**
+     * compose.include never carries a version in eRSD content, so the code map has to fall back to the
+     * version the expansion recorded. Without the fallback the compose entry claimed the code with a
+     * null version and the expansion entry was skipped, leaving the changelog's Code System Version
+     * column empty for every code.
+     */
+    @Test
+    void codeTakesCodeSystemVersionFromExpansionWhenComposeHasNone() {
+        assertEquals("2.81", getChangelogCode(leaf(null, "2.81")).getVersion());
+    }
+
+    /** An explicit version on compose.include is authoritative and must not be overwritten. */
+    @Test
+    void codeKeepsComposeVersionWhenOneIsPresent() {
+        assertEquals("2.76", getChangelogCode(leaf("2.76", "2.81")).getVersion());
+    }
+
+    /** Nothing to fall back to - the version stays null rather than throwing. */
+    @Test
+    void codeVersionIsNullWhenNeitherSideHasOne() {
+        assertNull(getChangelogCode(leaf(null, null)).getVersion());
+    }
+}


### PR DESCRIPTION
## Problem

Every code in the changelog had an empty `version`, so the UI and spreadsheet showed a blank
CodeSystem Version column.

`updateCodeMapAndLeafMetadataMap` reads both `compose.include` and `expansion.contains`, but reads compose
first. In practice, with eRSD, the compose path never carries a CodeSystem version and the expansion path, which does carry the version, was then skipped by its `!codeMap.containsKey(code)` guard.

## Solution

`collectCodeSystemVersionsFromExpansion` builds a code -> version map from the ValueSet's own
expansion, and the compose path falls back to it when `compose.include` has no version. An explicit
compose version still wins.

Ordering is left alone deliberately: running the expansion path first would let a grouper's stored
expansion claim codes before the recursion into leaves, losing the per leaf version attribution.

## Tests

`ChangeLogTest` - Ensures correct version when: fallback applies, explicit compose version is preserved, null when neither side has one. 