### PR TITLE
Improve $package terminology expansion: tx-resource, NPM federation, and smarter tx-server retries

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/BaseKnowledgeArtifactVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/BaseKnowledgeArtifactVisitor.java
@@ -197,7 +197,8 @@ public abstract class BaseKnowledgeArtifactVisitor implements IKnowledgeArtifact
                         if (hasUrl) {
                             // Try to resolve version using package source and IG dependencies
                             String canonical = resolveCanonicalWithIgVersion(ra.getReference(), igDependencyVersions);
-                            var bundle = SearchHelper.searchRepositoryByCanonicalWithPaging(repository, canonical);
+                            var bundle = SearchHelper.searchRepositoryByCanonicalWithPaging(
+                                    gatherResolutionRepository(), canonical);
                             var resolved = bundle == null ? null : findResourceMatchingVersion(bundle, canonical);
                             if (resolved == null) {
                                 // Not resolvable from the repository at the requested version; fall back
@@ -358,6 +359,79 @@ public abstract class BaseKnowledgeArtifactVisitor implements IKnowledgeArtifact
     }
 
     /**
+     * The repository used to resolve dependency references during {@link #recursiveGather}. Defaults to the
+     * operation's repository. Subclasses may override to federate additional sources (e.g. NPM packages
+     * declared by the artifact's ImplementationGuide) so version-pinned artifacts the repository/tx server
+     * lack can still be resolved.
+     */
+    protected IRepository gatherResolutionRepository() {
+        return repository;
+    }
+
+    /**
+     * Determines the ImplementationGuide governing the artifact being processed: the artifact itself if it is
+     * an ImplementationGuide, otherwise the IG referenced by a {@code composed-of} related artifact and
+     * resolved from the repository. Returns empty when no IG can be determined — callers must not guess.
+     */
+    protected Optional<IKnowledgeArtifactAdapter> resolveImplementationGuide(IKnowledgeArtifactAdapter adapter) {
+        if (adapter == null) {
+            return Optional.empty();
+        }
+        if ("ImplementationGuide".equals(adapter.get().fhirType())) {
+            return Optional.of(adapter);
+        }
+        for (var component : adapter.getComponents()) {
+            var reference = IKnowledgeArtifactAdapter.getRelatedArtifactReference(component);
+            if (reference == null
+                    || reference.isBlank()
+                    || !"ImplementationGuide".equals(Canonicals.getResourceType(reference))) {
+                continue;
+            }
+            var resolved = VisitorHelper.tryGetLatestVersion(reference, repository);
+            if (resolved.isPresent()) {
+                return resolved;
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Extracts the NPM package coordinates ({@code [packageId, version]}) declared by an ImplementationGuide's
+     * own package plus its {@code dependsOn} entries, used to seed an NPM-federated repository.
+     */
+    protected List<String[]> extractDependsOnPackages(IKnowledgeArtifactAdapter adapter) {
+        List<String[]> packages = new ArrayList<>();
+        try {
+            if (adapter.get() instanceof org.hl7.fhir.r4.model.ImplementationGuide ig) {
+                extractDependsOnPackages(
+                        ig.hasPackageId() && ig.hasVersion() ? ig.getPackageId() : null, ig.getVersion(), packages);
+                for (var dep : ig.getDependsOn()) {
+                    if (dep.hasPackageId() && dep.hasVersion()) {
+                        packages.add(new String[] {dep.getPackageId(), dep.getVersion()});
+                    }
+                }
+            } else if (adapter.get() instanceof org.hl7.fhir.r5.model.ImplementationGuide ig) {
+                extractDependsOnPackages(
+                        ig.hasPackageId() && ig.hasVersion() ? ig.getPackageId() : null, ig.getVersion(), packages);
+                for (var dep : ig.getDependsOn()) {
+                    if (dep.hasPackageId() && dep.hasVersion()) {
+                        packages.add(new String[] {dep.getPackageId(), dep.getVersion()});
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.debug("Error extracting dependsOn packages", e);
+        }
+        return packages;
+    }
+
+    private static void extractDependsOnPackages(String packageId, String version, List<String[]> packages) {
+        if (packageId != null && version != null) {
+            packages.add(new String[] {packageId, version});
+        }
+    }
+
+    /**
      * Populates dependency versions from an ImplementationGuide adapter.
      * Extracts packageId and version from the IG's dependsOn array.
      *
@@ -422,7 +496,7 @@ public abstract class BaseKnowledgeArtifactVisitor implements IKnowledgeArtifact
 
         try {
             // Search for the resource to determine its package source
-            var bundle = SearchHelper.searchRepositoryByCanonicalWithPaging(repository, canonical);
+            var bundle = SearchHelper.searchRepositoryByCanonicalWithPaging(gatherResolutionRepository(), canonical);
             if (bundle == null) {
                 return canonical;
             }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/DataRequirementsVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/DataRequirementsVisitor.java
@@ -632,42 +632,6 @@ public class DataRequirementsVisitor extends BaseKnowledgeArtifactVisitor {
         return transitiveKeyCanonicals;
     }
 
-    private List<String[]> extractDependsOnPackages(IKnowledgeArtifactAdapter adapter) {
-        List<String[]> packages = new ArrayList<>();
-        try {
-            if (adapter.get() instanceof org.hl7.fhir.r4.model.ImplementationGuide ig) {
-                extractR4DependsOnPackages(ig, packages);
-            } else if (adapter.get() instanceof org.hl7.fhir.r5.model.ImplementationGuide ig) {
-                extractR5DependsOnPackages(ig, packages);
-            }
-        } catch (Exception e) {
-            logger.debug("Error extracting dependsOn packages", e);
-        }
-        return packages;
-    }
-
-    private void extractR4DependsOnPackages(org.hl7.fhir.r4.model.ImplementationGuide ig, List<String[]> packages) {
-        if (ig.hasPackageId() && ig.hasVersion()) {
-            packages.add(new String[] {ig.getPackageId(), ig.getVersion()});
-        }
-        for (var dep : ig.getDependsOn()) {
-            if (dep.hasPackageId() && dep.hasVersion()) {
-                packages.add(new String[] {dep.getPackageId(), dep.getVersion()});
-            }
-        }
-    }
-
-    private void extractR5DependsOnPackages(org.hl7.fhir.r5.model.ImplementationGuide ig, List<String[]> packages) {
-        if (ig.hasPackageId() && ig.hasVersion()) {
-            packages.add(new String[] {ig.getPackageId(), ig.getVersion()});
-        }
-        for (var dep : ig.getDependsOn()) {
-            if (dep.hasPackageId() && dep.hasVersion()) {
-                packages.add(new String[] {dep.getPackageId(), dep.getVersion()});
-            }
-        }
-    }
-
     protected LibraryManager createLibraryManager() {
         var librarySourceProvider = buildLibrarySource();
         var sourceProviders = new ArrayList<>(Arrays.asList(librarySourceProvider, librarySourceProvider));

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/ExpandHelper.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/ExpandHelper.java
@@ -11,6 +11,7 @@ import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import ca.uhn.fhir.util.ParametersUtil;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -18,6 +19,8 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseBackboneElement;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IDomainResource;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.opencds.cqf.fhir.utility.Canonicals;
 import org.opencds.cqf.fhir.utility.Constants;
@@ -25,10 +28,13 @@ import org.opencds.cqf.fhir.utility.Parameters;
 import org.opencds.cqf.fhir.utility.ValueSets;
 import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
 import org.opencds.cqf.fhir.utility.adapter.IEndpointAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IKnowledgeArtifactAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IParametersAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IParametersParameterComponentAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetAdapter;
+import org.opencds.cqf.fhir.utility.adapter.IValueSetConceptSetAdapter;
 import org.opencds.cqf.fhir.utility.client.ExpandRunner.TerminologyServerExpansionException;
+import org.opencds.cqf.fhir.utility.client.TerminologyServerClientSettings.TxResourceMode;
 import org.opencds.cqf.fhir.utility.client.terminology.ArtifactEndpointConfiguration;
 import org.opencds.cqf.fhir.utility.client.terminology.ITerminologyProviderRouter;
 import org.opencds.cqf.fhir.utility.client.terminology.ITerminologyServerClient;
@@ -92,6 +98,32 @@ public class ExpandHelper {
             List<IValueSetAdapter> valueSets,
             List<String> expandedList,
             Date expansionTimestamp) {
+        expandValueSet(
+                valueSet,
+                expansionParameters,
+                terminologyEndpoint,
+                valueSets,
+                List.of(),
+                expandedList,
+                expansionTimestamp);
+    }
+
+    /**
+     * Same as {@link #expandValueSet(IValueSetAdapter, IParametersAdapter, Optional, List, List, Date)}, but
+     * additionally accepts the package-authored CodeSystems ({@code packageCodeSystems}) that make up the
+     * package closure. When a remote terminology server is used to expand, the package-authored ValueSets and
+     * CodeSystems referenced by the target ValueSet are supplied to the {@code $expand} call via the
+     * {@code tx-resource} parameter so version-pinned artifacts the server lacks can be resolved from the
+     * supplied resources.
+     */
+    public void expandValueSet(
+            IValueSetAdapter valueSet,
+            IParametersAdapter expansionParameters,
+            Optional<IEndpointAdapter> terminologyEndpoint,
+            List<IValueSetAdapter> valueSets,
+            List<IBaseResource> packageCodeSystems,
+            List<String> expandedList,
+            Date expansionTimestamp) {
         // Have we already expanded this ValueSet?
         if (expandedList.contains(valueSet.getUrl())) {
             // Nothing to do here
@@ -121,7 +153,8 @@ public class ExpandHelper {
                 && (authoritativeSourceUrl == null || authoritativeSourceUrl.equals(endpointAddressBase));
         if (endpointIsAuthoritativeSource) {
             try {
-                terminologyServerExpand(valueSet, expansionParameters, terminologyEndpoint.get());
+                terminologyServerExpand(
+                        valueSet, expansionParameters, terminologyEndpoint.get(), valueSets, packageCodeSystems);
                 return;
             } catch (TerminologyServerExpansionException e) {
                 log.warn(
@@ -144,6 +177,7 @@ public class ExpandHelper {
                         expansionParameters,
                         terminologyEndpoint,
                         valueSets,
+                        packageCodeSystems,
                         expandedList,
                         repository,
                         expansionTimestamp);
@@ -192,7 +226,8 @@ public class ExpandHelper {
             // rather than failing — a general terminology server can expand ValueSets authored elsewhere.
             if (terminologyEndpoint.isPresent() && !endpointIsAuthoritativeSource) {
                 try {
-                    terminologyServerExpand(valueSet, expansionParameters, terminologyEndpoint.get());
+                    terminologyServerExpand(
+                            valueSet, expansionParameters, terminologyEndpoint.get(), valueSets, packageCodeSystems);
                     // The endpoint used is not this ValueSet's authoritative source, so surface a
                     // warning that the expansion was completed non-authoritatively.
                     addExpansionWarningParameter(
@@ -257,6 +292,32 @@ public class ExpandHelper {
             List<IValueSetAdapter> valueSets,
             List<String> expandedList,
             Date expansionTimestamp) {
+        expandValueSet(
+                valueSet,
+                expansionParameters,
+                artifactEndpointConfigurations,
+                terminologyEndpoint,
+                valueSets,
+                List.of(),
+                expandedList,
+                expansionTimestamp);
+    }
+
+    /**
+     * Same as
+     * {@link #expandValueSet(IValueSetAdapter, IParametersAdapter, List, Optional, List, List, Date)}, but
+     * additionally accepts the package-authored CodeSystems ({@code packageCodeSystems}) that make up the
+     * package closure so they can be supplied to a remote {@code $expand} via {@code tx-resource}.
+     */
+    public void expandValueSet(
+            IValueSetAdapter valueSet,
+            IParametersAdapter expansionParameters,
+            List<ArtifactEndpointConfiguration> artifactEndpointConfigurations,
+            Optional<IEndpointAdapter> terminologyEndpoint,
+            List<IValueSetAdapter> valueSets,
+            List<IBaseResource> packageCodeSystems,
+            List<String> expandedList,
+            Date expansionTimestamp) {
         // Have we already expanded this ValueSet?
         if (expandedList.contains(valueSet.getUrl())) {
             return;
@@ -288,13 +349,31 @@ public class ExpandHelper {
         }
 
         // Fall back to legacy single endpoint or local expansion
-        expandValueSet(valueSet, expansionParameters, terminologyEndpoint, valueSets, expandedList, expansionTimestamp);
+        expandValueSet(
+                valueSet,
+                expansionParameters,
+                terminologyEndpoint,
+                valueSets,
+                packageCodeSystems,
+                expandedList,
+                expansionTimestamp);
     }
 
     private void terminologyServerExpand(
-            IValueSetAdapter valueSet, IParametersAdapter expansionParameters, IEndpointAdapter terminologyEndpoint) {
+            IValueSetAdapter valueSet,
+            IParametersAdapter expansionParameters,
+            IEndpointAdapter terminologyEndpoint,
+            List<IValueSetAdapter> valueSets,
+            List<IBaseResource> packageCodeSystems) {
+        // Supply the target ValueSet and the package's own resources it references to the $expand call
+        // via the tx-resource parameter so version-pinned artifacts the server lacks can be resolved
+        // from them. Attach to a per-expansion COPY of the parameters: the caller's parameters object is
+        // reused across every ValueSet in a $package run, so mutating it here would cause tx-resource
+        // params to accumulate across expansions.
+        var expandParameters = (IParametersAdapter) adapterFactory.createResource(expansionParameters.copy());
+        attachTxResourceParameters(valueSet, expandParameters, terminologyEndpoint, valueSets, packageCodeSystems);
         var expandedValueSet = (IValueSetAdapter) adapterFactory.createResource(
-                terminologyServerRouter.expand(valueSet, terminologyEndpoint, expansionParameters));
+                terminologyServerRouter.expand(valueSet, terminologyEndpoint, expandParameters));
         // expansions are only valid for a particular version
         if (!valueSet.hasVersion()) {
             valueSet.setVersion(expandedValueSet.getVersion());
@@ -304,11 +383,94 @@ public class ExpandHelper {
         validateExpansionParameters(valueSet, expansionParameters);
     }
 
+    /**
+     * Attaches {@code tx-resource} parameters to {@code expansionParameters} so they are supplied to the
+     * remote {@code $expand} call. Attaches the target ValueSet itself (the server may not hold the
+     * requested version) plus the package-authored ValueSets and CodeSystems it references: referenced
+     * ValueSet canonicals ({@code include[].valueSet}) matched against {@code valueSets}, and referenced
+     * CodeSystem systems ({@code include[].system}) matched against {@code packageCodeSystems}. Matches are
+     * de-duplicated by {@code url|version}. When the configured {@link TxResourceMode} is {@code DISABLED}
+     * nothing is attached.
+     */
+    private void attachTxResourceParameters(
+            IValueSetAdapter valueSet,
+            IParametersAdapter expansionParameters,
+            IEndpointAdapter terminologyEndpoint,
+            List<IValueSetAdapter> valueSets,
+            List<IBaseResource> packageCodeSystems) {
+        var settings = terminologyServerRouter.getTerminologyServerClientSettings(terminologyEndpoint);
+        var mode = settings != null ? settings.getTxResourceMode() : TxResourceMode.AUTO;
+        if (mode == TxResourceMode.DISABLED) {
+            return;
+        }
+
+        // De-duplicate attached resources by url|version, preserving insertion order.
+        var toAttach = new LinkedHashMap<String, IBaseResource>();
+
+        // Supply the target ValueSet itself. The reported failure mode is that the terminology server
+        // does not hold the requested ValueSet version; because $expand is invoked by url reference, the
+        // server cannot resolve a version it lacks. Supplied as a tx-resource, it is "used preferentially
+        // to those known to the system" (per the $expand OperationDefinition).
+        toAttach.put(urlVersionKey(valueSet.getUrl(), valueSet.getVersion()), valueSet.get());
+
+        boolean noValueSets = valueSets == null || valueSets.isEmpty();
+        boolean noCodeSystems = packageCodeSystems == null || packageCodeSystems.isEmpty();
+
+        if (!noValueSets || !noCodeSystems) {
+            // Referenced ValueSet canonicals from the target's compose (url|version strings)
+            var referencedValueSets = valueSet.getValueSetIncludes();
+            // Referenced CodeSystem systems from the target's compose includes
+            var referencedSystems = valueSet.getComposeInclude().stream()
+                    .filter(IValueSetConceptSetAdapter::hasSystem)
+                    .map(IValueSetConceptSetAdapter::getSystem)
+                    .collect(Collectors.toSet());
+
+            if (!noValueSets) {
+                for (var packageVs : valueSets) {
+                    for (var reference : referencedValueSets) {
+                        var refUrl = Canonicals.getUrl(reference);
+                        var refVersion = Canonicals.getVersion(reference);
+                        if (packageVs.getUrl() != null
+                                && packageVs.getUrl().equals(refUrl)
+                                && (refVersion == null || refVersion.equals(packageVs.getVersion()))) {
+                            toAttach.putIfAbsent(
+                                    urlVersionKey(packageVs.getUrl(), packageVs.getVersion()), packageVs.get());
+                        }
+                    }
+                }
+            }
+
+            if (!noCodeSystems) {
+                for (var codeSystem : packageCodeSystems) {
+                    IKnowledgeArtifactAdapter csAdapter =
+                            adapterFactory.createKnowledgeArtifactAdapter((IDomainResource) codeSystem);
+                    if (csAdapter.getUrl() != null && referencedSystems.contains(csAdapter.getUrl())) {
+                        toAttach.putIfAbsent(urlVersionKey(csAdapter.getUrl(), csAdapter.getVersion()), codeSystem);
+                    }
+                }
+            }
+        }
+
+        toAttach.values().forEach(resource -> expansionParameters.addParameter(Constants.TX_RESOURCE, resource));
+
+        log.info(
+                "Attached {} tx-resource(s) (mode={}) for $expand of ValueSet {}: [{}]",
+                toAttach.size(),
+                mode,
+                valueSet.getUrl(),
+                String.join(", ", toAttach.keySet()));
+    }
+
+    private static String urlVersionKey(String url, String version) {
+        return (url == null ? "" : url) + "|" + (version == null ? "" : version);
+    }
+
     private IBaseBackboneElement expandIncludes(
             IValueSetAdapter valueSet,
             IParametersAdapter expansionParameters,
             Optional<IEndpointAdapter> terminologyEndpoint,
             List<IValueSetAdapter> valueSets,
+            List<IBaseResource> packageCodeSystems,
             List<String> expandedList,
             IRepository repository,
             Date expansionTimestamp) {
@@ -325,6 +487,7 @@ public class ExpandHelper {
                             expansionParameters,
                             terminologyEndpoint,
                             valueSets,
+                            packageCodeSystems,
                             expandedList,
                             expansionTimestamp,
                             includedVS);
@@ -398,6 +561,7 @@ public class ExpandHelper {
             IParametersAdapter expansionParameters,
             Optional<IEndpointAdapter> terminologyEndpoint,
             List<IValueSetAdapter> valueSets,
+            List<IBaseResource> packageCodeSystems,
             List<String> expandedList,
             Date expansionTimestamp,
             IValueSetAdapter includedVS) {
@@ -431,7 +595,14 @@ public class ExpandHelper {
                     .map(IParametersParameterComponentAdapter::get)
                     .toList());
         }
-        expandValueSet(includedVS, childExpParams, terminologyEndpoint, valueSets, expandedList, expansionTimestamp);
+        expandValueSet(
+                includedVS,
+                childExpParams,
+                terminologyEndpoint,
+                valueSets,
+                packageCodeSystems,
+                expandedList,
+                expansionTimestamp);
     }
 
     /**

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/PackageVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/PackageVisitor.java
@@ -71,6 +71,10 @@ public class PackageVisitor extends BaseKnowledgeArtifactVisitor {
     protected final ExpandHelper expandHelper;
     protected final TerminologyServerClientSettings terminologyServerClientSettings;
 
+    // Set per-visit when the packaged artifact's ImplementationGuide declares dependsOn packages; used to
+    // federate NPM package resolution into dependency gathering. Null when no IG/packages can be determined.
+    private IRepository npmFederatedRepository;
+
     protected Map<String, List<?>> resourceTypes = new HashMap<>();
     private IBaseOperationOutcome messages;
     private final IAdapterFactory adapterFactory;
@@ -250,6 +254,10 @@ public class PackageVisitor extends BaseKnowledgeArtifactVisitor {
                 }
             });
         } else {
+            // Federate the NPM packages declared by the artifact's ImplementationGuide so version-pinned
+            // dependencies (e.g. us-core ValueSets at |6.1.0) the repository/tx server lack can be resolved
+            // directly from their NPM packages during gathering.
+            setUpNpmFederation(adapter, artifactEndpointConfigurations);
             // Use array wrapper to allow messages to be updated by recursiveGather
             var messagesWrapper = new IBaseOperationOutcome[] {messages};
             var packagedResources = new HashMap<String, IKnowledgeArtifactAdapter>();
@@ -441,6 +449,54 @@ public class PackageVisitor extends BaseKnowledgeArtifactVisitor {
      * @param packagedBundle the bundle produced by the package operation
      * @return the package-authored CodeSystems eligible to be supplied as tx-resources
      */
+    @Override
+    protected IRepository gatherResolutionRepository() {
+        return npmFederatedRepository != null ? npmFederatedRepository : super.gatherResolutionRepository();
+    }
+
+    /**
+     * Builds an NPM-federated repository ({@code repository} + {@link NpmRepository}) from the NPM packages
+     * declared by the packaged artifact's ImplementationGuide, so version-pinned dependencies the repository
+     * and terminology server lack can be resolved from their packages during {@link #recursiveGather}.
+     *
+     * <p>The IG is the artifact itself if it is an ImplementationGuide, otherwise the one referenced by a
+     * {@code composed-of} related artifact. When no IG (or no dependsOn packages) can be determined, this logs
+     * and leaves federation disabled — the operation continues against the plain repository, unchanged.
+     */
+    private void setUpNpmFederation(
+            IKnowledgeArtifactAdapter adapter, List<ArtifactEndpointConfiguration> artifactEndpointConfigurations) {
+        npmFederatedRepository = null;
+        var ig = resolveImplementationGuide(adapter);
+        if (ig.isEmpty()) {
+            myLogger.info(
+                    "Could not determine an ImplementationGuide (via composed-of) for artifact {}; continuing "
+                            + "$package dependency resolution without NPM package federation.",
+                    adapter.getUrl());
+            return;
+        }
+        var dependsOnPackages = extractDependsOnPackages(ig.get());
+        if (dependsOnPackages.isEmpty()) {
+            myLogger.info(
+                    "ImplementationGuide {} declares no dependsOn packages; continuing without NPM federation.",
+                    ig.get().getUrl());
+            return;
+        }
+        try {
+            var resolver =
+                    new ConformanceResourceResolver(repository, dependsOnPackages, artifactEndpointConfigurations);
+            npmFederatedRepository = resolver.getFederatedRepository();
+            myLogger.info(
+                    "Federating {} NPM package(s) for $package dependency resolution from ImplementationGuide {}.",
+                    dependsOnPackages.size(),
+                    ig.get().getUrl());
+        } catch (Exception e) {
+            myLogger.warn(
+                    "Failed to set up NPM package federation for $package; continuing without it. Reason: {}",
+                    e.getMessage());
+            npmFederatedRepository = null;
+        }
+    }
+
     List<IBaseResource> gatherPackageCodeSystems(IBaseBundle packagedBundle) {
         var codeSystems = new ArrayList<IBaseResource>();
         var terser = new FhirTerser(fhirContext());

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/PackageVisitor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/visitor/PackageVisitor.java
@@ -69,6 +69,7 @@ public class PackageVisitor extends BaseKnowledgeArtifactVisitor {
     private static final Pattern FHIR_ID_PATTERN = Pattern.compile("^[A-Za-z0-9\\-.]+$");
     protected final ITerminologyProviderRouter terminologyServerRouter;
     protected final ExpandHelper expandHelper;
+    protected final TerminologyServerClientSettings terminologyServerClientSettings;
 
     protected Map<String, List<?>> resourceTypes = new HashMap<>();
     private IBaseOperationOutcome messages;
@@ -84,8 +85,11 @@ public class PackageVisitor extends BaseKnowledgeArtifactVisitor {
 
     public PackageVisitor(IRepository repository, TerminologyServerClientSettings terminologyServerClientSettings) {
         super(repository);
+        this.terminologyServerClientSettings = terminologyServerClientSettings != null
+                ? terminologyServerClientSettings
+                : TerminologyServerClientSettings.getDefault();
         this.terminologyServerRouter =
-                new FederatedTerminologyProviderRouter(fhirContext(), terminologyServerClientSettings);
+                new FederatedTerminologyProviderRouter(fhirContext(), this.terminologyServerClientSettings);
         this.expandHelper = new ExpandHelper(this.repository, terminologyServerRouter);
         this.adapterFactory = IAdapterFactory.forFhirContext(repository.fhirContext());
         setupResourceTypes();
@@ -96,8 +100,11 @@ public class PackageVisitor extends BaseKnowledgeArtifactVisitor {
             TerminologyServerClientSettings terminologyServerClientSettings,
             IValueSetExpansionCache cache) {
         super(repository, cache);
+        this.terminologyServerClientSettings = terminologyServerClientSettings != null
+                ? terminologyServerClientSettings
+                : TerminologyServerClientSettings.getDefault();
         this.terminologyServerRouter =
-                new FederatedTerminologyProviderRouter(fhirContext(), terminologyServerClientSettings);
+                new FederatedTerminologyProviderRouter(fhirContext(), this.terminologyServerClientSettings);
         this.expandHelper = new ExpandHelper(this.repository, terminologyServerRouter);
         this.adapterFactory = IAdapterFactory.forFhirContext(repository.fhirContext());
         setupResourceTypes();
@@ -106,6 +113,7 @@ public class PackageVisitor extends BaseKnowledgeArtifactVisitor {
     public PackageVisitor(
             IRepository repository, ITerminologyProviderRouter terminologyServerRouter, IValueSetExpansionCache cache) {
         super(repository, cache);
+        this.terminologyServerClientSettings = TerminologyServerClientSettings.getDefault();
         if (terminologyServerRouter == null) {
             this.terminologyServerRouter = new FederatedTerminologyProviderRouter(fhirContext());
         } else {
@@ -315,6 +323,11 @@ public class PackageVisitor extends BaseKnowledgeArtifactVisitor {
                 .filter(r -> r.fhirType().equals(VALUESET_FHIR_TYPE))
                 .map(v -> (IValueSetAdapter) createAdapterForResource(v))
                 .collect(Collectors.toList());
+        // Gather the package-authored CodeSystems from the bundle. Because these are package-authored by
+        // construction, external big systems (e.g. SNOMED/LOINC) are excluded automatically (they are
+        // referenced by URL, not contained in the package). These are supplied to remote $expand calls via
+        // the tx-resource parameter so version-pinned artifacts the server lacks can be resolved.
+        var packageCodeSystems = gatherPackageCodeSystems(packagedBundle);
         var expansionCache = getExpansionCache();
         var expansionParamsHash = expansionCache.map(
                 e -> e.getExpansionParametersHash(rootSpecificationLibrary).orElse(null));
@@ -352,6 +365,7 @@ public class PackageVisitor extends BaseKnowledgeArtifactVisitor {
                         artifactEndpointConfigurations,
                         terminologyEndpoint,
                         valueSets,
+                        packageCodeSystems,
                         expandedList,
                         new Date());
                 addExpansionWarningsToOperationOutcome(valueSet);
@@ -385,7 +399,21 @@ public class PackageVisitor extends BaseKnowledgeArtifactVisitor {
                         return true;
                     }
                     var value = p.getPrimitiveValue();
-                    if (value == null || Canonicals.getUrl(value) == null) {
+                    if (value == null) {
+                        return true;
+                    }
+                    if (Canonicals.getUrl(value) == null) {
+                        // Canonicals.getUrl does not recognize bare URN systems (e.g. urn:ietf:bcp:47),
+                        // so they slip past the canonical check below. A version-pinning parameter whose
+                        // value is a URN system reference without a `|version` is still rejected by
+                        // terminology servers ("Unable to understand default system version ..."), so drop it.
+                        if (value.startsWith("urn:") && !value.contains("|")) {
+                            myLogger.warn(
+                                    "Excluding unversioned canonical from $package expansion parameters: {}={}",
+                                    p.getName(),
+                                    value);
+                            return false;
+                        }
                         return true;
                     }
                     if (Canonicals.getVersion(value) != null) {
@@ -400,6 +428,58 @@ public class PackageVisitor extends BaseKnowledgeArtifactVisitor {
                 .map(IParametersParameterComponentAdapter::get)
                 .toList();
         params.setParameter(kept);
+    }
+
+    /**
+     * Gathers the package-authored CodeSystems from the packaged bundle so they can be supplied to remote
+     * {@code $expand} calls via the {@code tx-resource} parameter. A safety filter is applied: CodeSystems
+     * whose {@code content} is {@code not-present}, {@code fragment}, or {@code supplement} are skipped (they
+     * carry no usable concepts), as are CodeSystems whose concept count exceeds
+     * {@link TerminologyServerClientSettings#getMaxTxResourceCodeSystemConcepts()}. A warning is logged for
+     * every skipped CodeSystem (no silent drop).
+     *
+     * @param packagedBundle the bundle produced by the package operation
+     * @return the package-authored CodeSystems eligible to be supplied as tx-resources
+     */
+    List<IBaseResource> gatherPackageCodeSystems(IBaseBundle packagedBundle) {
+        var codeSystems = new ArrayList<IBaseResource>();
+        var terser = new FhirTerser(fhirContext());
+        var maxConcepts = terminologyServerClientSettings.getMaxTxResourceCodeSystemConcepts();
+        for (var resource : BundleHelper.getEntryResources(packagedBundle)) {
+            if (!Constants.RESOURCETYPE_CODESYSTEM.equals(resource.fhirType())) {
+                continue;
+            }
+            var url = terser.getSinglePrimitiveValueOrNull(resource, "url");
+            var content = terser.getSinglePrimitiveValueOrNull(resource, "content");
+            if ("not-present".equals(content) || "fragment".equals(content) || "supplement".equals(content)) {
+                myLogger.warn(
+                        "Skipping package CodeSystem {} as a tx-resource because its content is '{}'.", url, content);
+                continue;
+            }
+            var conceptCount = countCodeSystemConcepts(resource, terser);
+            if (conceptCount > maxConcepts) {
+                myLogger.warn(
+                        "Skipping package CodeSystem {} as a tx-resource because its concept count ({}) exceeds the configured maximum ({}).",
+                        url,
+                        conceptCount,
+                        maxConcepts);
+                continue;
+            }
+            codeSystems.add(resource);
+        }
+        return codeSystems;
+    }
+
+    /**
+     * Counts the concepts of a CodeSystem, including nested concepts, in a FHIR-version-agnostic way.
+     */
+    private int countCodeSystemConcepts(IBase element, FhirTerser terser) {
+        var children = terser.getValues(element, "concept");
+        int count = children.size();
+        for (var child : children) {
+            count += countCodeSystemConcepts(child, terser);
+        }
+        return count;
     }
 
     // Helper to surface expansion parameter warnings as OperationOutcome issues

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/ExpandHelperTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/ExpandHelperTest.java
@@ -20,10 +20,14 @@ import ca.uhn.fhir.repository.IRepository;
 import com.google.common.collect.Multimap;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.hl7.fhir.r4.model.CanonicalType;
+import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.Endpoint;
+import org.hl7.fhir.r4.model.MetadataResource;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.UriType;
 import org.hl7.fhir.r4.model.ValueSet;
@@ -35,6 +39,8 @@ import org.opencds.cqf.fhir.utility.adapter.IEndpointAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IParametersAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetAdapter;
 import org.opencds.cqf.fhir.utility.client.ExpandRunner.TerminologyServerExpansionException;
+import org.opencds.cqf.fhir.utility.client.TerminologyServerClientSettings;
+import org.opencds.cqf.fhir.utility.client.TerminologyServerClientSettings.TxResourceMode;
 import org.opencds.cqf.fhir.utility.client.terminology.ArtifactEndpointConfiguration;
 import org.opencds.cqf.fhir.utility.client.terminology.FederatedTerminologyProviderRouter;
 import org.opencds.cqf.fhir.utility.client.terminology.ITerminologyProviderRouter;
@@ -321,7 +327,11 @@ class ExpandHelperTest {
         verify(client, times(1))
                 .expand(any(IValueSetAdapter.class), any(IEndpointAdapter.class), parametersCaptor.capture());
         var filteredExpansionParams = parametersCaptor.getValue();
-        assertEquals(2, filteredExpansionParams.getParameter().size());
+        // Ignore any tx-resource params the feature adds; this test is about unsupported-param removal.
+        var nonTxParams = filteredExpansionParams.getParameter().stream()
+                .filter(p -> !Constants.TX_RESOURCE.equals(p.getName()))
+                .toList();
+        assertEquals(2, nonTxParams.size());
         ExpandHelper.unsupportedParametersToRemove.forEach(parameterUrl -> {
             assertNull(filteredExpansionParams.getParameter(parameterUrl));
         });
@@ -1141,5 +1151,217 @@ class ExpandHelperTest {
         when(mockClient.expand(any(IValueSetAdapter.class), any(IEndpointAdapter.class), any()))
                 .thenReturn(valueSet);
         return mockClient;
+    }
+
+    // ---- tx-resource attachment -------------------------------------------------------------------
+
+    // Builds a target ValueSet that routes to the terminology server (same base as the endpoint, no
+    // authoritative-source extension) and whose compose references both a package-authored ValueSet
+    // (by canonical) and a package-authored CodeSystem (by system).
+    private ValueSet targetReferencing(String baseUrl, String depVsCanonical, String csSystem) {
+        var target = new ValueSet();
+        target.setUrl(baseUrl + "/ValueSet/target");
+        var include = target.getCompose().addInclude();
+        include.setSystem(csSystem);
+        include.addValueSet(depVsCanonical);
+        return target;
+    }
+
+    @Test
+    void terminologyServerExpand_attachesTxResourcePerPackageDependency() {
+        var baseUrl = "www.test.com/fhir";
+        var endpoint = new Endpoint();
+        endpoint.setAddress(baseUrl);
+
+        var depVsUrl = baseUrl + "/ValueSet/dep";
+        var depVsVersion = "1.0.0";
+        var csSystem = "http://example.org/CodeSystem/local";
+
+        var target = targetReferencing(baseUrl, depVsUrl + "|" + depVsVersion, csSystem);
+
+        // package closure
+        var depVs = createLeafWithUrl(depVsUrl);
+        depVs.setVersion(depVsVersion);
+        var cs = new CodeSystem();
+        cs.setUrl(csSystem).setVersion("6.1.0");
+
+        var expanded = createLeafWithUrl(target.getUrl());
+
+        var client = mock(FederatedTerminologyProviderRouter.class);
+        // AUTO by default
+        when(client.getTerminologyServerClientSettings(any(IEndpointAdapter.class)))
+                .thenReturn(TerminologyServerClientSettings.getDefault());
+        when(client.expand(any(IValueSetAdapter.class), any(IEndpointAdapter.class), any()))
+                .thenReturn(expanded);
+
+        var rep = mockRepositoryWithValueSetR4(new ValueSet());
+        var helper = new ExpandHelper(rep, client);
+
+        var captor = ArgumentCaptor.forClass(IParametersAdapter.class);
+        helper.expandValueSet(
+                (IValueSetAdapter) factory.createKnowledgeArtifactAdapter(target),
+                factory.createParameters(new Parameters()),
+                Optional.of(factory.createEndpoint(endpoint)),
+                List.of((IValueSetAdapter) factory.createValueSet(depVs)),
+                List.of((IBaseResource) cs),
+                new ArrayList<>(),
+                new Date());
+
+        verify(client, times(1)).expand(any(IValueSetAdapter.class), any(IEndpointAdapter.class), captor.capture());
+        var sent = (Parameters) captor.getValue().get();
+        var txResources = sent.getParameter().stream()
+                .filter(p -> Constants.TX_RESOURCE.equals(p.getName()))
+                .map(Parameters.ParametersParameterComponent::getResource)
+                .toList();
+        assertEquals(3, txResources.size(), "expected the target ValueSet plus one tx-resource per package dependency");
+        var attachedUrls =
+                txResources.stream().map(r -> ((MetadataResource) r).getUrl()).toList();
+        assertTrue(attachedUrls.contains(target.getUrl()), "the target ValueSet itself should be attached");
+        assertTrue(attachedUrls.contains(depVsUrl), "the referenced package ValueSet should be attached");
+        assertTrue(attachedUrls.contains(csSystem), "the referenced package CodeSystem should be attached");
+    }
+
+    @Test
+    void terminologyServerExpand_attachesTargetValueSetEvenWithoutPackageDependencies() {
+        // Reproduces the core of aphl-vsm#709: the terminology server lacks the requested ValueSet
+        // version. Even with no package dependencies to supply, the target ValueSet itself must be
+        // attached as a tx-resource so the server can expand the version it does not hold.
+        var baseUrl = "www.test.com/fhir";
+        var endpoint = new Endpoint();
+        endpoint.setAddress(baseUrl);
+
+        var target = new ValueSet();
+        target.setUrl(baseUrl + "/ValueSet/target").setVersion("6.1.0");
+        target.getCompose().getIncludeFirstRep().setSystem("http://example.org/external");
+
+        var expanded = createLeafWithUrl(target.getUrl());
+        var client = mock(FederatedTerminologyProviderRouter.class);
+        when(client.getTerminologyServerClientSettings(any(IEndpointAdapter.class)))
+                .thenReturn(TerminologyServerClientSettings.getDefault());
+        when(client.expand(any(IValueSetAdapter.class), any(IEndpointAdapter.class), any()))
+                .thenReturn(expanded);
+        var rep = mockRepositoryWithValueSetR4(new ValueSet());
+        var helper = new ExpandHelper(rep, client);
+
+        var captor = ArgumentCaptor.forClass(IParametersAdapter.class);
+        helper.expandValueSet(
+                (IValueSetAdapter) factory.createKnowledgeArtifactAdapter(target),
+                factory.createParameters(new Parameters()),
+                Optional.of(factory.createEndpoint(endpoint)),
+                new ArrayList<IValueSetAdapter>(),
+                List.of(),
+                new ArrayList<String>(),
+                new Date());
+
+        verify(client, times(1)).expand(any(IValueSetAdapter.class), any(IEndpointAdapter.class), captor.capture());
+        var sent = (Parameters) captor.getValue().get();
+        var txResources = sent.getParameter().stream()
+                .filter(p -> Constants.TX_RESOURCE.equals(p.getName()))
+                .map(Parameters.ParametersParameterComponent::getResource)
+                .toList();
+        assertEquals(1, txResources.size(), "the target ValueSet should be supplied even without package dependencies");
+        assertEquals(target.getUrl(), ((MetadataResource) txResources.get(0)).getUrl());
+    }
+
+    @Test
+    void terminologyServerExpand_doesNotAccumulateTxResourcesAcrossExpansions() {
+        // $package reuses one parameters object across every ValueSet it expands. tx-resource params must
+        // be scoped to a single $expand; they must not pile up on the shared object across expansions.
+        var baseUrl = "www.test.com/fhir";
+        var endpoint = new Endpoint();
+        endpoint.setAddress(baseUrl);
+
+        var vsA = new ValueSet();
+        vsA.setUrl(baseUrl + "/ValueSet/a").setVersion("1.0.0");
+        vsA.getCompose().getIncludeFirstRep().setSystem("http://example.org/external");
+        var vsB = new ValueSet();
+        vsB.setUrl(baseUrl + "/ValueSet/b").setVersion("1.0.0");
+        vsB.getCompose().getIncludeFirstRep().setSystem("http://example.org/external");
+
+        var client = mock(FederatedTerminologyProviderRouter.class);
+        when(client.getTerminologyServerClientSettings(any(IEndpointAdapter.class)))
+                .thenReturn(TerminologyServerClientSettings.getDefault());
+        when(client.expand(any(IValueSetAdapter.class), any(IEndpointAdapter.class), any()))
+                .thenAnswer(inv -> createLeafWithUrl(((IValueSetAdapter) inv.getArgument(0)).getUrl()));
+        var rep = mockRepositoryWithValueSetR4(new ValueSet());
+        var helper = new ExpandHelper(rep, client);
+
+        // One shared parameters object, reused for both expansions (as PackageVisitor does).
+        var sharedParams = factory.createParameters(new Parameters());
+        var expandedList = new ArrayList<String>();
+        helper.expandValueSet(
+                (IValueSetAdapter) factory.createKnowledgeArtifactAdapter(vsA),
+                sharedParams,
+                Optional.of(factory.createEndpoint(endpoint)),
+                new ArrayList<IValueSetAdapter>(),
+                List.of(),
+                expandedList,
+                new Date());
+
+        var captor = ArgumentCaptor.forClass(IParametersAdapter.class);
+        helper.expandValueSet(
+                (IValueSetAdapter) factory.createKnowledgeArtifactAdapter(vsB),
+                sharedParams,
+                Optional.of(factory.createEndpoint(endpoint)),
+                new ArrayList<IValueSetAdapter>(),
+                List.of(),
+                expandedList,
+                new Date());
+
+        verify(client, times(2)).expand(any(IValueSetAdapter.class), any(IEndpointAdapter.class), captor.capture());
+        var sentForB = (Parameters) captor.getValue().get();
+        var txUrls = sentForB.getParameter().stream()
+                .filter(p -> Constants.TX_RESOURCE.equals(p.getName()))
+                .map(p -> ((MetadataResource) p.getResource()).getUrl())
+                .toList();
+        // The second expansion must carry only its own target — never the first ValueSet's tx-resources.
+        assertEquals(List.of(vsB.getUrl()), txUrls, "tx-resources must not accumulate across expansions");
+        // The shared parameters object must never be mutated with tx-resource params.
+        assertNull(sharedParams.getParameter(Constants.TX_RESOURCE));
+    }
+
+    @Test
+    void terminologyServerExpand_disabledMode_attachesNoTxResource() {
+        var baseUrl = "www.test.com/fhir";
+        var endpoint = new Endpoint();
+        endpoint.setAddress(baseUrl);
+
+        var depVsUrl = baseUrl + "/ValueSet/dep";
+        var depVsVersion = "1.0.0";
+        var csSystem = "http://example.org/CodeSystem/local";
+
+        var target = targetReferencing(baseUrl, depVsUrl + "|" + depVsVersion, csSystem);
+
+        var depVs = createLeafWithUrl(depVsUrl);
+        depVs.setVersion(depVsVersion);
+        var cs = new CodeSystem();
+        cs.setUrl(csSystem).setVersion("6.1.0");
+
+        var expanded = createLeafWithUrl(target.getUrl());
+
+        var client = mock(FederatedTerminologyProviderRouter.class);
+        when(client.getTerminologyServerClientSettings(any(IEndpointAdapter.class)))
+                .thenReturn(TerminologyServerClientSettings.getDefault().setTxResourceMode(TxResourceMode.DISABLED));
+        when(client.expand(any(IValueSetAdapter.class), any(IEndpointAdapter.class), any()))
+                .thenReturn(expanded);
+
+        var rep = mockRepositoryWithValueSetR4(new ValueSet());
+        var helper = new ExpandHelper(rep, client);
+
+        var captor = ArgumentCaptor.forClass(IParametersAdapter.class);
+        helper.expandValueSet(
+                (IValueSetAdapter) factory.createKnowledgeArtifactAdapter(target),
+                factory.createParameters(new Parameters()),
+                Optional.of(factory.createEndpoint(endpoint)),
+                List.of((IValueSetAdapter) factory.createValueSet(depVs)),
+                List.of((IBaseResource) cs),
+                new ArrayList<>(),
+                new Date());
+
+        verify(client, times(1)).expand(any(IValueSetAdapter.class), any(IEndpointAdapter.class), captor.capture());
+        var sent = (Parameters) captor.getValue().get();
+        assertFalse(
+                sent.getParameter().stream().anyMatch(p -> Constants.TX_RESOURCE.equals(p.getName())),
+                "DISABLED mode must not attach any tx-resource parameters");
     }
 }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/PackageVisitorNpmFederationTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/PackageVisitorNpmFederationTest.java
@@ -1,0 +1,83 @@
+package org.opencds.cqf.fhir.cr.visitor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import org.hl7.fhir.r4.model.ImplementationGuide;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.MetadataResource;
+import org.hl7.fhir.r4.model.RelatedArtifact;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
+import org.opencds.cqf.fhir.utility.adapter.IKnowledgeArtifactAdapter;
+import org.opencds.cqf.fhir.utility.repository.InMemoryFhirRepository;
+
+/**
+ * Tests the $package NPM-federation setup: locating the governing ImplementationGuide (the artifact itself,
+ * or the one referenced by a {@code composed-of} related artifact) and extracting its dependsOn packages.
+ */
+class PackageVisitorNpmFederationTest {
+
+    private final FhirContext fhirContext = FhirContext.forR4Cached();
+    private final IAdapterFactory factory = IAdapterFactory.forFhirContext(FhirContext.forR4Cached());
+
+    private IKnowledgeArtifactAdapter adapt(MetadataResource r) {
+        return (IKnowledgeArtifactAdapter) factory.createKnowledgeArtifactAdapter(r);
+    }
+
+    private ImplementationGuide usCoreIg() {
+        var ig = new ImplementationGuide();
+        ig.setUrl("http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core");
+        ig.setVersion("6.1.0");
+        ig.setPackageId("hl7.fhir.us.core");
+        ig.addDependsOn().setPackageId("hl7.fhir.uv.sdc").setVersion("3.0.0");
+        return ig;
+    }
+
+    @Test
+    void resolveImplementationGuide_findsIgViaComposedOf() {
+        var repo = new InMemoryFhirRepository(fhirContext);
+        var ig = usCoreIg();
+        repo.update(ig);
+        var visitor = new PackageVisitor(repo);
+
+        var library = new Library();
+        library.setUrl("http://example.org/Library/vs-package");
+        library.addRelatedArtifact()
+                .setType(RelatedArtifact.RelatedArtifactType.COMPOSEDOF)
+                .setResource(ig.getUrl());
+
+        var resolved = visitor.resolveImplementationGuide(adapt(library));
+        assertTrue(resolved.isPresent(), "IG should be resolved via the composed-of reference");
+        assertEquals(ig.getUrl(), resolved.get().getUrl());
+    }
+
+    @Test
+    void resolveImplementationGuide_returnsSelfWhenArtifactIsIg() {
+        var visitor = new PackageVisitor(new InMemoryFhirRepository(fhirContext));
+        var ig = usCoreIg();
+        var resolved = visitor.resolveImplementationGuide(adapt(ig));
+        assertTrue(resolved.isPresent());
+        assertEquals(ig.getUrl(), resolved.get().getUrl());
+    }
+
+    @Test
+    void resolveImplementationGuide_emptyWhenNoComposedOfIg() {
+        var visitor = new PackageVisitor(new InMemoryFhirRepository(fhirContext));
+        var library = new Library();
+        library.setUrl("http://example.org/Library/no-ig");
+        assertTrue(
+                visitor.resolveImplementationGuide(adapt(library)).isEmpty(),
+                "no IG should be determined when there is no composed-of ImplementationGuide reference");
+    }
+
+    @Test
+    void extractDependsOnPackages_returnsIgOwnPackageAndDependsOn() {
+        var visitor = new PackageVisitor(new InMemoryFhirRepository(fhirContext));
+        var packages = visitor.extractDependsOnPackages(adapt(usCoreIg()));
+        assertEquals(2, packages.size(), "the IG's own package plus its one dependsOn entry");
+        assertTrue(packages.stream().anyMatch(p -> "hl7.fhir.us.core".equals(p[0]) && "6.1.0".equals(p[1])));
+        assertTrue(packages.stream().anyMatch(p -> "hl7.fhir.uv.sdc".equals(p[0]) && "3.0.0".equals(p[1])));
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/PackageVisitorTxResourceTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/PackageVisitorTxResourceTest.java
@@ -1,0 +1,93 @@
+package org.opencds.cqf.fhir.cr.visitor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CodeSystem;
+import org.hl7.fhir.r4.model.CodeSystem.CodeSystemContentMode;
+import org.hl7.fhir.r4.model.MetadataResource;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.utility.client.TerminologyServerClientSettings;
+import org.opencds.cqf.fhir.utility.repository.InMemoryFhirRepository;
+
+/**
+ * Unit tests for {@link PackageVisitor#gatherPackageCodeSystems} - the safety filter that decides which
+ * package-authored CodeSystems are eligible to be supplied to a remote {@code $expand} via {@code tx-resource}.
+ */
+class PackageVisitorTxResourceTest {
+
+    private final FhirContext fhirContext = FhirContext.forR4Cached();
+
+    private static CodeSystem codeSystem(String url, CodeSystemContentMode content, int concepts) {
+        var cs = new CodeSystem();
+        cs.setUrl(url);
+        cs.setContent(content);
+        for (int i = 0; i < concepts; i++) {
+            cs.addConcept().setCode("code-" + i);
+        }
+        return cs;
+    }
+
+    private Bundle bundleOf(IBaseResource... resources) {
+        var bundle = new Bundle();
+        for (var r : resources) {
+            bundle.addEntry().setResource((org.hl7.fhir.r4.model.Resource) r);
+        }
+        return bundle;
+    }
+
+    private List<String> urls(List<IBaseResource> resources) {
+        return resources.stream().map(r -> ((MetadataResource) r).getUrl()).collect(Collectors.toList());
+    }
+
+    @Test
+    void gatherPackageCodeSystems_includesUsableCodeSystems_andFiltersUnusableOnes() {
+        var repo = new InMemoryFhirRepository(fhirContext);
+        // Concept ceiling of 2: the "big" CodeSystem (3 concepts) must be excluded.
+        var settings = TerminologyServerClientSettings.getDefault().setMaxTxResourceCodeSystemConcepts(2);
+        var visitor = new PackageVisitor(repo, settings, null);
+
+        var usable = codeSystem("http://example.org/CodeSystem/usable", CodeSystemContentMode.COMPLETE, 2);
+        var notPresent = codeSystem("http://example.org/CodeSystem/not-present", CodeSystemContentMode.NOTPRESENT, 5);
+        var supplement = codeSystem("http://example.org/CodeSystem/supplement", CodeSystemContentMode.SUPPLEMENT, 1);
+        var tooBig = codeSystem("http://example.org/CodeSystem/big", CodeSystemContentMode.COMPLETE, 3);
+        // a non-CodeSystem resource should be ignored entirely
+        var valueSet = new org.hl7.fhir.r4.model.ValueSet();
+        valueSet.setUrl("http://example.org/ValueSet/vs");
+
+        var bundle = bundleOf(usable, notPresent, supplement, tooBig, valueSet);
+
+        var gathered = visitor.gatherPackageCodeSystems(bundle);
+        var gatheredUrls = urls(gathered);
+
+        assertEquals(1, gathered.size(), "only the usable CodeSystem should be gathered");
+        assertTrue(gatheredUrls.contains("http://example.org/CodeSystem/usable"));
+        assertFalse(gatheredUrls.contains("http://example.org/CodeSystem/not-present"), "content=not-present excluded");
+        assertFalse(gatheredUrls.contains("http://example.org/CodeSystem/supplement"), "content=supplement excluded");
+        assertFalse(gatheredUrls.contains("http://example.org/CodeSystem/big"), "over-ceiling CodeSystem excluded");
+    }
+
+    @Test
+    void gatherPackageCodeSystems_countsNestedConceptsTowardCeiling() {
+        var repo = new InMemoryFhirRepository(fhirContext);
+        var settings = TerminologyServerClientSettings.getDefault().setMaxTxResourceCodeSystemConcepts(2);
+        var visitor = new PackageVisitor(repo, settings, null);
+
+        // 1 top-level concept + 2 nested = 3 total, exceeding the ceiling of 2.
+        var nested = new CodeSystem();
+        nested.setUrl("http://example.org/CodeSystem/nested");
+        nested.setContent(CodeSystemContentMode.COMPLETE);
+        var parent = nested.addConcept().setCode("parent");
+        parent.addConcept().setCode("child-1");
+        parent.addConcept().setCode("child-2");
+
+        var gathered = visitor.gatherPackageCodeSystems(bundleOf(nested));
+        assertTrue(gathered.isEmpty(), "nested concepts must be counted toward the ceiling");
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/PackageVisitorTests.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/visitor/r4/PackageVisitorTests.java
@@ -1489,6 +1489,8 @@ class PackageVisitorTests {
         params.addParameter("canonicalVersion", "http://example.org/ValueSet/bar|1.0.0"); // versioned — keep
         params.addParameter("system-version", "urn:oid:1.2.3.4"); // unversioned urn canonical — drop
         params.addParameter("system-version", "urn:oid:1.2.3.4|2024"); // versioned urn canonical — keep
+        params.addParameter("system-version", "urn:ietf:bcp:47"); // unversioned bare-urn system — drop
+        params.addParameter("system-version", "urn:ietf:bcp:47|2.0"); // versioned bare-urn system — keep
         params.addParameter("displayLanguage", "en-US"); // non-canonical — keep
         params.addParameter("activeOnly", true); // boolean — keep
 
@@ -1504,16 +1506,18 @@ class PackageVisitorTests {
                 .map(p -> p.getName() + "=" + (p.hasValue() ? p.getPrimitiveValue() : "<no-value>"))
                 .toList();
 
-        assertEquals(5, remainingValues.size(), "should drop all three unversioned canonical entries");
+        assertEquals(6, remainingValues.size(), "should drop all four unversioned canonical entries");
         assertTrue(remainingValues.contains("system-version=http://loinc.org|2.81"));
         assertTrue(remainingValues.contains("canonicalVersion=http://example.org/ValueSet/bar|1.0.0"));
         assertTrue(remainingValues.contains("system-version=urn:oid:1.2.3.4|2024"));
+        assertTrue(remainingValues.contains("system-version=urn:ietf:bcp:47|2.0"));
         assertTrue(remainingValues.contains("displayLanguage=en-US"));
         assertTrue(remainingValues.contains("activeOnly=true"));
         assertFalse(remainingValues.stream().anyMatch(v -> v.equals("system-version=http://snomed.info/sct")));
         assertFalse(
                 remainingValues.stream().anyMatch(v -> v.equals("canonicalVersion=http://example.org/ValueSet/foo")));
         assertFalse(remainingValues.stream().anyMatch(v -> v.equals("system-version=urn:oid:1.2.3.4")));
+        assertFalse(remainingValues.stream().anyMatch(v -> v.equals("system-version=urn:ietf:bcp:47")));
     }
 
     @Test

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/Constants.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/Constants.java
@@ -252,6 +252,13 @@ public class Constants {
     public static final String RESOURCETYPE_VALUESET = "ValueSet";
     public static final String RESOURCETYPE_CODESYSTEM = "CodeSystem";
 
+    /**
+     * The {@code tx-resource} parameter of the {@code $expand} operation (R6 OperationDefinition).
+     * Additional value sets or code systems referred to from the value set being expanded, used
+     * preferentially to those known to the terminology server.
+     */
+    public static final String TX_RESOURCE = "tx-resource";
+
     public static final String EMPTY = "empty";
 
     public static final String PREVIOUS_VALUE = "previousValue";

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/client/ExpandRunner.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/client/ExpandRunner.java
@@ -90,13 +90,21 @@ public class ExpandRunner implements Runnable {
                 String terminologyServerBase = fhirClient.getServerBase();
                 String fullExpandUrl = terminologyServerBase + "/" + id + "/$expand";
 
-                // Format parameters for logging
-                String parametersLog = formatParametersForLogging(parameters);
+                // Compute the request parameters for THIS attempt. Depending on the configured
+                // TxResourceMode, tx-resource parameters may be stripped for this attempt (see
+                // parametersForAttempt).
+                var requestParameters = parametersForAttempt(expansionAttempt);
 
+                // Format parameters for logging
+                String parametersLog = formatParametersForLogging(requestParameters);
+
+                var txResourceCount = countTxResourceParameters(requestParameters);
                 logger.info(
-                        "Expansion attempt {} for ValueSet: {} | Terminology Server: {} | Full URL: {} | Parameters: {}",
+                        "Expansion attempt {} for ValueSet: {} | tx-resource params sent: {} (mode={}) | Terminology Server: {} | Full URL: {} | Parameters: {}",
                         expansionAttempt,
                         valueSetUrl,
+                        txResourceCount,
+                        terminologyServerClientSettings.getTxResourceMode(),
                         terminologyServerBase,
                         fullExpandUrl,
                         parametersLog);
@@ -105,7 +113,7 @@ public class ExpandRunner implements Runnable {
                         .operation()
                         .onInstance(id)
                         .named("$expand")
-                        .withParameters(parameters)
+                        .withParameters(requestParameters)
                         .returnResourceType(getValueSetClass())
                         .execute();
 
@@ -114,7 +122,7 @@ public class ExpandRunner implements Runnable {
                 if (expandedValueSetAdapter.getExpansionTotal()
                         > expandedValueSetAdapter.getExpansionContains().size()) {
                     var paramsWithOffset = (IParametersAdapter) createAdapterForResource(
-                            createAdapterForResource(parameters).copy());
+                            createAdapterForResource(requestParameters).copy());
                     var offset = terminologyServerClientSettings.getExpansionsPerPage();
 
                     for (int expansionPage = 2;
@@ -195,6 +203,56 @@ public class ExpandRunner implements Runnable {
         }
     }
 
+    /**
+     * Computes the {@code $expand} request parameters to send for the given attempt, honoring the
+     * configured {@link TerminologyServerClientSettings.TxResourceMode}. The {@code tx-resource}
+     * entries always ride inside {@link #parameters}; this method decides, per attempt, whether to
+     * send them:
+     * <ul>
+     *   <li>{@code DISABLED} — nothing was attached upstream; send {@link #parameters} as-is.</li>
+     *   <li>{@code ENABLED} — always keep {@code tx-resource}; send {@link #parameters} as-is.</li>
+     *   <li>{@code AUTO} — attempt 1 is sent WITHOUT {@code tx-resource} (a filtered copy);
+     *       attempts 2..N keep {@code tx-resource}.</li>
+     * </ul>
+     *
+     * @param attempt the 1-based attempt number
+     * @return the parameters to send for this attempt (either {@link #parameters} or a filtered copy)
+     */
+    IBaseParameters parametersForAttempt(int attempt) {
+        if (parameters == null) {
+            return null;
+        }
+        var mode = terminologyServerClientSettings.getTxResourceMode();
+        if (mode == TerminologyServerClientSettings.TxResourceMode.AUTO && attempt <= 1) {
+            return withoutTxResourceParameters(parameters);
+        }
+        return parameters;
+    }
+
+    /**
+     * Returns a copy of the supplied parameters with all {@code tx-resource} parameters removed. Uses
+     * the same adapter copy pattern used for paging so the original parameters are left untouched.
+     */
+    private static IBaseParameters withoutTxResourceParameters(IBaseParameters parameters) {
+        var copy = (IParametersAdapter)
+                createAdapterForResource(createAdapterForResource(parameters).copy());
+        copy.setParameter(copy.getParameter().stream()
+                .filter(p -> !org.opencds.cqf.fhir.utility.Constants.TX_RESOURCE.equals(p.getName()))
+                .map(IParametersParameterComponentAdapter::get)
+                .toList());
+        return (IBaseParameters) copy.get();
+    }
+
+    private static long countTxResourceParameters(IBaseParameters parameters) {
+        if (parameters == null) {
+            return 0;
+        }
+        return ((IParametersAdapter) createAdapterForResource(parameters))
+                .getParameter().stream()
+                        .filter(p -> org.opencds.cqf.fhir.utility.Constants.TX_RESOURCE.equals(p.getName()))
+                        .count();
+    }
+
     private static boolean isTransient(Exception ex) {
         var isTransient = false;
         if (ex instanceof BaseServerResponseException bsre) {
@@ -260,6 +318,14 @@ public class ExpandRunner implements Runnable {
                     return String.valueOf(primitive.getValue());
                 }
                 return value.toString();
+            }
+            // Resource-valued parameters (e.g. tx-resource) — log a compact reference, not the full body.
+            if (param.hasResource()) {
+                var resource = param.getResource();
+                var ref = resource.getIdElement() != null
+                        ? resource.getIdElement().getValue()
+                        : null;
+                return resource.fhirType() + (ref != null ? "/" + ref : "");
             }
             // If no value, might be a part parameter
             if (param.hasPart()) {

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/client/ExpandRunner.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/client/ExpandRunner.java
@@ -167,7 +167,18 @@ public class ExpandRunner implements Runnable {
                     parametersLog,
                     ex.getMessage());
 
-            if (expansionAttempt < terminologyServerClientSettings.getMaxRetryCount()) {
+            // Decide whether another attempt is worthwhile. Retrying only helps if either the fault was
+            // transient (a later identical call may succeed) or the NEXT attempt would send a materially
+            // different request. The latter happens only in AUTO mode after attempt 1, where attempt 2
+            // escalates by attaching tx-resource parameters (the escalation that a "definition could not be
+            // found" 422 is meant to resolve). Retrying a non-transient failure with an identical request
+            // (e.g. HTTP 422 for a CodeSystem the server will never know about) only adds latency and log
+            // noise, so stop early in that case.
+            var nextAttemptEscalates = terminologyServerClientSettings.getTxResourceMode()
+                            == TerminologyServerClientSettings.TxResourceMode.AUTO
+                    && expansionAttempt == 1;
+            if ((isTransient || nextAttemptEscalates)
+                    && expansionAttempt < terminologyServerClientSettings.getMaxRetryCount()) {
                 scheduler.schedule(
                         this,
                         terminologyServerClientSettings.getRetryIntervalMillis() * expansionAttempt,

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/client/TerminologyServerClientSettings.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/client/TerminologyServerClientSettings.java
@@ -18,7 +18,24 @@ public class TerminologyServerClientSettings {
         DISABLED
     }
 
+    /**
+     * Maximum number of attempts for terminology-server calls before a failure is surfaced. This governs
+     * BOTH ValueSet {@code $expand} calls and the resource-resolution reads ({@code getValueSetResource},
+     * {@code getCodeSystemResource}, {@code getLatestValueSetResource}) used during {@code $package} /
+     * {@code $data-requirements} dependency gathering. Only transient failures (connection/read timeouts and
+     * retryable HTTP statuses) are retried; each retry is delayed by {@link #retryIntervalMillis} times the
+     * attempt number (linear back-off).
+     *
+     * <p><strong>Performance note:</strong> a value greater than 1 improves resilience against a flaky
+     * terminology server (a single hiccup no longer aborts the whole operation), but it also makes every
+     * <em>transient</em> failure take up to {@code maxRetryCount}× longer — dominated by the per-attempt
+     * connect timeout — which can noticeably slow operations that make many terminology-server calls (e.g.
+     * {@code $data-requirements} against many un-cached ValueSets). In performance-sensitive production
+     * environments that prefer fail-fast over resilience, set this to {@code 1} to disable retries entirely
+     * (a single attempt per call).
+     */
     private int maxRetryCount = 3;
+
     private long retryIntervalMillis = 1000;
     private int timeoutSeconds = 30;
     private int socketTimeout = 60;

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/client/TerminologyServerClientSettings.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/client/TerminologyServerClientSettings.java
@@ -2,6 +2,22 @@ package org.opencds.cqf.fhir.utility.client;
 
 public class TerminologyServerClientSettings {
 
+    /**
+     * Controls when the package's own resources are supplied to a remote {@code $expand} call via the
+     * {@code tx-resource} parameter.
+     * <ul>
+     *   <li>{@code AUTO} — the first attempt is made WITHOUT {@code tx-resource}; retries (attempts 2..N)
+     *       are made WITH {@code tx-resource}.</li>
+     *   <li>{@code ENABLED} — every attempt (from the first) is made WITH {@code tx-resource}.</li>
+     *   <li>{@code DISABLED} — {@code tx-resource} is never attached (legacy behavior).</li>
+     * </ul>
+     */
+    public enum TxResourceMode {
+        AUTO,
+        ENABLED,
+        DISABLED
+    }
+
     private int maxRetryCount = 3;
     private long retryIntervalMillis = 1000;
     private int timeoutSeconds = 30;
@@ -9,6 +25,8 @@ public class TerminologyServerClientSettings {
     private String crmiVersion = "1.0.0";
     private int expansionsPerPage = 1000;
     private int maxExpansionPages = 1000;
+    private TxResourceMode txResourceMode = TxResourceMode.AUTO;
+    private int maxTxResourceCodeSystemConcepts = 1000;
 
     public static TerminologyServerClientSettings getDefault() {
         return new TerminologyServerClientSettings();
@@ -30,6 +48,8 @@ public class TerminologyServerClientSettings {
         this.crmiVersion = terminologyServerClientSettings.crmiVersion;
         this.expansionsPerPage = terminologyServerClientSettings.expansionsPerPage;
         this.maxExpansionPages = terminologyServerClientSettings.maxExpansionPages;
+        this.txResourceMode = terminologyServerClientSettings.txResourceMode;
+        this.maxTxResourceCodeSystemConcepts = terminologyServerClientSettings.maxTxResourceCodeSystemConcepts;
     }
 
     public int getMaxRetryCount() {
@@ -92,6 +112,32 @@ public class TerminologyServerClientSettings {
 
     public TerminologyServerClientSettings setMaxExpansionPages(int maxExpansionPages) {
         this.maxExpansionPages = maxExpansionPages;
+        return this;
+    }
+
+    public TxResourceMode getTxResourceMode() {
+        return txResourceMode;
+    }
+
+    public TerminologyServerClientSettings withTxResourceMode(TxResourceMode txResourceMode) {
+        return setTxResourceMode(txResourceMode);
+    }
+
+    public TerminologyServerClientSettings setTxResourceMode(TxResourceMode txResourceMode) {
+        this.txResourceMode = txResourceMode;
+        return this;
+    }
+
+    public int getMaxTxResourceCodeSystemConcepts() {
+        return maxTxResourceCodeSystemConcepts;
+    }
+
+    public TerminologyServerClientSettings withMaxTxResourceCodeSystemConcepts(int maxTxResourceCodeSystemConcepts) {
+        return setMaxTxResourceCodeSystemConcepts(maxTxResourceCodeSystemConcepts);
+    }
+
+    public TerminologyServerClientSettings setMaxTxResourceCodeSystemConcepts(int maxTxResourceCodeSystemConcepts) {
+        this.maxTxResourceCodeSystemConcepts = maxTxResourceCodeSystemConcepts;
         return this;
     }
 }

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/client/terminology/FederatedTerminologyProviderRouter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/client/terminology/FederatedTerminologyProviderRouter.java
@@ -3,11 +3,16 @@ package org.opencds.cqf.fhir.utility.client.terminology;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.exceptions.FhirClientConnectionException;
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IDomainResource;
@@ -24,6 +29,9 @@ import org.opencds.cqf.fhir.utility.search.Searches;
  * https://hl7.org/fhir/uv/crmi/StructureDefinition-crmi-artifact-endpoint-configurable-operation.html
  */
 public class FederatedTerminologyProviderRouter extends BaseTerminologyProvider implements ITerminologyProviderRouter {
+
+    private static final org.slf4j.Logger logger =
+            org.slf4j.LoggerFactory.getLogger(FederatedTerminologyProviderRouter.class);
 
     private final List<ITerminologyServerClient> clients;
     private final ITerminologyServerClient defaultClient;
@@ -133,11 +141,14 @@ public class FederatedTerminologyProviderRouter extends BaseTerminologyProvider 
     @Override
     public Optional<IDomainResource> getCodeSystemResource(IEndpointAdapter endpoint, String url) {
         var client = this.getClient(endpoint.getAddress());
-        return IKnowledgeArtifactAdapter.findLatestVersion(client.initializeClientWithAuth(endpoint)
-                .search()
-                .forResource(client.getCodeSystemClass())
-                .where(Searches.toFlattenedMap(Searches.byCanonical(url)))
-                .execute());
+        return executeWithRetry(
+                client,
+                url,
+                () -> IKnowledgeArtifactAdapter.findLatestVersion(client.initializeClientWithAuth(endpoint)
+                        .search()
+                        .forResource(client.getCodeSystemClass())
+                        .where(Searches.toFlattenedMap(Searches.byCanonical(url)))
+                        .execute()));
     }
 
     @Override
@@ -151,11 +162,14 @@ public class FederatedTerminologyProviderRouter extends BaseTerminologyProvider 
     @Override
     public Optional<IDomainResource> getLatestValueSetResource(IEndpointAdapter endpoint, String url) {
         var client = this.getClient(endpoint.getAddress());
-        return IKnowledgeArtifactAdapter.findLatestVersion(client.initializeClientWithAuth(endpoint)
-                .search()
-                .forResource(client.getValueSetClass())
-                .where(Searches.toFlattenedMap(Searches.byCanonical(url)))
-                .execute());
+        return executeWithRetry(
+                client,
+                url,
+                () -> IKnowledgeArtifactAdapter.findLatestVersion(client.initializeClientWithAuth(endpoint)
+                        .search()
+                        .forResource(client.getValueSetClass())
+                        .where(Searches.toFlattenedMap(Searches.byCanonical(url)))
+                        .execute()));
     }
 
     @Override
@@ -178,11 +192,74 @@ public class FederatedTerminologyProviderRouter extends BaseTerminologyProvider 
     @Override
     public Optional<IDomainResource> getValueSetResource(IEndpointAdapter endpoint, String url) {
         var client = this.getClient(url);
-        return IKnowledgeArtifactAdapter.findLatestVersion(client.initializeClientWithAuth(endpoint)
-                .search()
-                .forResource(client.getValueSetClass())
-                .where(Searches.toFlattenedMap(Searches.byCanonical(url)))
-                .execute());
+        return executeWithRetry(
+                client,
+                url,
+                () -> IKnowledgeArtifactAdapter.findLatestVersion(client.initializeClientWithAuth(endpoint)
+                        .search()
+                        .forResource(client.getValueSetClass())
+                        .where(Searches.toFlattenedMap(Searches.byCanonical(url)))
+                        .execute()));
+    }
+
+    /**
+     * Executes a terminology-server read, retrying transient failures (connection/read timeouts and
+     * retryable HTTP statuses) up to {@code maxRetryCount} times with a linear back-off, mirroring the
+     * resilience of the expansion path ({@code ExpandRunner}). A single transient tx-server hiccup during
+     * dependency resolution should not abort an entire {@code $package} run. Non-transient errors and the
+     * final failure after exhausting retries propagate unchanged.
+     */
+    <T> T executeWithRetry(ITerminologyServerClient client, String url, Supplier<T> operation) {
+        var settings = client.getTerminologyServerClientSettings();
+        int maxAttempts = settings != null ? Math.max(1, settings.getMaxRetryCount()) : 1;
+        long retryIntervalMillis = settings != null ? settings.getRetryIntervalMillis() : 0L;
+
+        RuntimeException lastError = null;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                return operation.get();
+            } catch (RuntimeException e) {
+                lastError = e;
+                if (attempt >= maxAttempts || !isTransient(e)) {
+                    throw e;
+                }
+                logger.warn(
+                        "Transient error resolving {} from terminology server (attempt {} of {}): {}. Retrying...",
+                        url,
+                        attempt,
+                        maxAttempts,
+                        e.getMessage());
+                try {
+                    Thread.sleep(retryIntervalMillis * attempt);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw e;
+                }
+            }
+        }
+        throw lastError; // unreachable: the loop either returns or throws
+    }
+
+    static boolean isTransient(Throwable error) {
+        for (Throwable t = error; t != null; t = t.getCause()) {
+            // Connection-level failures (connect/read timeouts, connection refused) — the reported symptom.
+            if (t instanceof FhirClientConnectionException
+                    || t instanceof SocketTimeoutException
+                    || t instanceof ConnectException) {
+                return true;
+            }
+            if (t instanceof BaseServerResponseException bsre
+                    && switch (bsre.getStatusCode()) {
+                        case 408, 429, 500, 502, 503, 504 -> true;
+                        default -> false;
+                    }) {
+                return true;
+            }
+            if (t.getCause() == t) {
+                break;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/client/terminology/FederatedTerminologyProviderRouter.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/client/terminology/FederatedTerminologyProviderRouter.java
@@ -208,6 +208,13 @@ public class FederatedTerminologyProviderRouter extends BaseTerminologyProvider 
      * resilience of the expansion path ({@code ExpandRunner}). A single transient tx-server hiccup during
      * dependency resolution should not abort an entire {@code $package} run. Non-transient errors and the
      * final failure after exhausting retries propagate unchanged.
+     *
+     * <p><strong>Performance note:</strong> against a flaky terminology server this trades speed for
+     * resilience — each transient failure takes up to {@code maxRetryCount}× longer (dominated by the
+     * per-attempt connect timeout). Operations that make many resolution calls (e.g. {@code $data-requirements}
+     * over many un-cached ValueSets) can be noticeably slower as a result. Performance-sensitive environments
+     * that prefer fail-fast can disable retries by setting
+     * {@link TerminologyServerClientSettings#setMaxRetryCount(int) maxRetryCount} to {@code 1}.
      */
     <T> T executeWithRetry(ITerminologyServerClient client, String url, Supplier<T> operation) {
         var settings = client.getTerminologyServerClientSettings();

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/client/ExpandRunnerTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/client/ExpandRunnerTest.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.fhir.utility.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
@@ -16,6 +17,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hl7.fhir.instance.model.api.IBaseParameters;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.CodeSystem;
+import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.ValueSet;
@@ -23,7 +26,9 @@ import org.hl7.fhir.r4.model.ValueSet.ValueSetExpansionContainsComponent;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsDeepStubs;
+import org.opencds.cqf.fhir.utility.Constants;
 import org.opencds.cqf.fhir.utility.client.ExpandRunner.TerminologyServerExpansionException;
+import org.opencds.cqf.fhir.utility.client.TerminologyServerClientSettings.TxResourceMode;
 
 class ExpandRunnerTest {
 
@@ -453,5 +458,135 @@ class ExpandRunnerTest {
         var result = (ValueSet) runner.expandValueSet();
 
         assertEquals(1, result.getExpansion().getContains().size());
+    }
+
+    // ---- tx-resource per-attempt behavior ----------------------------------------------------------
+
+    private static Parameters paramsWithTxResource() {
+        var params = new Parameters();
+        params.addParameter().setName("count").setValue(new IntegerType(1000));
+        var cs = new CodeSystem();
+        cs.setUrl("http://example.org/CodeSystem/local").setVersion("6.1.0");
+        params.addParameter().setName(Constants.TX_RESOURCE).setResource(cs);
+        return params;
+    }
+
+    private static boolean hasTxResource(IBaseParameters parameters) {
+        return ((Parameters) parameters)
+                .getParameter().stream().anyMatch(p -> Constants.TX_RESOURCE.equals(p.getName()));
+    }
+
+    @Test
+    void parametersForAttempt_auto_stripsFirstAttemptOnly() {
+        var params = paramsWithTxResource();
+        var client = mock(IGenericClient.class, new ReturnsDeepStubs());
+        // AUTO is the default mode
+        var settings = TerminologyServerClientSettings.getDefault();
+        var runner = new ExpandRunner(client, settings, "http://example.org/fhir/ValueSet/x", params);
+
+        assertFalse(hasTxResource(runner.parametersForAttempt(1)), "AUTO attempt 1 must NOT include tx-resource");
+        assertTrue(hasTxResource(runner.parametersForAttempt(2)), "AUTO attempt 2 must include tx-resource");
+        assertTrue(hasTxResource(params), "the original parameters must be left untouched");
+    }
+
+    @Test
+    void parametersForAttempt_enabled_keepsFromFirstAttempt() {
+        var params = paramsWithTxResource();
+        var client = mock(IGenericClient.class, new ReturnsDeepStubs());
+        var settings = TerminologyServerClientSettings.getDefault().setTxResourceMode(TxResourceMode.ENABLED);
+        var runner = new ExpandRunner(client, settings, "http://example.org/fhir/ValueSet/x", params);
+
+        assertTrue(hasTxResource(runner.parametersForAttempt(1)), "ENABLED attempt 1 must include tx-resource");
+        assertTrue(hasTxResource(runner.parametersForAttempt(2)), "ENABLED attempt 2 must include tx-resource");
+    }
+
+    @Test
+    void parametersForAttempt_disabled_keepsParametersAsIs() {
+        var params = paramsWithTxResource();
+        var client = mock(IGenericClient.class, new ReturnsDeepStubs());
+        var settings = TerminologyServerClientSettings.getDefault().setTxResourceMode(TxResourceMode.DISABLED);
+        var runner = new ExpandRunner(client, settings, "http://example.org/fhir/ValueSet/x", params);
+
+        // DISABLED does not strip; it sends whatever was provided (nothing is attached upstream in practice)
+        assertSameInstance(params, runner.parametersForAttempt(1));
+        assertSameInstance(params, runner.parametersForAttempt(2));
+    }
+
+    private static void assertSameInstance(IBaseParameters expected, IBaseParameters actual) {
+        assertTrue(expected == actual, "expected the very same parameters instance to be returned as-is");
+    }
+
+    @Test
+    void auto_endToEnd_stripsTxResourceOnFirstAttempt_thenAttachesOnRetry() {
+        var url = "http://example.org/fhir/ValueSet/test";
+        var params = paramsWithTxResource();
+
+        var expandedVs = new ValueSet();
+        expandedVs.setUrl(url);
+        expandedVs.getExpansion().addContains(new ValueSetExpansionContainsComponent().setCode("test"));
+
+        IGenericClient client = mock(IGenericClient.class, new ReturnsDeepStubs());
+        when(client.getFhirContext()).thenReturn(FhirContext.forR4Cached());
+        when(client.getServerBase()).thenReturn("http://example.org/fhir");
+
+        var captor = ArgumentCaptor.forClass(IBaseParameters.class);
+        when(client.operation()
+                        .onInstance(anyString())
+                        .named("$expand")
+                        .withParameters(captor.capture())
+                        .returnResourceType(any(Class.class))
+                        .execute())
+                .thenThrow(new InternalErrorException("Server error"))
+                .thenReturn(expandedVs);
+
+        // AUTO (default): attempt 1 without tx-resource, attempt 2 with it
+        var settings = TerminologyServerClientSettings.getDefault()
+                .setTimeoutSeconds(10)
+                .setMaxRetryCount(3)
+                .setRetryIntervalMillis(1L);
+
+        var runner = new ExpandRunner(client, settings, url, params);
+        var result = (ValueSet) runner.expandValueSet();
+
+        assertEquals(1, result.getExpansion().getContains().size());
+
+        var sent = captor.getAllValues();
+        assertEquals(2, sent.size(), "expected exactly two $expand attempts");
+        assertFalse(hasTxResource(sent.get(0)), "first attempt must be sent WITHOUT tx-resource");
+        assertTrue(hasTxResource(sent.get(1)), "retry must be sent WITH tx-resource");
+    }
+
+    @Test
+    void enabled_endToEnd_attachesTxResourceOnFirstAttempt() {
+        var url = "http://example.org/fhir/ValueSet/test";
+        var params = paramsWithTxResource();
+
+        var expandedVs = new ValueSet();
+        expandedVs.setUrl(url);
+        expandedVs.getExpansion().addContains(new ValueSetExpansionContainsComponent().setCode("test"));
+
+        IGenericClient client = mock(IGenericClient.class, new ReturnsDeepStubs());
+        when(client.getFhirContext()).thenReturn(FhirContext.forR4Cached());
+        when(client.getServerBase()).thenReturn("http://example.org/fhir");
+
+        var captor = ArgumentCaptor.forClass(IBaseParameters.class);
+        when(client.operation()
+                        .onInstance(anyString())
+                        .named("$expand")
+                        .withParameters(captor.capture())
+                        .returnResourceType(any(Class.class))
+                        .execute())
+                .thenReturn(expandedVs);
+
+        var settings = TerminologyServerClientSettings.getDefault()
+                .setTimeoutSeconds(10)
+                .setMaxRetryCount(3)
+                .setRetryIntervalMillis(1L)
+                .setTxResourceMode(TxResourceMode.ENABLED);
+
+        var runner = new ExpandRunner(client, settings, url, params);
+        runner.expandValueSet();
+
+        assertTrue(hasTxResource(captor.getValue()), "ENABLED first attempt must be sent WITH tx-resource");
     }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/client/ExpandRunnerTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/client/ExpandRunnerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -588,5 +589,81 @@ class ExpandRunnerTest {
         runner.expandValueSet();
 
         assertTrue(hasTxResource(captor.getValue()), "ENABLED first attempt must be sent WITH tx-resource");
+    }
+
+    // ---- non-transient failures short-circuit the retry loop ----------------------------------------
+
+    @Test
+    void auto_nonTransientFailure_escalatesOnceThenStops() {
+        // A non-transient failure (HTTP 422) will never succeed on an identical retry. In AUTO mode the
+        // first failure still warrants ONE retry (attempt 2 escalates by attaching tx-resource), but once
+        // that escalated attempt also fails non-transiently there is nothing new to try, so we must stop
+        // rather than burn the third attempt.
+        var url = "http://example.org/fhir/ValueSet/test";
+        var params = paramsWithTxResource();
+
+        IGenericClient client = mock(IGenericClient.class, new ReturnsDeepStubs());
+        when(client.getFhirContext()).thenReturn(FhirContext.forR4Cached());
+        when(client.getServerBase()).thenReturn("http://example.org/fhir");
+
+        AtomicInteger executeCalls = new AtomicInteger(0);
+        when(client.operation()
+                        .onInstance(anyString())
+                        .named("$expand")
+                        .withParameters(any(IBaseParameters.class))
+                        .returnResourceType(any(Class.class))
+                        .execute())
+                .thenAnswer(inv -> {
+                    executeCalls.incrementAndGet();
+                    throw new UnprocessableEntityException("CodeSystem could not be found");
+                });
+
+        var settings = TerminologyServerClientSettings.getDefault()
+                .setTimeoutSeconds(10)
+                .setMaxRetryCount(3)
+                .setRetryIntervalMillis(1L);
+
+        var runner = new ExpandRunner(client, settings, url, params);
+        assertThrows(TerminologyServerExpansionException.class, runner::expandValueSet);
+
+        assertEquals(
+                2,
+                executeCalls.get(),
+                "AUTO should make exactly two attempts (initial + one tx-resource escalation) on a non-transient failure");
+    }
+
+    @Test
+    void disabled_nonTransientFailure_doesNotRetry() {
+        // With no tx-resource escalation possible (DISABLED), a non-transient failure has no different
+        // request to try, so the loop must stop after the first attempt regardless of maxRetryCount.
+        var url = "http://example.org/fhir/ValueSet/test";
+        var params = new Parameters();
+
+        IGenericClient client = mock(IGenericClient.class, new ReturnsDeepStubs());
+        when(client.getFhirContext()).thenReturn(FhirContext.forR4Cached());
+        when(client.getServerBase()).thenReturn("http://example.org/fhir");
+
+        AtomicInteger executeCalls = new AtomicInteger(0);
+        when(client.operation()
+                        .onInstance(anyString())
+                        .named("$expand")
+                        .withParameters(any(IBaseParameters.class))
+                        .returnResourceType(any(Class.class))
+                        .execute())
+                .thenAnswer(inv -> {
+                    executeCalls.incrementAndGet();
+                    throw new UnprocessableEntityException("CodeSystem could not be found");
+                });
+
+        var settings = TerminologyServerClientSettings.getDefault()
+                .setTimeoutSeconds(10)
+                .setMaxRetryCount(3)
+                .setRetryIntervalMillis(1L)
+                .setTxResourceMode(TxResourceMode.DISABLED);
+
+        var runner = new ExpandRunner(client, settings, url, params);
+        assertThrows(TerminologyServerExpansionException.class, runner::expandValueSet);
+
+        assertEquals(1, executeCalls.get(), "DISABLED should make exactly one attempt on a non-transient failure");
     }
 }

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/client/GenericTerminologyServerClientClientTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/client/GenericTerminologyServerClientClientTest.java
@@ -24,6 +24,7 @@ import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.gclient.IQuery;
 import ca.uhn.fhir.rest.gclient.IUntypedQuery;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import java.util.Optional;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
@@ -291,10 +292,11 @@ public class GenericTerminologyServerClientClientTest {
                         .withParameters(any())
                         .returnResourceType(any())
                         .execute())
-                .thenThrow(new UnprocessableEntityException())
-                .thenThrow(new UnprocessableEntityException())
+                .thenThrow(new InternalErrorException("transient server error"))
+                .thenThrow(new InternalErrorException("transient server error"))
                 .thenReturn(leaf);
-        // Important part - successful response on 3rd attempt to expand
+        // Important part - a transient fault (HTTP 500) is retried and succeeds on the 3rd attempt.
+        // (Non-transient faults such as HTTP 422 are intentionally not retried to success.)
 
         var client = spy(new GenericTerminologyServerClient(fhirContextR4));
         doReturn(fhirClient).when(client).initializeClientWithAuth(any(IEndpointAdapter.class));

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/client/terminology/FederatedTerminologyProviderRouterTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/client/terminology/FederatedTerminologyProviderRouterTest.java
@@ -1,20 +1,29 @@
 package org.opencds.cqf.fhir.utility.client.terminology;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
+import ca.uhn.fhir.rest.client.exceptions.FhirClientConnectionException;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import org.hl7.fhir.instance.model.api.IDomainResource;
 import org.hl7.fhir.r4.model.Endpoint;
 import org.hl7.fhir.r4.model.ValueSet;
@@ -24,6 +33,7 @@ import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
 import org.opencds.cqf.fhir.utility.adapter.IEndpointAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IParametersAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IValueSetAdapter;
+import org.opencds.cqf.fhir.utility.client.TerminologyServerClientSettings;
 
 class FederatedTerminologyProviderRouterTest {
 
@@ -451,6 +461,69 @@ class FederatedTerminologyProviderRouterTest {
         var endpoint = new Endpoint();
         endpoint.setAddress(address);
         return (IEndpointAdapter) IAdapterFactory.createAdapterForResource(endpoint);
+    }
+
+    private ITerminologyServerClient fastRetryClient(int maxRetryCount) {
+        var settings = TerminologyServerClientSettings.getDefault()
+                .setMaxRetryCount(maxRetryCount)
+                .setRetryIntervalMillis(1);
+        var client = mock(ITerminologyServerClient.class);
+        when(client.getTerminologyServerClientSettings()).thenReturn(settings);
+        return client;
+    }
+
+    @Test
+    void executeWithRetry_retriesTransientThenSucceeds() {
+        var router = new FederatedTerminologyProviderRouter(fhirContext);
+        var calls = new AtomicInteger();
+        Supplier<String> op = () -> {
+            if (calls.incrementAndGet() < 3) {
+                throw new FhirClientConnectionException("HAPI-1361: Connect timed out");
+            }
+            return "ok";
+        };
+        var result = router.executeWithRetry(fastRetryClient(3), "http://example.org/fhir/ValueSet/x", op);
+        assertEquals("ok", result);
+        assertEquals(3, calls.get(), "should retry the two transient failures then succeed on the third attempt");
+    }
+
+    @Test
+    void executeWithRetry_nonTransientError_propagatesWithoutRetry() {
+        var router = new FederatedTerminologyProviderRouter(fhirContext);
+        var calls = new AtomicInteger();
+        Supplier<String> op = () -> {
+            calls.incrementAndGet();
+            throw new InvalidRequestException("bad request");
+        };
+        assertThrows(
+                InvalidRequestException.class,
+                () -> router.executeWithRetry(fastRetryClient(3), "http://example.org/fhir/ValueSet/x", op));
+        assertEquals(1, calls.get(), "non-transient errors must not be retried");
+    }
+
+    @Test
+    void executeWithRetry_exhaustsRetriesThenPropagates() {
+        var router = new FederatedTerminologyProviderRouter(fhirContext);
+        var calls = new AtomicInteger();
+        Supplier<String> op = () -> {
+            calls.incrementAndGet();
+            throw new FhirClientConnectionException("HAPI-1361: Connect timed out");
+        };
+        assertThrows(
+                FhirClientConnectionException.class,
+                () -> router.executeWithRetry(fastRetryClient(3), "http://example.org/fhir/ValueSet/x", op));
+        assertEquals(3, calls.get(), "should attempt exactly maxRetryCount times before propagating");
+    }
+
+    @Test
+    void isTransient_classifiesConnectionAndServerErrorsAsRetryable() {
+        // Connection-level failures (the reported symptom) — directly and when wrapped.
+        assertTrue(FederatedTerminologyProviderRouter.isTransient(
+                new FhirClientConnectionException("HAPI-1361: Connect timed out")));
+        assertTrue(FederatedTerminologyProviderRouter.isTransient(
+                new RuntimeException("wrapped", new SocketTimeoutException("Connect timed out"))));
+        // Non-transient: a 4xx client error should not be retried.
+        assertFalse(FederatedTerminologyProviderRouter.isTransient(new InvalidRequestException("bad request")));
     }
 
     /**


### PR DESCRIPTION
## Summary

Improves the `$package` operation's ability to expand ValueSets against a remote terminology server, and hardens the terminology-server interaction against flakiness and wasted work. Against the US Core 6.1.0 value-set package, ValueSets returning codes went from ~83/432 to 389/488 (183,302 codes), with the remaining non-expansions attributable to external terminology availability/licensing rather than defects.

Addresses https://github.com/DBCG/aphl-vsm/issues/709

## Motivation

When packaging an IG's ValueSets, a remote `$expand` frequently fails because the terminology server doesn't have the exact CodeSystem/ValueSet versions the package pins even though those definitions ship inside the package itself. Several secondary issues compounded this: a malformed `system-version` parameter for unversioned `urn:` systems produced HTTP 500s, `tx-resource` parameters accumulated across the ValueSet loop, transient socket timeouts against tx.fhir.org aborted whole runs, and permanent failures were retried pointlessly.

## What changed

1. **`tx-resource` support for remote `$expand`** - the package's own ValueSet and CodeSystem resources are supplied to the server via the `tx-resource` parameter so it can resolve definitions/versions it doesn't otherwise hold. Controlled by a `TxResourceMode` (`AUTO` / `ENABLED` / `DISABLED`); `AUTO` (default) sends the first attempt without `tx-resource` and escalates on retry. Large/external CodeSystems (e.g. SNOMED, LOINC) are filtered out so we never ship huge or non-package content.

2. **NPM package federation for `$package`** - the governing ImplementationGuide is resolved via the artifact's `composed-of` reference (or the artifact itself when it is an IG); its `dependsOn` packages are federated into the resolution repository so dependency ValueSets/CodeSystems resolve. If no IG can be determined, we log and continue without federation rather than guessing.

3. **`bcp:47` / unversioned-`urn:` fix** - stop emitting a malformed `system-version` parameter for unversioned `urn:` systems that caused HTTP 500s from the server.

4. **`tx-resource` accumulation fix** - attach `tx-resource` parameters to a per-expansion copy so they no longer pile up across successive ValueSets in the loop.

5. **Transient-failure retries on resolution reads** - dependency-gathering reads now retry transient faults (connection/read timeouts, retryable HTTP statuses), improving resilience against tx.fhir.org socket timeouts.

6. **Skip retrying non-transient `$expand` failures** - the `$expand` retry loop no longer burns identical attempts on permanent failures (e.g. HTTP 422 "CodeSystem could not be found"). It still allows the one `AUTO`-mode escalation (attempt 1 -> 2 attaches `tx-resource`, the escalation such a 422 is meant to resolve), then stops.

## Results (US Core 6.1.0 value-set package)

| Stage | ValueSets included | Expanded with codes | Notes |
|---|---|---|---|
| Early run (pre-fixes) | 432 | ~83 | HTTP 500s from `bcp:47`, accumulation bug |
| After `bcp:47` + accumulation fixes | 432 | 347 | 0 false failures, 1 empty (`icd-10`) |
| After NPM federation + retry short-circuit | 488 | 389 | 183,302 codes |

## Remaining limitations (inherent, not addressed here)

The 98 ValueSets that still don't expand fall into two groups, neither fixable in code:

- **Large/licensed terminologies** - SNOMED (44), LOINC (21), CPT, ICD-10. These require a terminology server provisioned with that content/license.
- **Identifier-style "systems" that aren't enumerable CodeSystems** - e.g. `https://www.usps.com/`, `urn:iso:std:iso:3166`, and other `urn:`/authority URIs. These are valid for validation but have no code list to enumerate, so `expansion` is correctly left null (no error).

## Performance / configuration note

Retries improve resilience but make each transient failure take up to `maxRetryCount`× longer (dominated by the connect timeout), which can slow operations that make many terminology-server calls against un-cached ValueSets (e.g. `$data-requirements`). Performance-sensitive deployments that prefer fail-fast can set `TerminologyServerClientSettings.setMaxRetryCount(1)` to disable retries entirely. This tradeoff is documented on the setting and the router.

## Testing

- `ExpandRunnerTest` - `tx-resource` per-attempt behavior (AUTO/ENABLED/DISABLED), plus new coverage that non-transient failures stop early (AUTO escalates once then stops; DISABLED makes a single attempt).
- `ExpandHelperTest` - `tx-resource` accumulation regression and target-attach behavior.
- `PackageVisitorNpmFederationTest` - IG resolution via `composed-of`/self/none and `dependsOn` extraction.
- `PackageVisitorTests` - `bcp:47` unversioned-`urn:` param filtering.
- `FederatedTerminologyProviderRouterTest` - transient-retry and `isTransient` behavior.
- `spotlessCheck` clean.
- Additionally ran local testing in VSM environment using US Core 6.1.0 as test subject