### PR TITLE
Adding abstraction to bring your own validation

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/CrSettings.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/CrSettings.java
@@ -1,11 +1,13 @@
 package org.opencds.cqf.fhir.cr;
 
 import org.opencds.cqf.fhir.cql.EvaluationSettings;
+import org.opencds.cqf.fhir.utility.IResourceValidator;
 import org.opencds.cqf.fhir.utility.client.TerminologyServerClientSettings;
 
 public class CrSettings {
     private EvaluationSettings evaluationSettings;
     private TerminologyServerClientSettings terminologyServerClientSettings;
+    private IResourceValidator resourceValidator;
 
     public static CrSettings getDefault() {
         return new CrSettings();
@@ -14,6 +16,7 @@ public class CrSettings {
     public CrSettings() {
         evaluationSettings = EvaluationSettings.getDefault();
         terminologyServerClientSettings = TerminologyServerClientSettings.getDefault();
+        resourceValidator = null;
     }
 
     public EvaluationSettings getEvaluationSettings() {
@@ -41,5 +44,31 @@ public class CrSettings {
 
     public void setTerminologyServerClientSettings(TerminologyServerClientSettings terminologyServerClientSettings) {
         this.terminologyServerClientSettings = terminologyServerClientSettings;
+    }
+
+    /**
+     * Returns the configured resource validator, or null if none has been set.
+     * When null, components should bootstrap their own validator as needed.
+     *
+     * @return the configured IResourceValidator, or null
+     */
+    public IResourceValidator getResourceValidator() {
+        return resourceValidator;
+    }
+
+    /**
+     * Sets a custom resource validator to be used instead of bootstrapping one internally.
+     * This allows external configuration of the FHIR validation support chain.
+     *
+     * @param resourceValidator the validator to use
+     * @return this CrSettings instance for fluent chaining
+     */
+    public CrSettings withResourceValidator(IResourceValidator resourceValidator) {
+        this.resourceValidator = resourceValidator;
+        return this;
+    }
+
+    public void setResourceValidator(IResourceValidator resourceValidator) {
+        this.resourceValidator = resourceValidator;
     }
 }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/CrSettingsTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/CrSettingsTest.java
@@ -1,0 +1,69 @@
+package org.opencds.cqf.fhir.cr;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.cql.EvaluationSettings;
+import org.opencds.cqf.fhir.utility.IResourceValidator;
+import org.opencds.cqf.fhir.utility.client.TerminologyServerClientSettings;
+
+class CrSettingsTest {
+
+    @Test
+    void defaultConstructorHasNullValidator() {
+        CrSettings settings = new CrSettings();
+
+        assertNull(settings.getResourceValidator());
+    }
+
+    @Test
+    void getDefaultReturnsNewInstance() {
+        CrSettings settings = CrSettings.getDefault();
+
+        assertNotNull(settings);
+        assertNotNull(settings.getEvaluationSettings());
+        assertNotNull(settings.getTerminologyServerClientSettings());
+        assertNull(settings.getResourceValidator());
+    }
+
+    @Test
+    void withResourceValidatorSetAndReturnsThis() {
+        CrSettings settings = new CrSettings();
+        IResourceValidator mockValidator = mock(IResourceValidator.class);
+
+        CrSettings result = settings.withResourceValidator(mockValidator);
+
+        assertSame(settings, result);
+        assertSame(mockValidator, settings.getResourceValidator());
+    }
+
+    @Test
+    void setResourceValidatorSetsValue() {
+        CrSettings settings = new CrSettings();
+        IResourceValidator mockValidator = mock(IResourceValidator.class);
+
+        settings.setResourceValidator(mockValidator);
+
+        assertSame(mockValidator, settings.getResourceValidator());
+    }
+
+    @Test
+    void fluentChainingWorksWithAllSettings() {
+        IResourceValidator mockValidator = mock(IResourceValidator.class);
+        EvaluationSettings evalSettings = EvaluationSettings.getDefault();
+        TerminologyServerClientSettings termSettings = TerminologyServerClientSettings.getDefault();
+
+        CrSettings settings = CrSettings.getDefault()
+                .withEvaluationSettings(evalSettings)
+                .withTerminologyServerClientSettings(termSettings)
+                .withResourceValidator(mockValidator);
+
+        assertSame(evalSettings, settings.getEvaluationSettings());
+        assertSame(termSettings, settings.getTerminologyServerClientSettings());
+        assertSame(mockValidator, settings.getResourceValidator());
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/CrSettingsTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/CrSettingsTest.java
@@ -1,6 +1,5 @@
 package org.opencds.cqf.fhir.cr;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/IResourceValidator.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/IResourceValidator.java
@@ -1,0 +1,30 @@
+package org.opencds.cqf.fhir.utility;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+/**
+ * Interface for FHIR resource validation. Implementations can use the HAPI FHIR validator
+ * or any custom validation logic.
+ */
+public interface IResourceValidator {
+
+    /**
+     * Validates the given resource. Returns the resource if valid, or an OperationOutcome
+     * containing validation errors if invalid.
+     *
+     * @param resource the resource to validate
+     * @return the original resource if valid, or an OperationOutcome if invalid
+     */
+    IBaseResource validate(IBaseResource resource);
+
+    /**
+     * Validates the given resource.
+     *
+     * @param resource the resource to validate
+     * @param throwOnError if true, throws a RuntimeException when validation fails;
+     *                     if false, returns an OperationOutcome
+     * @return the original resource if valid, or an OperationOutcome if invalid and throwOnError is false
+     * @throws RuntimeException if validation fails and throwOnError is true
+     */
+    IBaseResource validate(IBaseResource resource, Boolean throwOnError);
+}

--- a/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/ResourceValidator.java
+++ b/cqf-fhir-utility/src/main/java/org/opencds/cqf/fhir/utility/ResourceValidator.java
@@ -20,12 +20,35 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.ImplementationGuide;
 
-public class ResourceValidator {
+public class ResourceValidator implements IResourceValidator {
     protected IRepository repo;
     protected FhirContext context;
     protected FhirValidator validator;
     protected Map<String, ValidationProfile> profiles;
 
+    /**
+     * Creates a ResourceValidator with an externally-configured FhirValidator.
+     * Use this constructor when you want to provide your own pre-configured validator
+     * (e.g., with custom validation support chain, terminology services, etc.).
+     *
+     * @param validator the pre-configured FhirValidator to use
+     * @param profiles optional validation profiles for filtering error messages
+     */
+    public ResourceValidator(FhirValidator validator, Map<String, ValidationProfile> profiles) {
+        this.validator = validator;
+        this.profiles = profiles == null ? new HashMap<>() : profiles;
+        this.repo = null;
+        this.context = null;
+    }
+
+    /**
+     * Creates a ResourceValidator that bootstraps its own FhirValidator based on the
+     * provided FhirContext and profiles.
+     *
+     * @param context the FhirContext to use
+     * @param profiles validation profiles to load from the repository
+     * @param repo the repository to load ImplementationGuide resources from
+     */
     public ResourceValidator(FhirContext context, Map<String, ValidationProfile> profiles, IRepository repo) {
         this.repo = repo;
         this.context = context;
@@ -33,6 +56,14 @@ public class ResourceValidator {
         setValidator();
     }
 
+    /**
+     * Creates a ResourceValidator that bootstraps its own FhirValidator based on the
+     * provided FHIR version and profiles.
+     *
+     * @param version the FHIR version to use
+     * @param profiles validation profiles to load from the repository
+     * @param repo the repository to load ImplementationGuide resources from
+     */
     public ResourceValidator(FhirVersionEnum version, Map<String, ValidationProfile> profiles, IRepository repo) {
         this.repo = repo;
         this.context = FhirContext.forCached(version);
@@ -95,7 +126,7 @@ public class ResourceValidator {
                         && this.profiles.entrySet().stream()
                                 .flatMap(p -> p.getValue().getIgnoreKeys().stream())
                                 .noneMatch(m.getMessage()::contains))
-                .collect(Collectors.toList());
+                .toList();
 
         if (errors.isEmpty()) {
             return resource;

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/ResourceValidatorTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/ResourceValidatorTest.java
@@ -1,0 +1,104 @@
+package org.opencds.cqf.fhir.utility;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ca.uhn.fhir.validation.FhirValidator;
+import ca.uhn.fhir.validation.ValidationResult;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.jupiter.api.Test;
+
+class ResourceValidatorTest {
+
+    @Test
+    void constructorWithExternalValidator() {
+        FhirValidator mockValidator = mock(FhirValidator.class);
+
+        ResourceValidator resourceValidator = new ResourceValidator(mockValidator, null);
+
+        assertNotNull(resourceValidator);
+    }
+
+    @Test
+    void constructorWithExternalValidatorAndProfiles() {
+        FhirValidator mockValidator = mock(FhirValidator.class);
+        Map<String, ValidationProfile> profiles = new HashMap<>();
+        profiles.put("test", new ValidationProfile("test-profile", Collections.emptyList()));
+
+        ResourceValidator resourceValidator = new ResourceValidator(mockValidator, profiles);
+
+        assertNotNull(resourceValidator);
+    }
+
+    @Test
+    void validateWithExternalValidatorReturnsResourceOnSuccess() {
+        FhirValidator mockValidator = mock(FhirValidator.class);
+        ValidationResult mockResult = mock(ValidationResult.class);
+        Patient patient = new Patient();
+
+        when(mockValidator.validateWithResult(any(IBaseResource.class))).thenReturn(mockResult);
+        when(mockResult.getMessages()).thenReturn(Collections.emptyList());
+
+        ResourceValidator resourceValidator = new ResourceValidator(mockValidator, null);
+        IBaseResource result = resourceValidator.validate(patient);
+
+        assertSame(patient, result);
+        verify(mockValidator).validateWithResult(patient);
+    }
+
+    @Test
+    void validateWithExternalValidatorReturnsOperationOutcomeOnError() {
+        FhirValidator mockValidator = mock(FhirValidator.class);
+        ValidationResult mockResult = mock(ValidationResult.class);
+        OperationOutcome operationOutcome = new OperationOutcome();
+        Patient patient = new Patient();
+
+        var errorMessage = new ca.uhn.fhir.validation.SingleValidationMessage();
+        errorMessage.setSeverity(ca.uhn.fhir.validation.ResultSeverityEnum.ERROR);
+        errorMessage.setMessage("Test validation error");
+
+        when(mockValidator.validateWithResult(any(IBaseResource.class))).thenReturn(mockResult);
+        when(mockResult.getMessages()).thenReturn(Collections.singletonList(errorMessage));
+        when(mockResult.toOperationOutcome()).thenReturn(operationOutcome);
+
+        ResourceValidator resourceValidator = new ResourceValidator(mockValidator, null);
+        IBaseResource result = resourceValidator.validate(patient, false);
+
+        assertSame(operationOutcome, result);
+    }
+
+    @Test
+    void implementsIResourceValidatorInterface() {
+        FhirValidator mockValidator = mock(FhirValidator.class);
+
+        ResourceValidator resourceValidator = new ResourceValidator(mockValidator, null);
+
+        assertTrue(resourceValidator instanceof IResourceValidator);
+    }
+
+    @Test
+    void validateOverloadWithoutErrorFlagDelegatesToFullMethod() {
+        FhirValidator mockValidator = mock(FhirValidator.class);
+        ValidationResult mockResult = mock(ValidationResult.class);
+        Patient patient = new Patient();
+
+        when(mockValidator.validateWithResult(any(IBaseResource.class))).thenReturn(mockResult);
+        when(mockResult.getMessages()).thenReturn(Collections.emptyList());
+
+        ResourceValidator resourceValidator = new ResourceValidator(mockValidator, null);
+        IBaseResource result = resourceValidator.validate(patient);
+
+        assertSame(patient, result);
+    }
+}

--- a/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/ResourceValidatorTest.java
+++ b/cqf-fhir-utility/src/test/java/org/opencds/cqf/fhir/utility/ResourceValidatorTest.java
@@ -1,6 +1,5 @@
 package org.opencds.cqf.fhir.utility;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;


### PR DESCRIPTION
This pull request introduces a new abstraction for FHIR resource validation and enables external configuration of resource validators in the `CrSettings` class.