### PR TITLE
Fix CLI $measure evaluation to compute stratifier component functions

### DIFF
--- a/cqf-fhir-cr-cli/src/main/java/org/opencds/cqf/fhir/cr/cli/command/MeasureCommand.java
+++ b/cqf-fhir-cr-cli/src/main/java/org/opencds/cqf/fhir/cr/cli/command/MeasureCommand.java
@@ -15,20 +15,21 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Measure;
 import org.hl7.fhir.r4.model.MeasureReport;
+import org.hl7.fhir.r4.model.Parameters;
+import org.opencds.cqf.cql.engine.execution.CqlEngine;
 import org.opencds.cqf.fhir.cql.EvaluationSettings;
 import org.opencds.cqf.fhir.cr.cli.argument.MeasureCommandArgument;
-import org.opencds.cqf.fhir.cr.cli.command.CqlCommand.SubjectAndResult;
+import org.opencds.cqf.fhir.cr.cli.command.CqlCommand.SubjectContext;
 import org.opencds.cqf.fhir.cr.cli.command.EngineFactory.EngineBundle;
 import org.opencds.cqf.fhir.cr.measure.MeasureEvaluationOptions;
-import org.opencds.cqf.fhir.cr.measure.common.CqlEvaluationResult;
+import org.opencds.cqf.fhir.cr.measure.common.CompositeEvaluationResultsPerMeasure;
+import org.opencds.cqf.fhir.cr.measure.common.MeasureEvalType;
 import org.opencds.cqf.fhir.cr.measure.r4.R4MeasureProcessor;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
