### PR TITLE
Update CQL to 5.2.0

### DIFF
--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/ClassInstanceHelper.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/ClassInstanceHelper.java
@@ -1,6 +1,6 @@
 package org.opencds.cqf.fhir.cql;
 
-import static org.opencds.cqf.cql.engine.fhir.model.FhirModelResolver.fhirModelNamespaceUri;
+import static org.opencds.cqf.cql.engine.fhir.ConstantsKt.fhirModelNamespaceUri;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;

--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/parameters/CqlFhirParametersConverter.java
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/engine/parameters/CqlFhirParametersConverter.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.fhir.cql.engine.parameters;
 
 import static java.util.Objects.requireNonNull;
+import static org.opencds.cqf.cql.engine.fhir.ConstantsKt.fhirModelNamespaceUri;
 
 import ca.uhn.fhir.context.BaseRuntimeElementCompositeDefinition;
 import ca.uhn.fhir.context.FhirContext;
@@ -400,7 +401,7 @@ public class CqlFhirParametersConverter {
 
     public Object convertToFhirIfNeeded(Object value) {
         return value instanceof ClassInstance classInstance
-                        && classInstance.getType().getNamespaceURI().equals(FhirModelResolver.fhirModelNamespaceUri)
+                        && classInstance.getType().getNamespaceURI().equals(fhirModelNamespaceUri)
                 ? toFhirValue(classInstance)
                 : value;
     }
@@ -441,7 +442,7 @@ public class CqlFhirParametersConverter {
         IBase instance;
         try {
             if (clazz.isEnum()) {
-                instance = (IBase) modelResolver.createHapiInstance$engine_fhir(typeName);
+                instance = (IBase) modelResolver.createHapiInstance(typeName);
             } else {
                 instance = (IBase) clazz.getDeclaredConstructor().newInstance();
             }

--- a/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/engine/parameters/CqlFhirParametersConverterTests.java
+++ b/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/engine/parameters/CqlFhirParametersConverterTests.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.opencds.cqf.cql.engine.fhir.model.FhirModelResolver.fhirModelNamespaceUri;
+import static org.opencds.cqf.cql.engine.fhir.ConstantsKt.fhirModelNamespaceUri;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 hapi = "8.10.0"
-cql = "5.1.0"
+cql = "5.2.0"
 junit = "5.14.3"
 slf4j = "2.0.17"
 spring-boot = "3.4.11"


### PR DESCRIPTION
- Update CQL to 5.2.0
- Update imports for `org.opencds.cqf.cql.engine.fhir.ConstantsKt.fhirModelNamespaceUri`
- Update `createHapiInstance()` call