### PR TITLE
Fix issue with data absent responses from CQL resulting in incorrect result types

### DIFF
--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/LibraryEngine.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/LibraryEngine.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.fhir.cql;
 
 import static java.util.Objects.requireNonNull;
+import static org.opencds.cqf.fhir.utility.Constants.DATA_ABSENT_REASON;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.repository.IRepository;
@@ -22,6 +23,7 @@ import org.cqframework.cql.cql2elm.StringLibrarySourceProvider;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
+import org.hl7.fhir.instance.model.api.IBaseHasExtensions;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.opencds.cqf.cql.engine.execution.CqlEngine;
 import org.opencds.cqf.cql.engine.execution.EvaluationParams;
@@ -264,7 +266,12 @@ public class LibraryEngine {
                 .map(adapterFactory::createParametersParameter)
                 .map(param -> {
                     if (param.hasValue()) {
-                        return param.getValue();
+                        if (((IBaseHasExtensions) param.getValue())
+                                .getExtension().stream().anyMatch(e -> DATA_ABSENT_REASON.equals(e.getUrl()))) {
+                            return null;
+                        } else {
+                            return param.getValue();
+                        }
                     } else if (param.hasResource()) {
                         return param.getResource();
                     } else if (param.hasPart()) {

--- a/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/LibraryEngineTests.java
+++ b/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/LibraryEngineTests.java
@@ -4,7 +4,6 @@ import static kotlinx.io.CoreKt.buffered;
 import static kotlinx.io.JvmCoreKt.asSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opencds.cqf.fhir.test.Resources.getResourcePath;
 import static org.opencds.cqf.fhir.utility.r4.Parameters.parameters;
@@ -12,6 +11,7 @@ import static org.opencds.cqf.fhir.utility.r4.Parameters.part;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.repository.IRepository;
+import ca.uhn.fhir.util.ParametersUtil;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -21,7 +21,6 @@ import kotlinx.io.Source;
 import org.cqframework.cql.cql2elm.LibraryContentType;
 import org.cqframework.cql.cql2elm.LibrarySourceProvider;
 import org.hl7.elm.r1.VersionedIdentifier;
-import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Condition;
@@ -39,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.opencds.cqf.fhir.utility.CqfExpression;
 import org.opencds.cqf.fhir.utility.repository.ig.IgRepository;
 
+@SuppressWarnings("UnstableApiUsage")
 class LibraryEngineTests {
 
     IRepository repository;
@@ -196,7 +196,7 @@ class LibraryEngineTests {
         var result3 = libraryEngine.resolveExpression(patientId, expression1, params2, null, null, null, null);
         var result4 = libraryEngine.resolveExpression(patientId, expression2, params2, null, null, null, null);
         assertTrue(codeableConcept1.equalsDeep((CodeableConcept) result1.get(0)));
-        assertNull(((BooleanType) result2.get(0)).getValue());
+        assertEquals(0, result2.size());
         assertTrue(codeableConcept2.equalsDeep((CodeableConcept) result3.get(0)));
         assertEquals(codeableConcept2.getCodingFirstRep().getDisplay(), ((StringType) result4.get(0)).getValue());
     }
@@ -218,5 +218,30 @@ class LibraryEngineTests {
 
         var result = libraryEngine.resolveExpression(patientId, expression, params, null, null, null, null);
         assertEquals("Alice Marie", ((StringType) result.get(0)).getValue());
+    }
+
+    @Test
+    void resolveParameterValuesHandlesDataAbsent() {
+        var expression = "ExtensionForTask";
+        var parser = repository.fhirContext().newJsonParser();
+        var params = parser.parseResource("{\n"
+                + "  \"resourceType\": \"Parameters\",\n"
+                + "  \"parameter\": [\n"
+                + "    {\n"
+                + "      \"name\": \"" + expression + "\",\n"
+                + "      \"_valueBoolean\": {\n"
+                + "        \"extension\": [\n"
+                + "          {\n"
+                + "            \"url\": \"http://hl7.org/fhir/StructureDefinition/data-absent-reason\",\n"
+                + "            \"valueCode\": \"unknown\"\n"
+                + "          }\n"
+                + "        ]\n"
+                + "      }\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}");
+        var values = ParametersUtil.getNamedParameters(repository.fhirContext(), params, expression);
+        var actual = libraryEngine.resolveParameterValues(values);
+        assertEquals(0, actual.size());
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/Constants.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/Constants.java
@@ -29,6 +29,7 @@ public class Constants {
 
     public static final String FHIR_TYPE_EXTENSION =
             "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type";
+    public static final String DATA_ABSENT_REASON = "http://hl7.org/fhir/StructureDefinition/data-absent-reason";
     public static final String DISPLAY_EXTENSION = "http://hl7.org/fhir/StructureDefinition/display";
     public static final String PERTAINS_TO_GOAL = "http://hl7.org/fhir/StructureDefinition/resource-pertainsToGoal";
     public static final String REQUEST_DO_NOT_PERFORM = "http://hl7.org/fhir/StructureDefinition/request-doNotPerform";


### PR DESCRIPTION
When a CQL expression returns an empty list, the engine returns a Parameters resource with a parameter with a BooleanType that has a null value and the data-absent-reason extension.  During dynamic value resolution this can result in a BooleanType being passed to the `extension` property resulting in invalid FHIR objects. This fix changes LibraryEngine.resolveParameterValues to handle the data absent extension and return a null when it is present rather than the BooleanType.