### PR TITLE
Update to CQL 5.3.0

### DIFF
--- a/.claude/skills/linked-builds-pr/SKILL.md
+++ b/.claude/skills/linked-builds-pr/SKILL.md
@@ -36,7 +36,7 @@ Read `local.properties` in the project root. Each property key maps to a `Linked
 in the registry. For example:
 
 ```properties
-cql.engine.path=../clinical_quality_language/Src/java
+cql.engine.path=../clinical_quality_language
 ```
 
 Look up each active property key in `LinkedBuildRegistry` (in `LinkedBuild.kt`) to get the
@@ -53,7 +53,7 @@ For each linked build path discovered in Step 1, check if **that** repository al
 graph. This is important — if repo A depends on repo B which depends on repo C, PRs must be
 created starting from C (most upstream) and working down.
 
-For example, if `clinical_quality_language/Src/java` has its own `local.properties` pointing
+For example, if `clinical_quality_language` has its own `local.properties` pointing
 to another sibling repo, that repo needs a PR first.
 
 Each linked repo may have its own `LinkedBuildRegistry` (or equivalent) in its `build-logic/`
@@ -64,7 +64,7 @@ directory — read it to understand its structure.
 For each repository in topological order (most upstream first):
 
 1. **Navigate to the repo directory** (the path from `local.properties`, minus the `buildRoot`
-   suffix — e.g., `../clinical_quality_language` not `../clinical_quality_language/Src/java`)
+   suffix — e.g., `../clinical_quality_language` not `../clinical_quality_language`)
 
 2. **Check git status**: Identify the current branch, staged/unstaged changes, and unpushed commits.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ To build against a local checkout of a dependency (e.g., CQL Engine) instead of 
 cp local.properties.example local.properties
 
 # Edit local.properties — uncomment and set the path:
-# cql.engine.path=../clinical_quality_language/Src/java
+# cql.engine.path=../clinical_quality_language
 
 # Build as normal — the settings plugin detects local.properties and includes the linked build
 ./gradlew build

--- a/build-logic/src/main/kotlin/cqf/LinkedBuild.kt
+++ b/build-logic/src/main/kotlin/cqf/LinkedBuild.kt
@@ -27,7 +27,7 @@ object LinkedBuildRegistry {
         LinkedBuild(
             slug = "cqframework/clinical_quality_language",
             propertyKey = "cql.engine.path",
-            buildRoot = "Src/java",
+            buildRoot = "",
             substitutions =
                 buildMap {
                     // Kotlin/JVM modules — artifact name matches project name

--- a/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/engine/parameters/CqlFhirParametersConverterTests.java
+++ b/cqf-fhir-cql/src/test/java/org/opencds/cqf/fhir/cql/engine/parameters/CqlFhirParametersConverterTests.java
@@ -77,8 +77,9 @@ class CqlFhirParametersConverterTests {
         var testData = new EvaluationResult();
         testData.set(
                 new EvaluationExpressionRef("Patient"),
-                new ExpressionResult(new ClassInstance(new QName(fhirModelNamespaceUri, "Patient"), Map.of()), null));
-        testData.set(new EvaluationExpressionRef("Numerator"), new ExpressionResult(new Boolean(true), null));
+                new ExpressionResult(
+                        new ClassInstance(new QName(fhirModelNamespaceUri, "Patient"), Map.of()), Map.of()));
+        testData.set(new EvaluationExpressionRef("Numerator"), new ExpressionResult(new Boolean(true), Map.of()));
 
         var actual = (Parameters) cqlFhirParametersConverter.toFhirParameters(testData);
 
@@ -94,9 +95,11 @@ class CqlFhirParametersConverterTests {
         var testData = new EvaluationResult();
         testData.set(
                 new EvaluationExpressionRef("Patient"),
-                new ExpressionResult(new ClassInstance(new QName(fhirModelNamespaceUri, "Patient"), Map.of()), null));
+                new ExpressionResult(
+                        new ClassInstance(new QName(fhirModelNamespaceUri, "Patient"), Map.of()), Map.of()));
         testData.set(
-                new EvaluationExpressionRef("Encounters"), new ExpressionResult(List.Companion.getEMPTY_LIST(), null));
+                new EvaluationExpressionRef("Encounters"),
+                new ExpressionResult(List.Companion.getEMPTY_LIST(), Map.of()));
 
         Parameters actual = (Parameters) cqlFhirParametersConverter.toFhirParameters(testData);
 
@@ -116,7 +119,7 @@ class CqlFhirParametersConverterTests {
         var cqlList = new List(testList);
 
         var testData = new EvaluationResult();
-        testData.set(new EvaluationExpressionRef("NullInList"), new ExpressionResult(cqlList, null));
+        testData.set(new EvaluationExpressionRef("NullInList"), new ExpressionResult(cqlList, Map.of()));
 
         var actual = (Parameters) cqlFhirParametersConverter.toFhirParameters(testData);
 
@@ -132,8 +135,9 @@ class CqlFhirParametersConverterTests {
         var testData = new EvaluationResult();
         testData.set(
                 new EvaluationExpressionRef("Patient"),
-                new ExpressionResult(new ClassInstance(new QName(fhirModelNamespaceUri, "Patient"), Map.of()), null));
-        testData.set(new EvaluationExpressionRef("Null"), new ExpressionResult(null, null));
+                new ExpressionResult(
+                        new ClassInstance(new QName(fhirModelNamespaceUri, "Patient"), Map.of()), Map.of()));
+        testData.set(new EvaluationExpressionRef("Null"), new ExpressionResult(null, Map.of()));
 
         var actual = (Parameters) cqlFhirParametersConverter.toFhirParameters(testData);
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/CqlExpressionValue.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/CqlExpressionValue.java
@@ -24,13 +24,14 @@ import org.opencds.cqf.cql.engine.runtime.Value;
  */
 public final class CqlExpressionValue {
 
-    private static final CqlExpressionValue EMPTY = new CqlExpressionValue(null, null, Collections.emptySet());
+    private static final CqlExpressionValue EMPTY = new CqlExpressionValue(null, null, Collections.emptyMap());
 
     private final @Nullable String expressionName;
     private final @Nullable Object raw;
-    private final Set<Value> evaluatedResources;
+    private final Map<String, Value> evaluatedResources;
 
-    private CqlExpressionValue(@Nullable String expressionName, @Nullable Object raw, Set<Value> evaluatedResources) {
+    private CqlExpressionValue(
+            @Nullable String expressionName, @Nullable Object raw, Map<String, Value> evaluatedResources) {
         this.expressionName = expressionName;
         this.raw = raw;
         this.evaluatedResources = evaluatedResources;
@@ -45,7 +46,7 @@ public final class CqlExpressionValue {
         }
         var resources = result.getEvaluatedResources();
         return new CqlExpressionValue(
-                expressionName, result.getValue(), resources != null ? resources : Collections.emptySet());
+                expressionName, result.getValue(), resources != null ? resources : Collections.emptyMap());
     }
 
     /**
@@ -53,12 +54,12 @@ public final class CqlExpressionValue {
      * for callers that already hold the underlying value.
      */
     public static CqlExpressionValue ofRaw(
-            @Nullable String expressionName, @Nullable Object value, @Nullable Set<Value> evaluatedResources) {
+            @Nullable String expressionName, @Nullable Object value, @Nullable Map<String, Value> evaluatedResources) {
         if (value instanceof ExpressionResult expressionResult) {
             return of(expressionName, expressionResult);
         }
         return new CqlExpressionValue(
-                expressionName, value, evaluatedResources != null ? evaluatedResources : Collections.emptySet());
+                expressionName, value, evaluatedResources != null ? evaluatedResources : Collections.emptyMap());
     }
 
     /**
@@ -311,7 +312,7 @@ public final class CqlExpressionValue {
         return List.of(raw);
     }
 
-    public Set<Value> evaluatedResources() {
+    public Map<String, Value> evaluatedResources() {
         return evaluatedResources;
     }
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/EvaluationResultFormatter.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/EvaluationResultFormatter.java
@@ -65,7 +65,7 @@ public class EvaluationResultFormatter {
             if (expressionResult.evaluatedResources() != null
                     && !expressionResult.evaluatedResources().isEmpty()) {
                 sb.append(indent(baseIndent + 1)).append("Evaluated Resources:\n");
-                for (var resource : expressionResult.evaluatedResources()) {
+                for (var resource : expressionResult.evaluatedResources().values()) {
                     sb.append(indent(baseIndent + 2))
                             .append(formatResource(resource))
                             .append("\n");

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/FunctionEvaluationHandler.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/FunctionEvaluationHandler.java
@@ -4,12 +4,11 @@ import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import kotlin.Unit;
 import org.hl7.elm.r1.ExpressionDef;
 import org.hl7.elm.r1.FunctionDef;
@@ -273,7 +272,7 @@ public class FunctionEvaluationHandler {
         // FhirResourceAndCqlTypeUtils.areObjectsEqual where needed; nothing in the downstream pipeline
         // does random-access lookup by input, so a List is sufficient and self-documenting.
         final List<ObservationEntry> functionResults = new ArrayList<>();
-        final Set<Value> evaluatedResources = new HashSet<>();
+        final Map<String, Value> evaluatedResources = new HashMap<>();
 
         final String exceptionMessageIfNotFunction = """
             Measure: '%s', MeasureObservation population expression '%s' must be a CQL function
@@ -293,7 +292,7 @@ public class FunctionEvaluationHandler {
 
             var quantity = convertCqlResultToQuantityDef(observationResult.getValue());
             functionResults.add(new ObservationEntry(result, quantity));
-            Optional.ofNullable(observationResult.getEvaluatedResources()).ifPresent(evaluatedResources::addAll);
+            Optional.ofNullable(observationResult.getEvaluatedResources()).ifPresent(evaluatedResources::putAll);
         }
 
         return buildEvaluationResult(expressionName, new ObservationAccumulator(functionResults), evaluatedResources);
@@ -407,7 +406,7 @@ public class FunctionEvaluationHandler {
             // this will be used in MeasureEvaluator (Criteria population Id and Stratifier Expression)
             var expressionName = popDef.id() + "-" + stratifierExpression;
             final List<FunctionResultEntry> functionResults = new ArrayList<>();
-            final Set<Value> evaluatedResources = new HashSet<>();
+            final Map<String, Value> evaluatedResources = new HashMap<>();
 
             for (var result : resultsIter) {
                 final ExpressionResult functionResult = evaluateNonSubValueStratifiersFunction(
@@ -425,8 +424,8 @@ public class FunctionEvaluationHandler {
                     throw new IllegalStateException("CQL function '" + stratifierExpression
                             + "' returned null evaluatedResources for measure: " + measureUrl);
                 }
-                evaluatedResources.addAll(evaluated);
-                evaluatedResources.addAll(functionResult.getEvaluatedResources());
+                evaluatedResources.putAll(evaluated);
+                evaluatedResources.putAll(functionResult.getEvaluatedResources());
             }
             // add to EvaluationResult
             addToEvaluationResult(
@@ -655,7 +654,7 @@ public class FunctionEvaluationHandler {
     }
 
     private static CqlEvaluationResult buildEvaluationResult(
-            String expressionName, Object functionResults, Set<Value> evaluatedResources) {
+            String expressionName, Object functionResults, Map<String, Value> evaluatedResources) {
 
         final var evaluationResultToReturn = new CqlEvaluationResult();
 
@@ -666,7 +665,10 @@ public class FunctionEvaluationHandler {
     }
 
     private static void addToEvaluationResult(
-            CqlEvaluationResult result, String expressionName, Object functionResults, Set<Value> evaluatedResources) {
+            CqlEvaluationResult result,
+            String expressionName,
+            Object functionResults,
+            Map<String, Value> evaluatedResources) {
 
         result.addExpressionResult(CqlExpressionValue.ofRaw(expressionName, functionResults, evaluatedResources));
     }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureEvaluator.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureEvaluator.java
@@ -115,10 +115,10 @@ public class MeasureEvaluator {
             String subjectType,
             CqlExpressionValue expressionResult,
             CqlEvaluationResult evaluationResult,
-            Set<Value> outEvaluatedResources) {
+            Map<String, Value> outEvaluatedResources) {
 
         if (expressionResult != null && !expressionResult.evaluatedResources().isEmpty()) {
-            outEvaluatedResources.addAll(expressionResult.evaluatedResources());
+            outEvaluatedResources.putAll(expressionResult.evaluatedResources());
         }
 
         if (expressionResult == null || expressionResult.raw() == null) {
@@ -754,7 +754,7 @@ public class MeasureEvaluator {
             // to zero strata (the reported empty "stratifier": [ { "id": "..." } ]). A null result
             // instead groups the subject into a "null" stratum, matching how a null-returning
             // function component already behaves.
-            component.putResult(subjectId, component.expression(), null, Set.of());
+            component.putResult(subjectId, component.expression(), null, Map.of());
             return; // short-circuit
         }
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/PopulationDef.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/PopulationDef.java
@@ -29,7 +29,7 @@ public class PopulationDef {
     @Nullable
     private Double aggregationResult;
 
-    protected Set<Value> evaluatedResources;
+    protected Map<String, Value> evaluatedResources;
 
     /**
      * Per-subject results from CQL evaluation, stored as wrappers so the FHIR-identity / CQL-type
@@ -105,9 +105,9 @@ public class PopulationDef {
         return populationType == this.measurePopulationType;
     }
 
-    public Set<Value> getEvaluatedResources() {
+    public Map<String, Value> getEvaluatedResources() {
         if (this.evaluatedResources == null) {
-            this.evaluatedResources = new HashSetForFhirResourcesAndCqlTypes<>();
+            this.evaluatedResources = new HashMap<>();
         }
 
         return this.evaluatedResources;

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/SdeDef.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/SdeDef.java
@@ -1,9 +1,7 @@
 package org.opencds.cqf.fhir.cr.measure.common;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.opencds.cqf.cql.engine.runtime.Value;
@@ -18,7 +16,7 @@ public class SdeDef {
 
     // Pre-accumulated state (populated by MeasureMultiSubjectEvaluator)
     private final Map<StratumValueWrapper, Long> accumulatedValues = new HashMap<>();
-    private final Set<Value> allEvaluatedResources = new HashSet<>();
+    private final Map<String, Value> allEvaluatedResources = new HashMap<>();
 
     public SdeDef(String id, ConceptDef code, String expression) {
         this(id, code, expression, null);
@@ -47,7 +45,7 @@ public class SdeDef {
         return this.description;
     }
 
-    public void putResult(String subject, String expression, Object value, Set<Value> evaluatedResources) {
+    public void putResult(String subject, String expression, Object value, Map<String, Value> evaluatedResources) {
         this.results.put(subject, CqlExpressionValue.ofRaw(expression, value, evaluatedResources));
     }
 
@@ -55,7 +53,7 @@ public class SdeDef {
         return this.accumulatedValues;
     }
 
-    public Set<Value> getAllEvaluatedResources() {
+    public Map<String, Value> getAllEvaluatedResources() {
         return this.allEvaluatedResources;
     }
 
@@ -66,7 +64,7 @@ public class SdeDef {
     public void accumulate() {
         // Merge all evaluated resources across subjects
         for (CqlExpressionValue result : results.values()) {
-            allEvaluatedResources.addAll(result.evaluatedResources());
+            allEvaluatedResources.putAll(result.evaluatedResources());
         }
 
         // Count occurrences of each distinct value across all subjects

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/StratifierComponentDef.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/StratifierComponentDef.java
@@ -2,7 +2,6 @@ package org.opencds.cqf.fhir.cr.measure.common;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import org.opencds.cqf.cql.engine.runtime.Value;
 
 public class StratifierComponentDef {
@@ -34,7 +33,7 @@ public class StratifierComponentDef {
         this.getResults().put(subject, expressionValue);
     }
 
-    public void putResult(String subject, String expression, Object value, Set<Value> evaluatedResources) {
+    public void putResult(String subject, String expression, Object value, Map<String, Value> evaluatedResources) {
         this.putResult(subject, CqlExpressionValue.ofRaw(expression, value, evaluatedResources));
     }
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/StratifierDef.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/StratifierDef.java
@@ -78,12 +78,8 @@ public class StratifierDef {
         this.getResults().put(subject, expressionValue);
     }
 
-    public void putResult(String subject, String expression, Object value, Set<Value> evaluatedResources) {
-        this.getResults()
-                .put(
-                        subject,
-                        CqlExpressionValue.ofRaw(
-                                expression, value, new HashSetForFhirResourcesAndCqlTypes<>(evaluatedResources)));
+    public void putResult(String subject, String expression, Object value, Map<String, Value> evaluatedResources) {
+        this.getResults().put(subject, CqlExpressionValue.ofRaw(expression, value, evaluatedResources));
     }
 
     public Map<String, CqlExpressionValue> getResults() {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/dstu3/Dstu3MeasureReportBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/dstu3/Dstu3MeasureReportBuilder.java
@@ -359,9 +359,10 @@ public class Dstu3MeasureReportBuilder implements MeasureReportBuilder<Measure, 
         return referenceList;
     }
 
-    private void addResourceReferences(MeasurePopulationType measurePopulationType, Set<Value> evaluatedResources) {
+    private void addResourceReferences(
+            MeasurePopulationType measurePopulationType, Map<String, Value> evaluatedResources) {
         if (!evaluatedResources.isEmpty()) {
-            for (var object : evaluatedResources) {
+            for (var object : evaluatedResources.values()) {
                 var resource = (ClassInstance) object;
                 var resourceId = getId(resource);
                 var reference = this.getEvaluatedResourceReference(resourceId);
@@ -423,7 +424,7 @@ public class Dstu3MeasureReportBuilder implements MeasureReportBuilder<Measure, 
     }
 
     private void processSdeEvaluatedResourceExtension(SdeDef sdeDef) {
-        for (Object o : sdeDef.getAllEvaluatedResources()) {
+        for (Object o : sdeDef.getAllEvaluatedResources().values()) {
             if (o instanceof IBaseResource iBaseResource) {
                 // extension item
                 Extension extension = new Extension(MeasureConstants.EXT_SDE_URL);

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportBuilder.java
@@ -323,12 +323,12 @@ public class R4MeasureReportBuilder implements MeasureReportBuilder<Measure, Mea
     }
 
     private void addEvaluatedResourceReferences(
-            R4MeasureReportBuilderContext bc, String criteriaId, Set<Value> evaluatedResources) {
+            R4MeasureReportBuilderContext bc, String criteriaId, Map<String, Value> evaluatedResources) {
         if (evaluatedResources == null || evaluatedResources.isEmpty()) {
             return;
         }
 
-        for (var resource : evaluatedResources) {
+        for (var resource : evaluatedResources.values()) {
             if (resource instanceof ClassInstance classInstance) {
                 bc.addCriteriaExtensionToEvaluatedResource(getId(classInstance), criteriaId);
             }

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/CompositeEvaluationResultsPerMeasureTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/CompositeEvaluationResultsPerMeasureTest.java
@@ -9,10 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.DateType;
 import org.hl7.fhir.r4.model.Encounter;
@@ -41,7 +39,7 @@ class CompositeEvaluationResultsPerMeasureTest {
 
         // Create a non-empty EvaluationResult without depending on ExpressionResult constructors
         EvaluationResult er = new EvaluationResult();
-        er.set(new EvaluationExpressionRef("subject-123"), new ExpressionResult(null, null));
+        er.set(new EvaluationExpressionRef("subject-123"), new ExpressionResult(null, Map.of()));
 
         CompositeEvaluationResultsPerMeasure.Builder builder = CompositeEvaluationResultsPerMeasure.builder();
         builder.addResult(measureDef1, "subject-123", er, List.of());
@@ -119,7 +117,7 @@ class CompositeEvaluationResultsPerMeasureTest {
         // Create an EvaluationResult with expression results
         EvaluationResult er = new EvaluationResult();
         ExpressionResult expressionResult = new ExpressionResult(
-                new org.opencds.cqf.cql.engine.runtime.Boolean(true), new HashSet<>(List.of(patient)));
+                new org.opencds.cqf.cql.engine.runtime.Boolean(true), Map.of("Patient/patient-1", patient));
         er.set(new EvaluationExpressionRef("Initial Population"), expressionResult);
 
         CompositeEvaluationResultsPerMeasure.Builder builder = CompositeEvaluationResultsPerMeasure.builder();
@@ -180,11 +178,12 @@ class CompositeEvaluationResultsPerMeasureTest {
         // Create EvaluationResult with multiple expression results
         EvaluationResult er = new EvaluationResult();
         ExpressionResult popResult = new ExpressionResult(
-                new org.opencds.cqf.cql.engine.runtime.Integer(5), new HashSet<>(List.of(patient, encounter)));
+                new org.opencds.cqf.cql.engine.runtime.Integer(5),
+                Map.of("Patient/patient-2", patient, "Encounter/patient-2-encounter-1", encounter));
         er.set(new EvaluationExpressionRef("Initial Population"), popResult);
 
         ExpressionResult numResult =
-                new ExpressionResult(new org.opencds.cqf.cql.engine.runtime.String("test-string"), Set.of());
+                new ExpressionResult(new org.opencds.cqf.cql.engine.runtime.String("test-string"), Map.of());
         er.set(new EvaluationExpressionRef("Numerator"), numResult);
 
         CompositeEvaluationResultsPerMeasure.Builder builder = CompositeEvaluationResultsPerMeasure.builder();
@@ -229,12 +228,12 @@ class CompositeEvaluationResultsPerMeasureTest {
 
         var localDate =
                 modelResolver.toCqlValue(new DateType(LocalDate.of(2024, 1, 15).toString()), false);
-        ExpressionResult dateResult = new ExpressionResult(localDate, Set.of());
+        ExpressionResult dateResult = new ExpressionResult(localDate, Map.of());
         er.set(new EvaluationExpressionRef("Date Expression"), dateResult);
 
         var localDateTime = modelResolver.toCqlValue(
                 new DateTimeType(LocalDateTime.of(2024, 1, 15, 14, 30, 45).toString()), false);
-        ExpressionResult dateTimeResult = new ExpressionResult(localDateTime, Set.of());
+        ExpressionResult dateTimeResult = new ExpressionResult(localDateTime, Map.of());
         er.set(new EvaluationExpressionRef("DateTime Expression"), dateTimeResult);
 
         CompositeEvaluationResultsPerMeasure.Builder builder = CompositeEvaluationResultsPerMeasure.builder();
@@ -267,7 +266,7 @@ class CompositeEvaluationResultsPerMeasureTest {
         // Create EvaluationResult with collection value
         EvaluationResult er = new EvaluationResult();
         var patientList = new org.opencds.cqf.cql.engine.runtime.List(List.of(patient1, patient2));
-        ExpressionResult listResult = new ExpressionResult(patientList, Set.of());
+        ExpressionResult listResult = new ExpressionResult(patientList, Map.of());
         er.set(new EvaluationExpressionRef("Patient List"), listResult);
 
         CompositeEvaluationResultsPerMeasure.Builder builder = CompositeEvaluationResultsPerMeasure.builder();
@@ -294,14 +293,14 @@ class CompositeEvaluationResultsPerMeasureTest {
         EvaluationResult er = new EvaluationResult();
         er.set(
                 new EvaluationExpressionRef("expr1"),
-                new ExpressionResult(new org.opencds.cqf.cql.engine.runtime.Boolean(true), Set.of()));
+                new ExpressionResult(new org.opencds.cqf.cql.engine.runtime.Boolean(true), Map.of()));
 
         var debugResult = new DebugResult();
         er.setDebugResult(debugResult);
 
         var observationResult = new CqlEvaluationResult();
         observationResult.setExpressionResults(List.of(
-                CqlExpressionValue.ofRaw("obs1", new org.opencds.cqf.cql.engine.runtime.Integer(42), Set.of())));
+                CqlExpressionValue.ofRaw("obs1", new org.opencds.cqf.cql.engine.runtime.Integer(42), Map.of())));
 
         var builder = CompositeEvaluationResultsPerMeasure.builder();
         builder.addResult(measureDef, "patient-1", er, List.of(observationResult));
@@ -324,7 +323,7 @@ class CompositeEvaluationResultsPerMeasureTest {
         EvaluationResult er = new EvaluationResult();
         er.set(
                 new EvaluationExpressionRef("expr1"),
-                new ExpressionResult(new org.opencds.cqf.cql.engine.runtime.Boolean(true), Set.of()));
+                new ExpressionResult(new org.opencds.cqf.cql.engine.runtime.Boolean(true), Map.of()));
 
         var trace = new Trace(List.of());
         er.setTrace(trace);
@@ -348,7 +347,7 @@ class CompositeEvaluationResultsPerMeasureTest {
         EvaluationResult er = new EvaluationResult();
         er.set(
                 new EvaluationExpressionRef("expr1"),
-                new ExpressionResult(new org.opencds.cqf.cql.engine.runtime.Boolean(true), Set.of()));
+                new ExpressionResult(new org.opencds.cqf.cql.engine.runtime.Boolean(true), Map.of()));
 
         var builder = CompositeEvaluationResultsPerMeasure.builder();
         builder.addResult(measureDef, "patient-1", er, List.of());

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/CqlExpressionValueTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/CqlExpressionValueTest.java
@@ -13,7 +13,6 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -43,14 +42,14 @@ class CqlExpressionValueTest {
         assertTrue(wrapper.isNull());
         assertTrue(wrapper.isEmpty());
         assertSame(CqlExpressionValue.empty(), wrapper);
-        assertEquals(Set.of(), wrapper.evaluatedResources());
+        assertEquals(Map.of(), wrapper.evaluatedResources());
     }
 
     @Test
     void of_expressionResult_propagatesValueAndResources() {
         var patient = modelResolver.toCqlValue(new Patient().setId("p1"), false);
         assertNotNull(patient);
-        Set<Value> resources = new HashSet<>(List.of(patient));
+        Map<java.lang.String, Value> resources = Map.of("r1", patient);
         ExpressionResult result = new ExpressionResult(patient, resources);
 
         CqlExpressionValue wrapper = CqlExpressionValue.ofRaw(null, result, null);
@@ -61,11 +60,11 @@ class CqlExpressionValueTest {
 
     @Test
     void of_expressionResultWithNullResources_substitutesEmptySet() {
-        ExpressionResult result = new ExpressionResult(new String("v"), null);
+        ExpressionResult result = new ExpressionResult(new String("v"), Map.of());
 
         CqlExpressionValue wrapper = CqlExpressionValue.ofRaw(null, result, null);
 
-        assertEquals(Set.of(), wrapper.evaluatedResources());
+        assertEquals(Map.of(), wrapper.evaluatedResources());
     }
 
     @Test
@@ -73,7 +72,7 @@ class CqlExpressionValueTest {
         CqlExpressionValue wrapper = CqlExpressionValue.ofRaw(null, 42, null);
 
         assertEquals(42, wrapper.raw());
-        assertEquals(Set.of(), wrapper.evaluatedResources());
+        assertEquals(Map.of(), wrapper.evaluatedResources());
     }
 
     // -- predicates --------------------------------------------------------------
@@ -203,7 +202,7 @@ class CqlExpressionValueTest {
     void resolveForPopulation_falseReturnsEmpty() {
         EvaluationResult evaluationResult = new EvaluationResult();
         var patient = modelResolver.toCqlValue(new Patient(), false);
-        evaluationResult.set(new EvaluationExpressionRef("Patient"), new ExpressionResult(patient, Set.of()));
+        evaluationResult.set(new EvaluationExpressionRef("Patient"), new ExpressionResult(patient, Map.of()));
 
         Iterable<Object> result = CqlExpressionValue.ofRaw(null, new Boolean(false), null)
                 .resolveForPopulation("Patient", evaluationResult);
@@ -215,7 +214,7 @@ class CqlExpressionValueTest {
     void resolveForPopulation_trueLooksUpSubjectContextValue() {
         var patient = modelResolver.toCqlValue(new Patient().setId("p1"), false);
         var evaluationResult = new EvaluationResult();
-        evaluationResult.set(new EvaluationExpressionRef("Patient"), new ExpressionResult(patient, Set.of()));
+        evaluationResult.set(new EvaluationExpressionRef("Patient"), new ExpressionResult(patient, Map.of()));
 
         Iterable<Object> result = CqlExpressionValue.ofRaw(null, new Boolean(true), null)
                 .resolveForPopulation("Patient", evaluationResult);
@@ -471,7 +470,7 @@ class CqlExpressionValueTest {
 
     @Test
     void evaluatedResources_returnsTheBackingSet() {
-        Set<Value> resources = new HashSet<>(List.of(new String("r1"), new String("r2")));
+        Map<java.lang.String, Value> resources = Map.of("r1", new String("r1"), "r2", new String("r2"));
         CqlExpressionValue wrapper = CqlExpressionValue.ofRaw(null, "v", resources);
 
         assertSame(resources, wrapper.evaluatedResources());

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/MeasureMultiSubjectEvaluatorTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/MeasureMultiSubjectEvaluatorTest.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Patient;
@@ -93,7 +92,7 @@ class MeasureMultiSubjectEvaluatorTest {
     @Test
     void singleSubject_singlePrimitiveValue() {
         var sde = new SdeDef("sde-1", new ConceptDef(List.of(), null), null);
-        sde.putResult("Patient/p1", null, new org.opencds.cqf.cql.engine.runtime.String("male"), Set.of());
+        sde.putResult("Patient/p1", null, new org.opencds.cqf.cql.engine.runtime.String("male"), Map.of());
 
         MeasureMultiSubjectEvaluator.postEvaluationMultiSubject(FHIR_CONTEXT, measureDefWith(sde));
 
@@ -107,9 +106,9 @@ class MeasureMultiSubjectEvaluatorTest {
     @Test
     void multipleSubjects_sameValue() {
         var sde = new SdeDef("sde-1", new ConceptDef(List.of(), null), null);
-        sde.putResult("Patient/p1", null, new org.opencds.cqf.cql.engine.runtime.String("male"), Set.of());
-        sde.putResult("Patient/p2", null, new org.opencds.cqf.cql.engine.runtime.String("male"), Set.of());
-        sde.putResult("Patient/p3", null, new org.opencds.cqf.cql.engine.runtime.String("male"), Set.of());
+        sde.putResult("Patient/p1", null, new org.opencds.cqf.cql.engine.runtime.String("male"), Map.of());
+        sde.putResult("Patient/p2", null, new org.opencds.cqf.cql.engine.runtime.String("male"), Map.of());
+        sde.putResult("Patient/p3", null, new org.opencds.cqf.cql.engine.runtime.String("male"), Map.of());
 
         MeasureMultiSubjectEvaluator.postEvaluationMultiSubject(FHIR_CONTEXT, measureDefWith(sde));
 
@@ -120,9 +119,9 @@ class MeasureMultiSubjectEvaluatorTest {
     @Test
     void multipleSubjects_differentValues() {
         var sde = new SdeDef("sde-1", new ConceptDef(List.of(), null), null);
-        sde.putResult("Patient/p1", null, new org.opencds.cqf.cql.engine.runtime.String("male"), Set.of());
-        sde.putResult("Patient/p2", null, new org.opencds.cqf.cql.engine.runtime.String("female"), Set.of());
-        sde.putResult("Patient/p3", null, new org.opencds.cqf.cql.engine.runtime.String("male"), Set.of());
+        sde.putResult("Patient/p1", null, new org.opencds.cqf.cql.engine.runtime.String("male"), Map.of());
+        sde.putResult("Patient/p2", null, new org.opencds.cqf.cql.engine.runtime.String("female"), Map.of());
+        sde.putResult("Patient/p3", null, new org.opencds.cqf.cql.engine.runtime.String("male"), Map.of());
 
         MeasureMultiSubjectEvaluator.postEvaluationMultiSubject(FHIR_CONTEXT, measureDefWith(sde));
 
@@ -137,8 +136,8 @@ class MeasureMultiSubjectEvaluatorTest {
     void resourceTypedValues_accumulated() {
         var patient = modelResolver.toCqlValue(new Patient().setId(new IdType("Patient", "patient1")), false);
         var sde = new SdeDef("sde-1", new ConceptDef(List.of(), null), null);
-        sde.putResult("Patient/p1", null, patient, Set.of());
-        sde.putResult("Patient/p2", null, patient, Set.of());
+        sde.putResult("Patient/p1", null, patient, Map.of());
+        sde.putResult("Patient/p2", null, patient, Map.of());
 
         MeasureMultiSubjectEvaluator.postEvaluationMultiSubject(FHIR_CONTEXT, measureDefWith(sde));
 
@@ -153,7 +152,7 @@ class MeasureMultiSubjectEvaluatorTest {
                 new org.opencds.cqf.cql.engine.runtime.String("male"),
                 null,
                 new org.opencds.cqf.cql.engine.runtime.String("female")));
-        sde.putResult("Patient/p1", null, list, Set.of());
+        sde.putResult("Patient/p1", null, list, Map.of());
 
         MeasureMultiSubjectEvaluator.postEvaluationMultiSubject(FHIR_CONTEXT, measureDefWith(sde));
 
@@ -168,27 +167,35 @@ class MeasureMultiSubjectEvaluatorTest {
         var res3 = modelResolver.toCqlValue(new Patient().setId(new IdType("Patient", "res3")), false);
 
         var sde = new SdeDef("sde-1", new ConceptDef(List.of(), null), null);
-        sde.putResult("Patient/p1", null, new org.opencds.cqf.cql.engine.runtime.String("male"), Set.of(res1, res2));
-        sde.putResult("Patient/p2", null, new org.opencds.cqf.cql.engine.runtime.String("female"), Set.of(res2, res3));
+        sde.putResult(
+                "Patient/p1",
+                null,
+                new org.opencds.cqf.cql.engine.runtime.String("male"),
+                Map.of("res1", res1, "res2", res2));
+        sde.putResult(
+                "Patient/p2",
+                null,
+                new org.opencds.cqf.cql.engine.runtime.String("female"),
+                Map.of("res2", res2, "res3", res3));
 
         MeasureMultiSubjectEvaluator.postEvaluationMultiSubject(FHIR_CONTEXT, measureDefWith(sde));
 
         // All unique evaluated resources should be aggregated
         assertEquals(3, sde.getAllEvaluatedResources().size());
-        assertTrue(sde.getAllEvaluatedResources().contains(res1));
-        assertTrue(sde.getAllEvaluatedResources().contains(res2));
-        assertTrue(sde.getAllEvaluatedResources().contains(res3));
+        assertTrue(sde.getAllEvaluatedResources().containsKey("res1"));
+        assertTrue(sde.getAllEvaluatedResources().containsKey("res2"));
+        assertTrue(sde.getAllEvaluatedResources().containsKey("res3"));
     }
 
     @Test
     void multipleSdeDefs_accumulatedIndependently() {
         var sde1 = new SdeDef("sde-race", new ConceptDef(List.of(), null), null);
-        sde1.putResult("Patient/p1", null, new org.opencds.cqf.cql.engine.runtime.String("white"), Set.of());
-        sde1.putResult("Patient/p2", null, new org.opencds.cqf.cql.engine.runtime.String("black"), Set.of());
+        sde1.putResult("Patient/p1", null, new org.opencds.cqf.cql.engine.runtime.String("white"), Map.of());
+        sde1.putResult("Patient/p2", null, new org.opencds.cqf.cql.engine.runtime.String("black"), Map.of());
 
         var sde2 = new SdeDef("sde-sex", new ConceptDef(List.of(), null), null);
-        sde2.putResult("Patient/p1", null, new org.opencds.cqf.cql.engine.runtime.String("male"), Set.of());
-        sde2.putResult("Patient/p2", null, new org.opencds.cqf.cql.engine.runtime.String("male"), Set.of());
+        sde2.putResult("Patient/p1", null, new org.opencds.cqf.cql.engine.runtime.String("male"), Map.of());
+        sde2.putResult("Patient/p2", null, new org.opencds.cqf.cql.engine.runtime.String("male"), Map.of());
 
         MeasureMultiSubjectEvaluator.postEvaluationMultiSubject(FHIR_CONTEXT, measureDefWith(sde1, sde2));
 
@@ -237,8 +244,8 @@ class MeasureMultiSubjectEvaluatorTest {
             Map<Object, Object> p1Result = new LinkedHashMap<>();
             p1Result.put(enc1, "finished");
             p1Result.put(enc2, "in-progress");
-            component.putResult("p1", null, p1Result, Set.of());
-            component.putResult("p2", null, Map.of(enc3, "finished"), Set.of());
+            component.putResult("p1", null, p1Result, Map.of());
+            component.putResult("p2", null, Map.of(enc3, "finished"), Map.of());
 
             var stratifierDef = new StratifierDef(
                     "stratifier-1",
@@ -314,8 +321,8 @@ class MeasureMultiSubjectEvaluatorTest {
 
             var component = new StratifierComponentDef("strat-1-c1", textConcept("Gender"), "Patient Gender");
             // Scalar value per subject — what MeasureEvaluator.handleNonBooleanBasisComponent writes.
-            component.putResult("p1", null, "male", Set.of());
-            component.putResult("p2", null, "female", Set.of());
+            component.putResult("p1", null, "male", Map.of());
+            component.putResult("p2", null, "female", Map.of());
 
             var stratifierDef = new StratifierDef(
                     "stratifier-1",
@@ -383,8 +390,8 @@ class MeasureMultiSubjectEvaluatorTest {
             pop.addResource("p2", null, Boolean.TRUE);
 
             var component = new StratifierComponentDef("strat-1-c1", textConcept("Gender"), "Gender Stratification");
-            component.putResult("p1", null, "male", Set.of());
-            component.putResult("p2", null, "female", Set.of());
+            component.putResult("p1", null, "male", Map.of());
+            component.putResult("p2", null, "female", Map.of());
 
             var stratifierDef = new StratifierDef(
                     "stratifier-1",
@@ -417,9 +424,9 @@ class MeasureMultiSubjectEvaluatorTest {
             pop.addResource("p3", null, Boolean.TRUE);
 
             var component = new StratifierComponentDef("strat-1-c1", textConcept("Gender"), "Gender Stratification");
-            component.putResult("p1", null, "male", Set.of());
-            component.putResult("p2", null, "female", Set.of());
-            component.putResult("p3", null, "male", Set.of());
+            component.putResult("p1", null, "male", Map.of());
+            component.putResult("p2", null, "female", Map.of());
+            component.putResult("p3", null, "male", Map.of());
 
             var stratifierDef = new StratifierDef(
                     "stratifier-1",
@@ -479,8 +486,8 @@ class MeasureMultiSubjectEvaluatorTest {
                     "strat-1-c1", textConcept("Distinct Statuses"), "Distinct Encounter Statuses");
             // p1's list contains both "finished" and "in-progress" → p1 appears in BOTH strata
             // with all of p1's encounters (the scalar fallback fanned out across strata).
-            component.putResult("p1", null, List.of("finished", "in-progress"), Set.of());
-            component.putResult("p2", null, List.of("finished"), Set.of());
+            component.putResult("p1", null, List.of("finished", "in-progress"), Map.of());
+            component.putResult("p2", null, List.of("finished"), Map.of());
 
             var stratifierDef = new StratifierDef(
                     "stratifier-1",
@@ -522,7 +529,7 @@ class MeasureMultiSubjectEvaluatorTest {
             // The list contains a null element. ofIterableElement(null, i) creates a Scalar with
             // null value (legacy form "null_<i>"). The StratumValueWrapper for null wraps null
             // and produces a "null" stratum.
-            component.putResult("p1", null, Arrays.asList("finished", null), Set.of());
+            component.putResult("p1", null, Arrays.asList("finished", null), Map.of());
 
             var stratifierDef = new StratifierDef(
                     "stratifier-1",
@@ -553,7 +560,7 @@ class MeasureMultiSubjectEvaluatorTest {
             pop.addResource("p1", null, enc2);
 
             var component = new StratifierComponentDef("strat-1-c1", textConcept("Encounters"), "All Encounters");
-            component.putResult("p1", null, List.of(enc1, enc2), Set.of());
+            component.putResult("p1", null, List.of(enc1, enc2), Map.of());
 
             var stratifierDef = new StratifierDef(
                     "stratifier-1",
@@ -597,11 +604,11 @@ class MeasureMultiSubjectEvaluatorTest {
             Map<Object, Object> p1Function = new LinkedHashMap<>();
             p1Function.put(enc1, "finished");
             p1Function.put(enc2, "in-progress");
-            funcComponent.putResult("p1", null, p1Function, Set.of());
+            funcComponent.putResult("p1", null, p1Function, Map.of());
 
             // Component 2: per-subject scalar — must be expanded across both function rows.
             var scalarComponent = new StratifierComponentDef("c-gender", textConcept("Gender"), "Patient Gender");
-            scalarComponent.putResult("p1", null, "male", Set.of());
+            scalarComponent.putResult("p1", null, "male", Map.of());
 
             var stratifierDef = new StratifierDef(
                     "stratifier-1",
@@ -640,10 +647,10 @@ class MeasureMultiSubjectEvaluatorTest {
             pop.addResource("p1", pop.expression(), Boolean.TRUE);
 
             var componentA = new StratifierComponentDef("component-a", textConcept("Component A"), "Expression A");
-            componentA.putResult("p1", "Expression A", "shared-value", Set.of());
+            componentA.putResult("p1", "Expression A", "shared-value", Map.of());
 
             var componentB = new StratifierComponentDef("component-b", textConcept("Component B"), "Expression B");
-            componentB.putResult("p1", "Expression B", "shared-value", Set.of());
+            componentB.putResult("p1", "Expression B", "shared-value", Map.of());
 
             var stratifierDef = new StratifierDef(
                     "stratifier-1",
@@ -675,13 +682,13 @@ class MeasureMultiSubjectEvaluatorTest {
             pop.addResource("p1", pop.expression(), Boolean.TRUE);
 
             var componentA = new StratifierComponentDef("component-a", textConcept("Component A"), "Expression A");
-            componentA.putResult("p1", "Expression A", "distinct-value", Set.of());
+            componentA.putResult("p1", "Expression A", "distinct-value", Map.of());
 
             var componentB = new StratifierComponentDef("component-b", textConcept("Component B"), "Expression B");
-            componentB.putResult("p1", "Expression B", "shared-value", Set.of());
+            componentB.putResult("p1", "Expression B", "shared-value", Map.of());
 
             var componentC = new StratifierComponentDef("component-c", textConcept("Component C"), "Expression C");
-            componentC.putResult("p1", "Expression C", "shared-value", Set.of());
+            componentC.putResult("p1", "Expression C", "shared-value", Map.of());
 
             var stratifierDef = new StratifierDef(
                     "stratifier-1",
@@ -726,9 +733,9 @@ class MeasureMultiSubjectEvaluatorTest {
             var stratifierDef = new StratifierDef(
                     "stratifier-1", textConcept("Selected"), "Selected Encounters", MeasureStratifierType.CRITERIA);
             // p1: stratifier selects enc1 + a non-population encounter → only enc1 intersects.
-            stratifierDef.putResult("p1", null, List.of(enc1, encounter("enc-not-in-pop")), Set.of());
+            stratifierDef.putResult("p1", null, List.of(enc1, encounter("enc-not-in-pop")), Map.of());
             // p2: stratifier selects enc3 → matches population.
-            stratifierDef.putResult("p2", null, enc3, Set.of());
+            stratifierDef.putResult("p2", null, enc3, Map.of());
 
             var groupDef = cohortGroup(basis, pop, stratifierDef);
 
@@ -757,7 +764,7 @@ class MeasureMultiSubjectEvaluatorTest {
             Map<Object, Object> p1Map = new LinkedHashMap<>();
             p1Map.put(enc1, "finished");
             p1Map.put(enc2, "in-progress");
-            stratifierDef.putResult("p1", null, p1Map, Set.of());
+            stratifierDef.putResult("p1", null, p1Map, Map.of());
 
             var groupDef = cohortGroup(basis, pop, stratifierDef);
 
@@ -777,8 +784,8 @@ class MeasureMultiSubjectEvaluatorTest {
 
             var stratifierDef = new StratifierDef(
                     "stratifier-1", textConcept("Nothing"), "Nothing", MeasureStratifierType.CRITERIA);
-            // null result → criteriaResultAsIntersectionSet returns Set.of().
-            stratifierDef.putResult("p1", null, null, Set.of());
+            // null result → criteriaResultAsIntersectionSet returns Map.of().
+            stratifierDef.putResult("p1", null, null, Map.of());
 
             var groupDef = cohortGroup(basis, pop, stratifierDef);
 

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportBuilderTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportBuilderTest.java
@@ -12,11 +12,9 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.time.LocalDate;
 import java.time.Month;
-import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
@@ -75,7 +73,7 @@ class R4MeasureReportBuilderTest {
 
         var measureReport = r4MeasureReportBuilder.build(
                 buildMeasure(MEASURE_ID_1, MEASURE_URL_1, 2, 0),
-                buildMeasureDef(MEASURE_ID_1, MEASURE_URL_1, 2, 0, true, Set.of(buildInterval())),
+                buildMeasureDef(MEASURE_ID_1, MEASURE_URL_1, 2, 0, true, Map.of("", buildInterval())),
                 MeasureReportType.INDIVIDUAL,
                 null,
                 List.of());
@@ -111,7 +109,7 @@ class R4MeasureReportBuilderTest {
 
         var measureReport = r4MeasureReportBuilder.build(
                 buildMeasure(MEASURE_ID_1, MEASURE_URL_1, 2, 3),
-                buildMeasureDef(MEASURE_ID_1, MEASURE_URL_1, 2, 3, true, Set.of()),
+                buildMeasureDef(MEASURE_ID_1, MEASURE_URL_1, 2, 3, true, Map.of()),
                 MeasureReportType.INDIVIDUAL,
                 null,
                 List.of());
@@ -136,7 +134,7 @@ class R4MeasureReportBuilderTest {
 
         var measureReport = r4MeasureReportBuilder.build(
                 buildMeasure(MEASURE_ID_1, null, 2, 3),
-                buildMeasureDef(MEASURE_ID_1, MEASURE_URL_1, 2, 3, false, Set.of()),
+                buildMeasureDef(MEASURE_ID_1, MEASURE_URL_1, 2, 3, false, Map.of()),
                 MeasureReportType.INDIVIDUAL,
                 null,
                 List.of());
@@ -159,7 +157,7 @@ class R4MeasureReportBuilderTest {
     void errorMismatchedGroupsSizes_tooMany() {
         var r4MeasureReportBuilder = new R4MeasureReportBuilder();
         final Measure measure = buildMeasure(MEASURE_ID_1, MEASURE_URL_1, 1, 2);
-        final MeasureDef measureDef = buildMeasureDef(MEASURE_ID_1, MEASURE_URL_1, 2, 2, true, Set.of());
+        final MeasureDef measureDef = buildMeasureDef(MEASURE_ID_1, MEASURE_URL_1, 2, 2, true, Map.of());
         final List<String> subjectIds = List.of();
 
         try {
@@ -176,7 +174,7 @@ class R4MeasureReportBuilderTest {
     void errorMismatchedGroupsSizes_tooFew() {
         var r4MeasureReportBuilder = new R4MeasureReportBuilder();
         final Measure measure = buildMeasure(MEASURE_ID_1, MEASURE_URL_1, 2, 2);
-        final MeasureDef measureDef = buildMeasureDef(MEASURE_ID_1, MEASURE_URL_1, 1, 2, true, Set.of());
+        final MeasureDef measureDef = buildMeasureDef(MEASURE_ID_1, MEASURE_URL_1, 1, 2, true, Map.of());
         final List<String> subjectIds = List.of();
 
         try {
@@ -193,11 +191,11 @@ class R4MeasureReportBuilderTest {
     void invalidPopulationResource() {
         var r4MeasureReportBuilder = new R4MeasureReportBuilder();
 
-        var patient = modelResolver.toCqlValue(new Patient(), false);
+        var patient = modelResolver.toCqlValue(new Patient().setId("pat1"), false);
         try {
             r4MeasureReportBuilder.build(
                     buildMeasure(null, MEASURE_URL_1, 2, 2),
-                    buildMeasureDef(MEASURE_ID_1, MEASURE_URL_1, 2, 2, true, Set.of(patient)),
+                    buildMeasureDef(MEASURE_ID_1, MEASURE_URL_1, 2, 2, true, Map.of("pat1", patient)),
                     MeasureReportType.INDIVIDUAL,
                     null,
                     List.of());
@@ -213,7 +211,7 @@ class R4MeasureReportBuilderTest {
             int numGroups,
             int numSdes,
             boolean isKeyResource,
-            Collection<Value> evaluatedResources) {
+            Map<String, Value> evaluatedResources) {
         var measureDef = new MeasureDef(
                 new IdType(ResourceType.Measure.name(), id),
                 url,
@@ -229,7 +227,7 @@ class R4MeasureReportBuilderTest {
         return measureDef;
     }
 
-    private static SdeDef buildSdes(String id, boolean isKeyResource, @Nullable Collection<Value> evaluatedResources) {
+    private static SdeDef buildSdes(String id, boolean isKeyResource, @Nullable Map<String, Value> evaluatedResources) {
         final SdeDef sdeDef = new SdeDef(
                 id,
                 new ConceptDef(List.of(new CodeDef("system", MeasurePopulationType.DATEOFCOMPLIANCE.toCode())), null),
@@ -242,14 +240,14 @@ class R4MeasureReportBuilderTest {
                     isKeyResource
                             ? modelResolver.toCqlValue(new Patient().setId(new IdType("Patient", "patient1")), false)
                             : new org.opencds.cqf.cql.engine.runtime.String("nonResource"),
-                    evaluatedResources.stream().filter(Objects::nonNull).collect(Collectors.toUnmodifiableSet()));
+                    evaluatedResources);
         }
 
         return sdeDef;
     }
 
     @Nonnull
-    private static GroupDef buildGroupDef(String id, Collection<Value> resources) {
+    private static GroupDef buildGroupDef(String id, Map<String, Value> resources) {
         return new GroupDef(
                 id,
                 null,
@@ -261,7 +259,7 @@ class R4MeasureReportBuilderTest {
                 new CodeDef(MeasureConstants.POPULATION_BASIS_URL, "boolean"));
     }
 
-    private static PopulationDef buildPopulationRef(Collection<Value> resources) {
+    private static PopulationDef buildPopulationRef(Map<String, Value> resources) {
         CodeDef booleanBasis = new CodeDef(MeasureConstants.POPULATION_BASIS_URL, "boolean");
         final PopulationDef populationDef = new PopulationDef(
                 null,
@@ -274,7 +272,7 @@ class R4MeasureReportBuilderTest {
                 null);
 
         if (resources != null) {
-            resources.forEach(res -> populationDef.addResource("subj", null, res));
+            resources.values().forEach(res -> populationDef.addResource("subj", null, res));
         }
 
         return populationDef;

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/R4PopulationBasisValidatorTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/R4PopulationBasisValidatorTest.java
@@ -11,7 +11,6 @@ import jakarta.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Stream;
 import org.hl7.fhir.Code;
 import org.hl7.fhir.r4.model.CodeableConcept;
@@ -627,7 +626,7 @@ class R4PopulationBasisValidatorTest {
     private static CqlEvaluationResult buildEvaluationResult(Map<String, Value> expressionResultMap) {
         final EvaluationResult evaluationResult = new EvaluationResult();
         expressionResultMap.forEach((key, value) ->
-                evaluationResult.set(new EvaluationExpressionRef(key), new ExpressionResult(value, Set.of())));
+                evaluationResult.set(new EvaluationExpressionRef(key), new ExpressionResult(value, Map.of())));
         return new CqlEvaluationResult(evaluationResult);
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 hapi = "8.10.0"
-cql = "5.2.0"
+cql = "5.3.0"
 junit = "5.14.3"
 slf4j = "2.0.17"
 spring-boot = "3.4.11"

--- a/local.properties.example
+++ b/local.properties.example
@@ -2,4 +2,4 @@
 # Uncomment and set paths to use local checkouts instead of Maven Central artifacts.
 
 # CQL Engine (clinical_quality_language) - Gradle project root
-#cql.engine.path=../clinical_quality_language/Src/java
+#cql.engine.path=../clinical_quality_language


### PR DESCRIPTION
- Use CQL 5.3.0 (future release).
- The updated engine returns `evaluatedResources` as `Map<kotlin.String, Value>` (with resources keyed by their string IDs) instead of `Set<Value>` (see https://github.com/cqframework/clinical_quality_language/pull/1834). This structure is reused where applicable (e.g. in `MeasureEvaluator`) to avoid building hashes for the evaluated resources.
- Update docs and `local.properties.example` following CQL's [repo restructure](https://github.com/cqframework/clinical_quality_language/blob/main/docs/proposals/repo-restructure.md).