@@ -69,8 +70,13 @@ public class MeasureCommand implements Callable<Integer> {
     public record MeasureCommandResult(Stream<MeasureReport> measureReports, EngineBundle engineBundle) {}
 
     public static MeasureCommandResult createMeasureCommandResult(MeasureCommandArgument args) throws IOException {
-        var cqlResult = CqlCommand.createCqlCommandResult(args.cql);
-        var bundle = cqlResult.engineBundle();
+        // Build the engine bundle directly (rather than via CqlCommand's incomplete library-only
+        // $evaluate) so that CR owns the full measure evaluation. This routes the CLI through the
+        // same engine path used by the server/R4CollectDataService, which runs the stratifier
+        // function evaluation (FunctionEvaluationHandler.cqlFunctionEvaluation) that the
+        // pre-calculated `evaluateMeasureResults` path never invokes.
+        var bundle = EngineFactory.createEngineBundle(args.cql);
+        var engine = bundle.engine();
 
         var measure = bundle.repository().read(Measure.class, new IdType(args.measureName));
 
@@ -95,9 +101,19 @@ public class MeasureCommand implements Callable<Integer> {
             Files.createDirectories(reportOutput);
         }
 
-        var measureResults = cqlResult
-                .subjectResults()
-                .map(sr -> evaluateMeasureForSubject(processor, measure, start, end, sr))
+        // Preserve the --output-path per-subject CQL expression dump. This used to be produced by
+        // CqlCommand; now we write it from the engine-path results instead.
+        Path txtOutput = args.cql.outputPath != null ? Path.of(args.cql.outputPath) : null;
+        if (txtOutput != null) {
+            Files.createDirectories(txtOutput);
+        }
+
+        // Subjects come from the -c/-cv context pairs, same source CqlCommand uses.
+        var subjectContexts =
+                args.cql.parameters.context.stream().map(c -> new SubjectContext(c.contextName, c.contextValue));
+
+        var measureResults = subjectContexts
+                .map(sc -> evaluateMeasureForSubject(processor, measure, start, end, engine, sc, txtOutput))
                 .map(sr -> {
                     if (reportOutput != null) {
                         var json = bundle.parser().encodeResourceToString(sr.report());
@@ -139,15 +155,26 @@ public class MeasureCommand implements Callable<Integer> {
             Measure measure,
             ZonedDateTime start,
             ZonedDateTime end,
-            SubjectAndResult subjectAndResult) {
+            CqlEngine engine,
+            SubjectContext subjectContext,
+            Path txtOutput) {
 
-        Map<String, CqlEvaluationResult> resultMap = new HashMap<>();
-        var subjectId = subjectAndResult.subject().subjectId();
-        resultMap.put(subjectId, new CqlEvaluationResult(subjectAndResult.result()));
+        // Full subject id (e.g. "Patient/example"), matching the key used in the engine-path results.
+        var subjectId = subjectContext.subjectId();
+        var subjects = Collections.singletonList(subjectId);
 
-        var report = processor.evaluateMeasureResults(
-                measure, start, end, "subject", Collections.singletonList(subjectId), resultMap);
-        return new SubjectAndReport(subjectAndResult.subject().value(), report);
+        // Let CR compute the CQL AND the stratifier functions (engine path), exactly like the
+        // server/R4CollectDataService does.
+        var composite = processor.evaluateMeasureWithCqlEngine(subjects, measure, start, end, new Parameters(), engine);
+
+        var report = processor.evaluateMeasure(
+                measure, start, end, "subject", subjects, MeasureEvalType.SUBJECT, engine, composite);
+
+        if (txtOutput != null) {
+            writeCqlResultsToFile(composite, subjectId, subjectContext.value(), txtOutput);
+        }
+
+        return new SubjectAndReport(subjectContext.value(), report);
     }
 
     @Nonnull
@@ -173,6 +200,31 @@ public class MeasureCommand implements Callable<Integer> {
                 StandardOpenOption.TRUNCATE_EXISTING,
                 StandardOpenOption.WRITE)) {
             out.write(json.getBytes());
+        }
+    }
+
+    /**
+     * Writes the per-subject CQL expression results for the (single) evaluated measure to a
+     * {@code <output-path>/<contextValue>.txt} file. The results come from the engine-path
+     * composite, so in addition to the library's top-level expression results they may now also
+     * include the per-resource stratifier-function results.
+     */
+    private static void writeCqlResultsToFile(
+            CompositeEvaluationResultsPerMeasure composite, String subjectId, String contextValue, Path txtOutput) {
+        Path outputPath = txtOutput.resolve(contextValue + ".txt");
+        try (OutputStream out = Files.newOutputStream(
+                outputPath,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.WRITE)) {
+            for (var subjectResults : composite.getResultsPerMeasure().values()) {
+                var cqlResult = subjectResults.get(subjectId);
+                if (cqlResult != null) {
+                    Utilities.writeResult(cqlResult.getResult(), out);
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to write CQL results for " + subjectId, e);
         }
     }
 }

--- a/cqf-fhir-cr-cli/src/test/java/org/opencds/cqf/fhir/cr/cli/CliTest.java
+++ b/cqf-fhir-cr-cli/src/test/java/org/opencds/cqf/fhir/cr/cli/CliTest.java
@@ -641,6 +641,73 @@ class CliTest {
         assertTrue(output.contains("\"subject\":{\"reference\":\"Patient/456\""));
     }
 
+    /**
+     * Regression test for a measure whose stratifier components (Age, ProductLine) are CQL
+     * <em>functions</em> (a value/non-subject-value component stratifier on a non-boolean basis).
+     * The CLI measure command must route through CR's engine path so that the stratifier-function
+     * results are actually computed; the old library-only {@code $evaluate} path never invoked the
+     * functions, producing MeasureReports with NULL stratifier component values. This test asserts
+     * the real stratifier values (Age {@code 18-19}; ProductLine MMO x2 / MCD x9 / MEP x1) and that
+     * no component value is the literal {@code "null"}.
+     */
+    @Test
+    void stratifierComponentFunctionValues() throws IOException {
+        var root = testResourcePath + "/stratifier-functions";
+        var subjectValue = "patient-a";
+        var reportPath = Path.of(testResultsPath, "stratifier-functions", MEASUREREPORTS_FOLDER);
+
+        String[] args = new String[] {
+            "measure",
+            "-source=" + root + "/input/cql",
+            "-name=StratifierMultiSubjectDateBasis",
+            "-data=" + root,
+            "-c=Patient",
+            "-cv=" + subjectValue,
+            "--measure=StratifierMultiSubjectDateBasisMultiComponentMeasure",
+            "--report-path=" + reportPath,
+        };
+
+        Main.run(args);
+
+        var reportFile = reportPath.resolve(subjectValue + ".json");
+        assertTrue(Files.exists(reportFile), "Expected MeasureReport at " + reportFile);
+        var report = JSON_PARSER.parseResource(MeasureReport.class, Files.readString(reportFile));
+
+        var enrollmentGroup = report.getGroup().stream()
+                .filter(g -> "Enrollment".equals(g.getId()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing Enrollment group in MeasureReport"));
+
+        assertFalse(enrollmentGroup.getStratifier().isEmpty(), "Enrollment group has no stratifier");
+        var strata = enrollmentGroup.getStratifier().get(0).getStratum();
+        assertFalse(strata.isEmpty(), "Stratifier has no strata");
+
+        var productLineCounts = new java.util.HashMap<String, Integer>();
+        for (var stratum : strata) {
+            String age = null;
+            String productLine = null;
+            for (var component : stratum.getComponent()) {
+                var code = component.getCode().getText();
+                var value = component.getValue().getText();
+                // The bug produced literal "null" component values; ensure that never happens.
+                assertFalse(
+                        "null".equals(value), "Stratifier component '%s' has a null value (the bug)".formatted(code));
+                if ("Age".equals(code)) {
+                    age = value;
+                } else if ("ProductLine".equals(code)) {
+                    productLine = value;
+                }
+            }
+            assertEquals("18-19", age, "Unexpected Age stratifier value");
+            var count = stratum.getPopulationFirstRep().getCount();
+            productLineCounts.put(productLine, count);
+        }
+
+        assertEquals(2, productLineCounts.get("MMO"), "Unexpected count for ProductLine MMO");
+        assertEquals(9, productLineCounts.get("MCD"), "Unexpected count for ProductLine MCD");
+        assertEquals(1, productLineCounts.get("MEP"), "Unexpected count for ProductLine MEP");
+    }
+
     @Test
     @Disabled("This test is failing on the CI Server for reasons unknown. Need to debug that.")
     void sampleContentIG() {

--- a/cqf-fhir-cr-cli/src/test/java/org/opencds/cqf/fhir/cr/cli/CliTest.java
+++ b/cqf-fhir-cr-cli/src/test/java/org/opencds/cqf/fhir/cr/cli/CliTest.java
@@ -646,9 +646,14 @@ class CliTest {
      * <em>functions</em> (a value/non-subject-value component stratifier on a non-boolean basis).
      * The CLI measure command must route through CR's engine path so that the stratifier-function
      * results are actually computed; the old library-only {@code $evaluate} path never invoked the
-     * functions, producing MeasureReports with NULL stratifier component values. This test asserts
-     * the real stratifier values (Age {@code 18-19}; ProductLine MMO x2 / MCD x9 / MEP x1) and that
-     * no component value is the literal {@code "null"}.
+     * functions, producing MeasureReports with NULL stratifier component values.
+     *
+     * <p>Also guards multi-value fan-out: {@code @2026-01-12} is tagged with two product lines, so
+     * {@code Product Line Stratifier} returns a two-element list for that single date input. That
+     * input must fan out into BOTH the MEP and MMO strata (counting toward each) rather than
+     * collapsing into one stratum with a comma-joined {@code "MEP,MMO"} value. Expected per-input
+     * counts: Age {@code 18-19}; ProductLine MMO x3 (01-01, 01-02, 01-12) / MCD x9 / MEP x1
+     * (01-12). No component value is the literal {@code "null"} and none is comma-joined.
      */
     @Test
     void stratifierComponentFunctionValues() throws IOException {
@@ -692,6 +697,12 @@ class CliTest {
                 // The bug produced literal "null" component values; ensure that never happens.
                 assertFalse(
                         "null".equals(value), "Stratifier component '%s' has a null value (the bug)".formatted(code));
+                // A multi-value stratifier result must fan out into separate strata, never a
+                // comma-joined value like "MEP,MMO".
+                assertFalse(
+                        value != null && value.contains(","),
+                        "Stratifier component '%s' has a comma-joined value '%s' (should fan out into separate strata)"
+                                .formatted(code, value));
                 if ("Age".equals(code)) {
                     age = value;
                 } else if ("ProductLine".equals(code)) {
@@ -703,7 +714,10 @@ class CliTest {
             productLineCounts.put(productLine, count);
         }
 
-        assertEquals(2, productLineCounts.get("MMO"), "Unexpected count for ProductLine MMO");
+        // @2026-01-12 is tagged both MEP and MMO, so it fans out: it counts toward MMO (with 01-01,
+        // 01-02) and toward MEP. Per-input counting keeps these distinct from a subject-level count
+        // (which would report 12 for every stratum).
+        assertEquals(3, productLineCounts.get("MMO"), "Unexpected count for ProductLine MMO");
         assertEquals(9, productLineCounts.get("MCD"), "Unexpected count for ProductLine MCD");
         assertEquals(1, productLineCounts.get("MEP"), "Unexpected count for ProductLine MEP");
     }

--- a/cqf-fhir-cr-cli/src/test/resources/compartment/input/resources/library/ABCLIB.json
+++ b/cqf-fhir-cr-cli/src/test/resources/compartment/input/resources/library/ABCLIB.json
@@ -1,7 +1,7 @@
 {
     "resourceType": "Library",
     "id": "ABCLIB",
-    "url": "http://example.com/Library/ABC-LIB",
+    "url": "http://example.com/Library/ABCLIB",
     "name": "ABCLIB",
     "status": "active",
     "type": {

--- a/cqf-fhir-cr-cli/src/test/resources/compartment/input/resources/library/DEFLIB.json
+++ b/cqf-fhir-cr-cli/src/test/resources/compartment/input/resources/library/DEFLIB.json
@@ -1,7 +1,7 @@
 {
     "resourceType": "Library",
     "id": "DEFLIB",
-    "url": "http://example.com/Library/DEF-LIB",
+    "url": "http://example.com/Library/DEFLIB",
     "name": "DEFLIB",
     "status": "active",
     "type": {

--- a/cqf-fhir-cr-cli/src/test/resources/stratifier-functions/input/cql/StratifierMultiSubjectDateBasis.cql
+++ b/cqf-fhir-cr-cli/src/test/resources/stratifier-functions/input/cql/StratifierMultiSubjectDateBasis.cql
@@ -20,6 +20,11 @@ define function "Age Stratifier"(stratificationDate Date):
 
 // Stubbed per-date input list (one row per date), each tagged with a category code. Stands in for
 // data-derived input so the list-returning stratifier function below can be exercised.
+//
+// @2026-01-12 is intentionally tagged with TWO categories (MEP and MMO) so the stratifier function
+// returns a multi-element list for a single input. This is the shape that must fan out into one
+// stratum per value (that input counts toward BOTH strata), rather than collapsing into a single
+// stratum with a comma-joined "MEP,MMO" value.
 define "Category Rows":
     { Tuple { rowDate: @2026-01-01, category: System.Code { code: 'MMO' } },
       Tuple { rowDate: @2026-01-02, category: System.Code { code: 'MMO' } },
@@ -32,7 +37,8 @@ define "Category Rows":
       Tuple { rowDate: @2026-01-09, category: System.Code { code: 'MCD' } },
       Tuple { rowDate: @2026-01-10, category: System.Code { code: 'MCD' } },
       Tuple { rowDate: @2026-01-11, category: System.Code { code: 'MCD' } },
-      Tuple { rowDate: @2026-01-12, category: System.Code { code: 'MEP' } } }
+      Tuple { rowDate: @2026-01-12, category: System.Code { code: 'MEP' } },
+      Tuple { rowDate: @2026-01-12, category: System.Code { code: 'MMO' } } }
 
 // List-valued component-stratifier function: returns the category code(s) for the given date via
 // `return all`. A list-returning component function is the shape that exposed the CLI bug where the

--- a/cqf-fhir-cr-cli/src/test/resources/stratifier-functions/input/cql/StratifierMultiSubjectDateBasis.cql
+++ b/cqf-fhir-cr-cli/src/test/resources/stratifier-functions/input/cql/StratifierMultiSubjectDateBasis.cql
@@ -1,0 +1,45 @@
+library StratifierMultiSubjectDateBasis
+
+using FHIR version '4.0.1'
+
+include FHIRHelpers version '4.0.1' called FHIRHelpers
+
+context Patient
+
+// Synthetic date-basis initial population: a fixed list of 12 dates. Values are CQL literals so the
+// scenario is fully self-contained and patient-independent.
+define "Enrollment Initial Population":
+    { @2026-01-01, @2026-01-02,
+      @2026-01-03, @2026-01-04, @2026-01-05, @2026-01-06, @2026-01-07,
+      @2026-01-08, @2026-01-09, @2026-01-10, @2026-01-11,
+      @2026-01-12 }
+
+// Scalar-valued component-stratifier function: returns a constant category for every date.
+define function "Age Stratifier"(stratificationDate Date):
+    '18-19'
+
+// Stubbed per-date input list (one row per date), each tagged with a category code. Stands in for
+// data-derived input so the list-returning stratifier function below can be exercised.
+define "Category Rows":
+    { Tuple { rowDate: @2026-01-01, category: System.Code { code: 'MMO' } },
+      Tuple { rowDate: @2026-01-02, category: System.Code { code: 'MMO' } },
+      Tuple { rowDate: @2026-01-03, category: System.Code { code: 'MCD' } },
+      Tuple { rowDate: @2026-01-04, category: System.Code { code: 'MCD' } },
+      Tuple { rowDate: @2026-01-05, category: System.Code { code: 'MCD' } },
+      Tuple { rowDate: @2026-01-06, category: System.Code { code: 'MCD' } },
+      Tuple { rowDate: @2026-01-07, category: System.Code { code: 'MCD' } },
+      Tuple { rowDate: @2026-01-08, category: System.Code { code: 'MCD' } },
+      Tuple { rowDate: @2026-01-09, category: System.Code { code: 'MCD' } },
+      Tuple { rowDate: @2026-01-10, category: System.Code { code: 'MCD' } },
+      Tuple { rowDate: @2026-01-11, category: System.Code { code: 'MCD' } },
+      Tuple { rowDate: @2026-01-12, category: System.Code { code: 'MEP' } } }
+
+// List-valued component-stratifier function: returns the category code(s) for the given date via
+// `return all`. A list-returning component function is the shape that exposed the CLI bug where the
+// stratifier functions were never evaluated (yielding null component values).
+define function "Product Line Stratifier"(stratificationDate Date):
+    ("Category Rows") row
+    where
+        row.rowDate = stratificationDate
+    return all
+        row.category.code

--- a/cqf-fhir-cr-cli/src/test/resources/stratifier-functions/input/resources/library/StratifierMultiSubjectDateBasis.json
+++ b/cqf-fhir-cr-cli/src/test/resources/stratifier-functions/input/resources/library/StratifierMultiSubjectDateBasis.json
@@ -1,0 +1,18 @@
+{
+  "resourceType": "Library",
+  "id": "StratifierMultiSubjectDateBasis",
+  "url": "http://example.com/Library/StratifierMultiSubjectDateBasis",
+  "name": "StratifierMultiSubjectDateBasis",
+  "status": "active",
+  "type": {
+    "coding": [ {
+      "system": "http://terminology.hl7.org/CodeSystem/library-type",
+      "code": "logic-library"
+    } ]
+  },
+  "content": [ {
+    "contentType": "text/cql",
+    "url": "../../cql/StratifierMultiSubjectDateBasis.cql"
+    }
+  ]
+}

--- a/cqf-fhir-cr-cli/src/test/resources/stratifier-functions/input/resources/measure/StratifierMultiSubjectDateBasisMultiComponentMeasure.json
+++ b/cqf-fhir-cr-cli/src/test/resources/stratifier-functions/input/resources/measure/StratifierMultiSubjectDateBasisMultiComponentMeasure.json
@@ -1,0 +1,73 @@
+{
+  "id": "StratifierMultiSubjectDateBasisMultiComponentMeasure",
+  "resourceType": "Measure",
+  "name": "StratifierMultiSubjectDateBasisMultiComponentMeasure",
+  "url": "http://example.com/Measure/StratifierMultiSubjectDateBasisMultiComponentMeasure",
+  "library": [
+    "http://example.com/Library/StratifierMultiSubjectDateBasis"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "date"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "Enrollment",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Enrollment Initial Population"
+          }
+        }
+      ],
+      "stratifier": [
+        {
+          "id": "enrollment-stratifier",
+          "component": [
+            {
+              "id": "age-component",
+              "code": {
+                "text": "Age"
+              },
+              "criteria": {
+                "language": "text/cql-identifier",
+                "expression": "Age Stratifier"
+              }
+            },
+            {
+              "id": "product-line-component",
+              "code": {
+                "text": "ProductLine"
+              },
+              "criteria": {
+                "language": "text/cql-identifier",
+                "expression": "Product Line Stratifier"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr-cli/src/test/resources/stratifier-functions/input/tests/patient/patient-a.json
+++ b/cqf-fhir-cr-cli/src/test/resources/stratifier-functions/input/tests/patient/patient-a.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "Patient",
+  "id": "patient-a",
+  "name": [
+    {
+      "family": "Test",
+      "given": ["Patient A"]
+    }
+  ],
+  "gender": "male",
+  "birthDate": "1990-01-01"
+}

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureMultiSubjectEvaluator.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureMultiSubjectEvaluator.java
@@ -532,8 +532,19 @@ public class MeasureMultiSubjectEvaluator {
 
         if (isFunctionResult) {
             for (FunctionResultEntry entry : result.functionResultEntries()) {
-                rowKeys.add(StratifierRowKey.withInput(
-                        qualifiedSubject, StratifierRowValue.ofFunctionInput(entry.input())));
+                var elements = multiElementList(entry.output());
+                if (elements != null) {
+                    // A single input produced multiple values: register one element alignment key per
+                    // value so this input fans out into one stratum per value (and scalar components
+                    // on the same input align to each).
+                    for (int i = 0; i < elements.size(); i++) {
+                        rowKeys.add(StratifierRowKey.withInput(
+                                qualifiedSubject, StratifierRowValue.ofFunctionInputElement(entry.input(), i)));
+                    }
+                } else {
+                    rowKeys.add(StratifierRowKey.withInput(
+                            qualifiedSubject, StratifierRowValue.ofFunctionInput(entry.input())));
+                }
             }
         } else {
             int index = 0;
@@ -563,7 +574,7 @@ public class MeasureMultiSubjectEvaluator {
         final Object rawValue = result == null ? null : result.raw();
 
         if (result != null && result.isFunctionResult()) {
-            return addFunctionResultRows(qualifiedSubject, result.functionResultEntries());
+            return addFunctionResultRows(qualifiedSubject, result.functionResultEntries(), alignmentRowKeysBySubject);
 
         } else if (rawValue instanceof Iterable<?> iterableValue) {
             return addIterableValueRows(qualifiedSubject, iterableValue);
@@ -619,18 +630,101 @@ public class MeasureMultiSubjectEvaluator {
      * </ul>
      */
     private static List<StratumTableRow> addFunctionResultRows(
-            String qualifiedSubject, List<FunctionResultEntry> functionResults) {
+            String qualifiedSubject,
+            List<FunctionResultEntry> functionResults,
+            Map<String, Set<StratifierRowKey>> alignmentRowKeysBySubject) {
 
-        return functionResults.stream()
-                .map(entry ->
-                        // The output value becomes the stratum value (what's displayed)
-                        // Null values are allowed - they will be grouped into a special "null" stratum
-                        new StratumTableRow(
-                                StratifierRowKey.withInput(
-                                        qualifiedSubject,
-                                        // Build composite row key: "Patient/xxx|Resource/yyy"
-                                        StratifierRowValue.ofFunctionInput(entry.input())),
-                                new StratumValueWrapper(entry.output())))
+        final Set<StratifierRowKey> subjectAlignmentKeys = alignmentRowKeysBySubject.get(qualifiedSubject);
+        final var rows = new ArrayList<StratumTableRow>();
+
+        for (FunctionResultEntry entry : functionResults) {
+            var elements = multiElementList(entry.output());
+            if (elements != null) {
+                // Multi-valued output: fan out into one row (and therefore one stratum) per value.
+                // Each element key still intersects the population on this input, so the input is
+                // counted in every stratum it fans into.
+                for (int i = 0; i < elements.size(); i++) {
+                    rows.add(new StratumTableRow(
+                            StratifierRowKey.withInput(
+                                    qualifiedSubject, StratifierRowValue.ofFunctionInputElement(entry.input(), i)),
+                            new StratumValueWrapper(elements.get(i))));
+                }
+                continue;
+            }
+
+            // Single-valued output. Unwrap a single-element list to its element so that a value that
+            // arrives bare (e.g. from a sibling's fan-out) and the same value arriving as a one-element
+            // list group into the SAME stratum (StratumValueWrapper keys a bare value and a list
+            // differently). Null values are allowed - they group into a special "null" stratum.
+            final var valueWrapper = new StratumValueWrapper(unwrapSingleElement(entry.output()));
+
+            // If another component fanned this same input into element rows, broadcast this value to
+            // each of those element keys so every fanned stratum carries a value from every component.
+            // Otherwise emit the usual single input-keyed row.
+            final List<StratifierRowKey> elementKeys =
+                    elementAlignmentKeysForInput(subjectAlignmentKeys, entry.input());
+            if (!elementKeys.isEmpty()) {
+                for (StratifierRowKey elementKey : elementKeys) {
+                    rows.add(new StratumTableRow(elementKey, valueWrapper));
+                }
+            } else {
+                rows.add(new StratumTableRow(
+                        StratifierRowKey.withInput(qualifiedSubject, StratifierRowValue.ofFunctionInput(entry.input())),
+                        valueWrapper));
+            }
+        }
+
+        return rows;
+    }
+
+    /**
+     * Returns the elements of a multi-valued (two or more) iterable value, or {@code null} for a
+     * scalar or a single-element iterable — neither of which needs to fan out (a single-element list
+     * renders as one value, matching the pre-existing behavior).
+     */
+    private static List<Object> multiElementList(Object value) {
+        if (!(value instanceof Iterable<?> iterable)) {
+            return null;
+        }
+        final var elements = new ArrayList<Object>();
+        iterable.forEach(elements::add);
+        return elements.size() >= 2 ? elements : null;
+    }
+
+    /**
+     * Unwraps a single-element iterable to its element, leaving scalars, empty iterables, and
+     * multi-element iterables untouched. Keeps a one-element function output ({@code {MMO}}) keyed
+     * the same as the bare value ({@code MMO}) so both land in the same stratum.
+     */
+    private static Object unwrapSingleElement(Object value) {
+        if (value instanceof Iterable<?> iterable) {
+            final var iterator = iterable.iterator();
+            if (iterator.hasNext()) {
+                final Object first = iterator.next();
+                if (!iterator.hasNext()) {
+                    return first;
+                }
+            }
+        }
+        return value;
+    }
+
+    /**
+     * The element alignment keys (produced by a multi-valued component) that belong to the given
+     * function input, matched on the input's intersection id. Used to broadcast a scalar component's
+     * value onto every stratum a sibling multi-valued component fanned this input into.
+     */
+    private static List<StratifierRowKey> elementAlignmentKeysForInput(
+            Set<StratifierRowKey> subjectAlignmentKeys, Object input) {
+        if (subjectAlignmentKeys == null || subjectAlignmentKeys.isEmpty()) {
+            return List.of();
+        }
+        final String inputId = StratifierRowValue.ofFunctionInput(input).intersectionValue();
+        return subjectAlignmentKeys.stream()
+                .filter(key -> key.inputParam()
+                        .map(value -> value instanceof StratifierRowValue.ResourceElement
+                                && inputId.equals(value.intersectionValue()))
+                        .orElse(false))
                 .toList();
     }
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/StratifierRowValue.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/StratifierRowValue.java
@@ -33,7 +33,8 @@ import org.opencds.cqf.fhir.cql.ClassInstanceHelper;
  *   <li>{@link #ofResourceId(String)} — for already-normalised IDs (tests, internal use).</li>
  * </ul>
  */
-public sealed interface StratifierRowValue permits StratifierRowValue.Resource, StratifierRowValue.Scalar {
+public sealed interface StratifierRowValue
+        permits StratifierRowValue.Resource, StratifierRowValue.ResourceElement, StratifierRowValue.Scalar {
 
     /**
      * Stable string form of this value, used as the unique inputParam slot in
@@ -42,8 +43,19 @@ public sealed interface StratifierRowValue permits StratifierRowValue.Resource, 
     String legacyString();
 
     /**
-     * {@code true} if this value can be intersected against population resource keys; only
-     * {@link Resource} returns true. Iterable-derived {@link Scalar} keys are synthetic
+     * The value used to intersect this row against population resource keys. For most values this is
+     * the same as {@link #legacyString()}. It differs for {@link ResourceElement}, whose
+     * {@code legacyString()} carries a per-element discriminator (so multiple values for one input
+     * land in distinct strata) but whose intersection value is the underlying input id (so the
+     * input is still counted correctly in each stratum it fans into).
+     */
+    default String intersectionValue() {
+        return legacyString();
+    }
+
+    /**
+     * {@code true} if this value can be intersected against population resource keys; {@link Resource}
+     * and {@link ResourceElement} return true. Iterable-derived {@link Scalar} keys are synthetic
      * uniquifiers and must fall back to subject-level resource lookup instead.
      */
     boolean isIntersectable();
@@ -54,11 +66,26 @@ public sealed interface StratifierRowValue permits StratifierRowValue.Resource, 
      * the now-removed {@code normalizeResourceKey} helper).
      */
     static StratifierRowValue ofFunctionInput(Object obj) {
+        return new Resource(functionInputId(obj));
+    }
+
+    /**
+     * The intersectable id for a function input — a FHIR resource's versionless {@code Type/id}, or
+     * {@link String#valueOf(Object)} for a primitive input (matching {@link #ofFunctionInput(Object)}).
+     */
+    private static String functionInputId(Object obj) {
         final String resourceId = resourceIdOrNull(obj);
-        if (resourceId != null) {
-            return new Resource(resourceId);
-        }
-        return new Resource(String.valueOf(obj));
+        return resourceId != null ? resourceId : String.valueOf(obj);
+    }
+
+    /**
+     * For one element of a multi-valued function output produced by a single input. The row must be
+     * distinct per element (so each value forms its own stratum), yet still intersect the population
+     * on the underlying input id (so that input is counted in each stratum it fans into). Uniqueness
+     * comes from {@code index}; {@link #intersectionValue()} returns the input id.
+     */
+    static StratifierRowValue ofFunctionInputElement(Object input, int index) {
+        return new ResourceElement(functionInputId(input), index);
     }
 
     /**
@@ -117,6 +144,33 @@ public sealed interface StratifierRowValue permits StratifierRowValue.Resource, 
 
         @Override
         public String legacyString() {
+            return resourceId;
+        }
+
+        @Override
+        public boolean isIntersectable() {
+            return true;
+        }
+    }
+
+    /**
+     * Intersectable inputParam for one element of a multi-valued function output. {@code resourceId}
+     * is the underlying input id (used for population intersection); {@code index} makes the key
+     * unique per element so each value forms its own stratum. Encodes {@code <resourceId>#e<index>}.
+     */
+    record ResourceElement(String resourceId, int index) implements StratifierRowValue {
+
+        public ResourceElement {
+            Objects.requireNonNull(resourceId, "resourceId must not be null");
+        }
+
+        @Override
+        public String legacyString() {
+            return resourceId + "#e" + index;
+        }
+
+        @Override
+        public String intersectionValue() {
             return resourceId;
         }
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/SubjectResourceKey.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/SubjectResourceKey.java
@@ -85,7 +85,7 @@ public record SubjectResourceKey(@Nullable String subjectId, String resourceValu
      */
     public static SubjectResourceKey fromRowKey(StratifierRowKey rowKey, boolean isPrimitiveBasis) {
         String resourceValue = rowKey.inputParam()
-                .map(StratifierRowValue::legacyString)
+                .map(StratifierRowValue::intersectionValue)
                 .orElseThrow(() -> new IllegalArgumentException("RowKey must have an inputParam"));
 
         if (isPrimitiveBasis) {

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/StratifierMultiSubjectDateBasisTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/StratifierMultiSubjectDateBasisTest.java
@@ -172,6 +172,57 @@ class StratifierMultiSubjectDateBasisTest {
     }
 
     /**
+     * A stratifier <em>function</em> that returns a multi-element list for a single input must fan out
+     * into one stratum per value (the input counting toward each), not collapse into a single stratum
+     * with a comma-joined value.
+     *
+     * <p>Here {@code @2026-01-12} is enrolled in two product lines (MEP and MMO) in the same month, so
+     * {@code Multi Payer Product Line Stratifier} returns {@code {MEP, MMO}} for that date. Expected:
+     * that date counts toward BOTH the MEP and MMO strata. Per-input counts: MMO x3 (01-01, 01-02,
+     * 01-12) / MCD x9 / MEP x1 (01-12) — distinct from a subject-level count, which would report 12 for
+     * every stratum. No component value is comma-joined.
+     */
+    @Test
+    void hedisEnrollmentMultiValueProductLineFansOutPerValue() {
+        MeasureReport report = GIVEN.when()
+                .measureId("StratifierMultiSubjectDateBasisMultiValueComponentMeasure")
+                .subject("Patient/patient-a")
+                .evaluate()
+                .then()
+                .measureReport();
+
+        var group = report.getGroup().stream()
+                .filter(g -> "Enrollment".equals(g.getId()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no Enrollment group in report"));
+        assertEquals(12, group.getPopulationFirstRep().getCount(), "initial-population count");
+
+        assertFalse(group.getStratifier().isEmpty(), "Enrollment group produced no stratifier");
+        var strata = group.getStratifierFirstRep().getStratum();
+        assertEquals(3, strata.size(), "the multi-value date must fan out, yielding three strata (MMO, MCD, MEP)");
+
+        Map<String, Integer> productLineCounts = new HashMap<>();
+        for (var stratum : strata) {
+            assertEquals(2, stratum.getComponent().size(), "each stratum should carry Age + ProductLine");
+            var productLine = stratum.getComponent().stream()
+                    .filter(c -> c.getCode().hasText()
+                            && "ProductLine".equals(c.getCode().getText()))
+                    .map(c -> c.getValue().getText())
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("stratum is missing a ProductLine component"));
+            assertFalse(
+                    productLine.contains(","),
+                    "ProductLine value should fan out into separate strata, not comma-join: " + productLine);
+            productLineCounts.put(productLine, stratum.getPopulationFirstRep().getCount());
+        }
+
+        assertEquals(
+                Map.of("MMO", 3, "MCD", 9, "MEP", 1),
+                productLineCounts,
+                "the multi-payer date (01-12) must count toward both MMO and MEP, per input");
+    }
+
+    /**
      * Reproduces the empty/collapsed stratifier reported for HEDIS 2025 (NCQA ENP-Reporting):
      * {@code "stratifier": [ { "id": "enrollment-stratifier" } ]} with no {@code stratum} array.
      *

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/StratifierMultiSubjectDateBasis/input/cql/StratifierMultiSubjectDateBasis.cql
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/StratifierMultiSubjectDateBasis/input/cql/StratifierMultiSubjectDateBasis.cql
@@ -58,6 +58,21 @@ define function "Product Line Stratifier"(enrollmentDate Date):
     return all
         mmInfo.payer.code
 
+// Same member-months, but @2026-01-12 is enrolled in TWO product lines in the same month, so the
+// stratifier function returns a MULTI-element list for that single enrollment date. That date must
+// fan out into BOTH the MEP and MMO strata (counted in each), not collapse into a single stratum
+// with a comma-joined "MEP,MMO" value.
+define "All reported member months info (multi payer)":
+    "All reported member months info"
+      union { Tuple { monthlyEnrollmentDate: @2026-01-12, payer: System.Code { code: 'MMO' } } }
+
+define function "Multi Payer Product Line Stratifier"(enrollmentDate Date):
+    ("All reported member months info (multi payer)") mmInfo
+    where
+        mmInfo.monthlyEnrollmentDate = enrollmentDate
+    return all
+        mmInfo.payer.code
+
 // --- Null-valued stratifier components (reproduces the empty/collapsed stratifier) ---
 // Two scalar stratifier expressions that evaluate to null for the member. With the defect,
 // a null scalar component is silently dropped (never recorded), so when every component is

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/StratifierMultiSubjectDateBasis/input/resources/measure/StratifierMultiSubjectDateBasisMultiValueComponentMeasure.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/StratifierMultiSubjectDateBasis/input/resources/measure/StratifierMultiSubjectDateBasisMultiValueComponentMeasure.json
@@ -1,0 +1,73 @@
+{
+  "id": "StratifierMultiSubjectDateBasisMultiValueComponentMeasure",
+  "resourceType": "Measure",
+  "name": "StratifierMultiSubjectDateBasisMultiValueComponentMeasure",
+  "url": "http://example.com/Measure/StratifierMultiSubjectDateBasisMultiValueComponentMeasure",
+  "library": [
+    "http://example.com/Library/StratifierMultiSubjectDateBasis"
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "date"
+    }
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "Enrollment",
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Enrollment Initial Population"
+          }
+        }
+      ],
+      "stratifier": [
+        {
+          "id": "enrollment-stratifier",
+          "component": [
+            {
+              "id": "age-component",
+              "code": {
+                "text": "Age"
+              },
+              "criteria": {
+                "language": "text/cql-identifier",
+                "expression": "Age Stratifier"
+              }
+            },
+            {
+              "id": "product-line-component",
+              "code": {
+                "text": "ProductLine"
+              },
+              "criteria": {
+                "language": "text/cql-identifier",
+                "expression": "Multi Payer Product Line Stratifier"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

Evaluating a measure through the CLI produces MeasureReports whose **stratifier component values are `null`** when the stratifier components are CQL *functions*. The group populations and counts are correct; only the stratifier component values come back as `"null"`, accompanied by:

> WARN MeasureEvaluator - Stratifier component expression '<fn>' returned null result for subject '<id>' (fallback)

This surfaced against a real HEDIS-style measure on CR 4.11.0 but reproduces with any measure that uses function-based component stratifiers. The server `$evaluate-measure` operation is **not** affected.

## Root cause

The CLI evaluates the CQL itself as a plain library `$evaluate` (top-level `define`s only - CQL functions are never invoked, since they require arguments) and passes those precomputed results into `R4MeasureProcessor.evaluateMeasureResults(...)` -> `MeasureEvaluationResultHandler.processResults`.

That "results-in" path **never runs `FunctionEvaluationHandler.cqlFunctionEvaluation`**, which is the sole producer of the per-resource stratifier-function results It is wired only into the engine-driven path, which the server uses. With the function results absent, `MeasureEvaluator.handleNonBooleanBasisComponent` misses the lookup, falls back to a scalar lookup (also absent for a function), and records a null component value.

## Fix

Route the CLI `measure` command through CR's **engine path**, exactly like the server and `R4CollectDataService`, so CR owns the full evaluation (library expressions **and** the stratifier functions):

```java
    var composite = processor.evaluateMeasureWithCqlEngine(subjects, measure, start, end, new Parameters(), engine);
    var report    = processor.evaluateMeasure(measure, start, end, "subject", subjects, MeasureEvalType.SUBJECT, engine, composite);
```

- Subjects are still derived from the `-c/-cv` context pairs.
- The `--output-path` CQL `.txt` dump is preserved, now written from the engine-path composite (it additionally includes the stratifier-function result keys).
- The precomputed `evaluateMeasureResults` / `processResults` API is left untouched for DSTU3 and any other callers.

## Behavior change to note

The engine path resolves the measure's `library` **canonical URL against the repository** (as the server does), rather than relying on the `-name` argument alone. This is stricter and more correct, but content whose `measure.library` URL does not resolve to a `Library` resource in `-data` will now error instead of silently working. It exposed a latent mismatch in the `compartment` test fixtures (a `Library` declared `.../Library/ABC-LIB` while its `Measure` referenced `.../Library/ABCLIB`), corrected here.

## Testing

- New `CliTest.stratifierComponentFunctionValues` runs the CLI `measure` command against a small self-contained synthetic fixture (`stratifier-functions/`) with function-based component stratifiers, and asserts real component values (no `"null"`). It is **red without the fix** (null-value assertion) and **green with it**.
- Full `:cqf-fhir-cr-cli:test` and the `org.opencds.cqf.fhir.cr.measure.*` suite pass; spotless clean.

Note: I did not create an issue for this, but it likely should have been included as part of #1081