### PR TITLE
Feat: Surface all evaluated expressions as supporting evidence on subject MeasureReports

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/MeasureEvaluationOptions.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/MeasureEvaluationOptions.java
@@ -3,6 +3,7 @@ package org.opencds.cqf.fhir.cr.measure;
 import java.util.HashMap;
 import java.util.Map;
 import org.opencds.cqf.fhir.cql.EvaluationSettings;
+import org.opencds.cqf.fhir.cr.measure.common.SupportingEvidenceMode;
 import org.opencds.cqf.fhir.utility.ValidationProfile;
 
 public class MeasureEvaluationOptions {
@@ -19,6 +20,7 @@ public class MeasureEvaluationOptions {
 
     private boolean ensureSearchParameters = true;
     private EvaluationSettings evaluationSettings = null;
+    private SupportingEvidenceMode supportingEvidenceMode = SupportingEvidenceMode.DECLARED;
 
     public boolean isValidationEnabled() {
         return this.isValidationEnabled;
@@ -61,6 +63,15 @@ public class MeasureEvaluationOptions {
 
     public boolean getApplyScoringSetMembership() {
         return this.applyScoringSetMembership;
+    }
+
+    public MeasureEvaluationOptions setSupportingEvidenceMode(SupportingEvidenceMode supportingEvidenceMode) {
+        this.supportingEvidenceMode = supportingEvidenceMode;
+        return this;
+    }
+
+    public SupportingEvidenceMode getSupportingEvidenceMode() {
+        return this.supportingEvidenceMode;
     }
 
     public boolean isEnsureSearchParameters() {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/EvaluatedExpressionCollector.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/EvaluatedExpressionCollector.java
@@ -1,0 +1,94 @@
+package org.opencds.cqf.fhir.cr.measure.common;
+
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.EXT_SUPPORTING_EVIDENCE_URL;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Collects results of expressions the measure does not declare onto
+ * {@link MeasureDef#evaluatedExpressions()}, so every evaluated expression can surface as
+ * supporting evidence. Reads results the evaluation already produced; nothing is re-evaluated.
+ */
+public class EvaluatedExpressionCollector {
+
+    private EvaluatedExpressionCollector() {}
+
+    public static void collect(
+            MeasureDef measureDef,
+            Map<String, CqlEvaluationResult> evalResultsPerSubject,
+            MeasureEvalType measureEvalType,
+            SupportingEvidenceMode mode,
+            FhirVersionEnum fhirVersion) {
+
+        if (measureDef == null || evalResultsPerSubject == null || evalResultsPerSubject.isEmpty()) {
+            return;
+        }
+        if (mode != SupportingEvidenceMode.ALL_EXPRESSIONS || !isSubjectScoped(measureEvalType)) {
+            return;
+        }
+
+        Set<String> declared = declaredExpressions(measureDef);
+        Set<String> collected = new HashSet<>();
+        evalResultsPerSubject.forEach((subjectId, evalResult) -> {
+            if (evalResult != null) {
+                collectSubject(measureDef, subjectId, evalResult, declared, collected, fhirVersion);
+            }
+        });
+
+        measureDef.evaluatedExpressions().sort(Comparator.comparing(SupportingEvidenceDef::getName));
+    }
+
+    private static void collectSubject(
+            MeasureDef measureDef,
+            String subjectId,
+            CqlEvaluationResult evalResult,
+            Set<String> declared,
+            Set<String> collected,
+            FhirVersionEnum fhirVersion) {
+
+        for (CqlExpressionValue expressionValue : evalResult.getExpressionResults()) {
+            String name = expressionValue.expressionName();
+            if (name == null || name.isBlank() || declared.contains(name) || !collected.add(name)) {
+                continue;
+            }
+            // dedupe precedes the filter so the recursive value walk runs once per expression,
+            // not once per subject
+            if (!SupportingEvidenceValueFilter.isSupported(expressionValue.raw(), fhirVersion)) {
+                continue;
+            }
+            // description, language and code are author-supplied metadata with nothing to author from
+            var def = new SupportingEvidenceDef(name, EXT_SUPPORTING_EVIDENCE_URL, null, name, null, null);
+            def.addResource(subjectId, normalizeForEncoding(expressionValue.raw()));
+            measureDef.addEvaluatedExpression(def);
+        }
+    }
+
+    private static boolean isSubjectScoped(MeasureEvalType measureEvalType) {
+        return measureEvalType == MeasureEvalType.SUBJECT || measureEvalType == MeasureEvalType.PATIENT;
+    }
+
+    private static Set<String> declaredExpressions(MeasureDef measureDef) {
+        return measureDef.groups().stream()
+                .flatMap(group -> group.populations().stream())
+                .map(PopulationDef::getSupportingEvidenceDefs)
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
+                .map(SupportingEvidenceDef::getExpression)
+                .collect(Collectors.toSet());
+    }
+
+    /** Null stays null (encodes as a data-absent marker); scalars are wrapped to arrive like lists. */
+    private static Object normalizeForEncoding(Object raw) {
+        if (raw == null || raw instanceof Iterable<?>) {
+            return raw;
+        }
+        return List.of(raw);
+    }
+}

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/EvaluatedExpressionCollector.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/EvaluatedExpressionCollector.java
@@ -55,12 +55,13 @@ public class EvaluatedExpressionCollector {
 
         for (CqlExpressionValue expressionValue : evalResult.getExpressionResults()) {
             String name = expressionValue.expressionName();
-            if (name == null || name.isBlank() || declared.contains(name) || !collected.add(name)) {
-                continue;
-            }
-            // dedupe precedes the filter so the recursive value walk runs once per expression,
-            // not once per subject
-            if (!SupportingEvidenceValueFilter.isSupported(expressionValue.raw(), fhirVersion)) {
+            // The dedupe (collected.add) short-circuits ahead of the filter on purpose, so the
+            // recursive value walk runs once per expression rather than once per subject.
+            if (name == null
+                    || name.isBlank()
+                    || declared.contains(name)
+                    || !collected.add(name)
+                    || !SupportingEvidenceValueFilter.isSupported(expressionValue.raw(), fhirVersion)) {
                 continue;
             }
             // description, language and code are author-supplied metadata with nothing to author from

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureDef.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureDef.java
@@ -19,6 +19,8 @@ public class MeasureDef {
     private final List<SdeDef> sdes;
     private final List<String> errors;
 
+    private final List<SupportingEvidenceDef> evaluatedExpressions;
+
     public static MeasureDef fromIdAndUrl(IIdType idType, @Nullable String url) {
         return new MeasureDef(idType, url, null, List.of(), List.of());
     }
@@ -31,6 +33,7 @@ public class MeasureDef {
         this.sdes = sdes;
 
         this.errors = new ArrayList<>();
+        this.evaluatedExpressions = new ArrayList<>();
     }
 
     // This is the raw unqualified ID (ex: for "Measure/measure123", we return "measure123"
@@ -67,6 +70,14 @@ public class MeasureDef {
 
     public void addError(String error) {
         this.errors.add(error);
+    }
+
+    public List<SupportingEvidenceDef> evaluatedExpressions() {
+        return this.evaluatedExpressions;
+    }
+
+    public void addEvaluatedExpression(SupportingEvidenceDef evaluatedExpression) {
+        this.evaluatedExpressions.add(evaluatedExpression);
     }
 
     // We need to limit the contract of equality to id, url, and version only

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureDef.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureDef.java
@@ -106,6 +106,7 @@ public class MeasureDef {
                 .add("version='" + version + "'")
                 .add("groups=" + groups.size())
                 .add("sdes=" + sdes.size())
+                .add("evaluatedExpressions=" + evaluatedExpressions.size())
                 .add("errors=" + errors)
                 .toString();
     }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureEvaluationResultHandler.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/MeasureEvaluationResultHandler.java
@@ -80,6 +80,13 @@ public class MeasureEvaluationResultHandler {
             }
         }
 
+        EvaluatedExpressionCollector.collect(
+                measureDef,
+                evalResultsPerSubject,
+                measureEvalType,
+                measureEvaluationOptions.getSupportingEvidenceMode(),
+                fhirContext.getVersion().getVersion());
+
         MeasureMultiSubjectEvaluator.postEvaluationMultiSubject(fhirContext, measureDef);
 
         // Score all groups and stratifiers using version-agnostic scorer

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/SupportingEvidenceMode.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/SupportingEvidenceMode.java
@@ -1,0 +1,14 @@
+package org.opencds.cqf.fhir.cr.measure.common;
+
+/**
+ * How much supporting evidence a MeasureReport carries. Governs what reaches the report, not what
+ * the CQL engine evaluates.
+ */
+public enum SupportingEvidenceMode {
+    /** No supporting evidence is written, including evidence the measure declares. */
+    OFF,
+    /** Only evidence declared on a population through {@code cqf-supportingEvidenceDefinition}. */
+    DECLARED,
+    /** Declared evidence, plus one report-level entry per other evaluated expression. */
+    ALL_EXPRESSIONS
+}

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/SupportingEvidenceValueFilter.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/SupportingEvidenceValueFilter.java
@@ -1,0 +1,72 @@
+package org.opencds.cqf.fhir.cr.measure.common;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import jakarta.annotation.Nullable;
+import org.opencds.cqf.cql.engine.runtime.ClassInstance;
+import org.opencds.cqf.cql.engine.runtime.Interval;
+import org.opencds.cqf.cql.engine.runtime.Tuple;
+import org.opencds.cqf.cql.engine.runtime.Value;
+import org.opencds.cqf.fhir.cql.ClassInstanceHelper;
+
+/**
+ * Decides whether a CQL expression result is in scope to be surfaced as supporting evidence.
+ * Selection is per expression, not per leaf: a value containing anything out of scope takes the
+ * whole expression out.
+ */
+public final class SupportingEvidenceValueFilter {
+
+    private static final int MAX_DEPTH = 25;
+
+    private SupportingEvidenceValueFilter() {}
+
+    public static boolean isSupported(@Nullable Object value, FhirVersionEnum fhirVersion) {
+        return isSupported(value, fhirVersion, 0);
+    }
+
+    private static boolean isSupported(@Nullable Object value, FhirVersionEnum fhirVersion, int depth) {
+        if (depth > MAX_DEPTH) {
+            return false;
+        }
+
+        // null is representable: it encodes as a data-absent marker
+        if (value == null) {
+            return true;
+        }
+
+        // Anything that is not an engine value did not come from a top-level define, e.g. the
+        // accumulators FunctionEvaluationHandler merges into the per-subject results.
+        if (!(value instanceof Value cqlValue)) {
+            return false;
+        }
+
+        // FHIR resources encode as reference strings; FHIR elements have no reference form
+        if (cqlValue instanceof ClassInstance classInstance) {
+            return ClassInstanceHelper.isFhirResource(fhirVersion, classInstance);
+        }
+
+        if (cqlValue instanceof org.opencds.cqf.cql.engine.runtime.List list) {
+            for (Value element : list) {
+                if (!isSupported(element, fhirVersion, depth + 1)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        if (cqlValue instanceof Interval interval) {
+            return isSupported(interval.getLow(), fhirVersion, depth + 1)
+                    && isSupported(interval.getHigh(), fhirVersion, depth + 1);
+        }
+
+        if (cqlValue instanceof Tuple tuple) {
+            for (Value element : tuple.getElements().values()) {
+                if (!isSupported(element, fhirVersion, depth + 1)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        return true;
+    }
+}

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/SupportingEvidenceValueFilter.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/SupportingEvidenceValueFilter.java
@@ -45,12 +45,7 @@ public final class SupportingEvidenceValueFilter {
         }
 
         if (cqlValue instanceof org.opencds.cqf.cql.engine.runtime.List list) {
-            for (Value element : list) {
-                if (!isSupported(element, fhirVersion, depth + 1)) {
-                    return false;
-                }
-            }
-            return true;
+            return allSupported(list, fhirVersion, depth);
         }
 
         if (cqlValue instanceof Interval interval) {
@@ -59,14 +54,19 @@ public final class SupportingEvidenceValueFilter {
         }
 
         if (cqlValue instanceof Tuple tuple) {
-            for (Value element : tuple.getElements().values()) {
-                if (!isSupported(element, fhirVersion, depth + 1)) {
-                    return false;
-                }
-            }
-            return true;
+            return allSupported(tuple.getElements().values(), fhirVersion, depth);
         }
 
+        return true;
+    }
+
+    /** One element out of scope takes the whole container with it. */
+    private static boolean allSupported(Iterable<Value> elements, FhirVersionEnum fhirVersion, int depth) {
+        for (Value element : elements) {
+            if (!isSupported(element, fhirVersion, depth + 1)) {
+                return false;
+            }
+        }
         return true;
     }
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureProcessor.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureProcessor.java
@@ -39,6 +39,7 @@ import org.opencds.cqf.fhir.cr.measure.common.MeasureProcessorTimeUtils;
 import org.opencds.cqf.fhir.cr.measure.common.MeasureReference;
 import org.opencds.cqf.fhir.cr.measure.common.MeasureReportType;
 import org.opencds.cqf.fhir.cr.measure.common.MultiLibraryIdMeasureEngineDetails;
+import org.opencds.cqf.fhir.cr.measure.common.SupportingEvidenceMode;
 import org.opencds.cqf.fhir.cr.measure.r4.utils.R4DateHelper;
 import org.opencds.cqf.fhir.cr.measure.r4.utils.R4MeasureServiceUtils;
 import org.opencds.cqf.fhir.utility.search.Searches;
@@ -67,6 +68,10 @@ public class R4MeasureProcessor {
     // processor: this may be some sort of federated proxy repository initialized at runtime
     public IRepository getRepository() {
         return repository;
+    }
+
+    private SupportingEvidenceMode supportingEvidenceMode() {
+        return measureEvaluationOptions.getSupportingEvidenceMode();
     }
 
     public MeasureReport evaluateMeasure(
@@ -184,7 +189,7 @@ public class R4MeasureProcessor {
         measureEvaluationResultHandler.processResults(fhirContext, results, measureDef, evaluationType);
 
         // Build Measure Report with Results
-        MeasureReport measureReport = new R4MeasureReportBuilder()
+        MeasureReport measureReport = new R4MeasureReportBuilder(supportingEvidenceMode())
                 .build(
                         measure,
                         measureDef,
@@ -238,7 +243,7 @@ public class R4MeasureProcessor {
         var measurementPeriod = MeasureProcessorTimeUtils.getMeasurementPeriod(periodStart, periodEnd, context);
 
         // Build Measure Report with Results
-        MeasureReport measureReport = new R4MeasureReportBuilder()
+        MeasureReport measureReport = new R4MeasureReportBuilder(supportingEvidenceMode())
                 .build(
                         measure,
                         measureDef,

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportBuilder.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4MeasureReportBuilder.java
@@ -62,6 +62,7 @@ import org.opencds.cqf.fhir.cr.measure.common.StratifierDef;
 import org.opencds.cqf.fhir.cr.measure.common.StratumDef;
 import org.opencds.cqf.fhir.cr.measure.common.StratumPopulationDef;
 import org.opencds.cqf.fhir.cr.measure.common.StratumValueWrapper;
+import org.opencds.cqf.fhir.cr.measure.common.SupportingEvidenceMode;
 import org.opencds.cqf.fhir.cr.measure.constant.MeasureConstants;
 import org.opencds.cqf.fhir.cr.measure.r4.utils.R4DateHelper;
 import org.opencds.cqf.fhir.cr.measure.r4.utils.R4MeasureReportUtils;
@@ -72,6 +73,16 @@ public class R4MeasureReportBuilder implements MeasureReportBuilder<Measure, Mea
 
     private static final Logger logger = LoggerFactory.getLogger(R4MeasureReportBuilder.class);
     protected static final String POPULATION_SUBJECT_SET = "POPULATION_SUBJECT_SET";
+
+    private final SupportingEvidenceMode supportingEvidenceMode;
+
+    public R4MeasureReportBuilder() {
+        this(SupportingEvidenceMode.DECLARED);
+    }
+
+    public R4MeasureReportBuilder(SupportingEvidenceMode supportingEvidenceMode) {
+        this.supportingEvidenceMode = Objects.requireNonNull(supportingEvidenceMode);
+    }
 
     @Override
     public MeasureReport build(
@@ -93,6 +104,7 @@ public class R4MeasureReportBuilder implements MeasureReportBuilder<Measure, Mea
 
         addEvaluatedResource(bc);
         addSupplementalData(bc);
+        addEvaluatedExpressions(bc);
         bc.addOperationOutcomes();
 
         for (var r : bc.contained().values()) {
@@ -112,6 +124,13 @@ public class R4MeasureReportBuilder implements MeasureReportBuilder<Measure, Mea
                         .anyMatch(t -> t.getResourceType().equals(ResourceType.OperationOutcome))) {
             // Measure Reports that have encountered an error during evaluation will be set to status 'Error'
             bc.report().setStatus(MeasureReportStatus.ERROR);
+        }
+    }
+
+    private void addEvaluatedExpressions(R4MeasureReportBuilderContext bc) {
+        if (bc.report().getType().equals(MeasureReport.MeasureReportType.INDIVIDUAL)) {
+            R4SupportingEvidenceExtension.addSupportingEvidenceExtensions(
+                    bc.report(), bc.measureDef().evaluatedExpressions());
         }
     }
 
@@ -262,7 +281,8 @@ public class R4MeasureReportBuilder implements MeasureReportBuilder<Measure, Mea
         reportPopulation.setCount(populationDef.getCount());
 
         // Supporting Evidence
-        if (bc.report().getType().equals(MeasureReport.MeasureReportType.INDIVIDUAL)
+        if (supportingEvidenceMode != SupportingEvidenceMode.OFF
+                && bc.report().getType().equals(MeasureReport.MeasureReportType.INDIVIDUAL)
                 && populationDef.getSupportingEvidenceDefs() != null
                 && !populationDef.getSupportingEvidenceDefs().isEmpty()) {
             var extDefs = populationDef.getSupportingEvidenceDefs();

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4SupportingEvidenceExtension.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4SupportingEvidenceExtension.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.fhir.cr.measure.r4;
 
 import static org.opencds.cqf.fhir.cql.ClassInstanceHelper.convertToFhirR4;
+import static org.opencds.cqf.fhir.cql.ClassInstanceHelper.getId;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import jakarta.annotation.Nullable;
@@ -11,6 +12,7 @@ import java.util.Map;
 import java.util.Set;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.BooleanType;
+import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
@@ -20,9 +22,13 @@ import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.MeasureReport;
 import org.hl7.fhir.r4.model.Period;
 import org.hl7.fhir.r4.model.StringType;
+import org.opencds.cqf.cql.engine.fhir.converter.FhirTypeConverter;
+import org.opencds.cqf.cql.engine.fhir.converter.FhirTypeConverterFactory;
+import org.opencds.cqf.cql.engine.runtime.ClassInstance;
 import org.opencds.cqf.cql.engine.runtime.Interval;
 import org.opencds.cqf.cql.engine.runtime.Tuple;
 import org.opencds.cqf.cql.engine.runtime.Value;
+import org.opencds.cqf.cql.engine.runtime.Vocabulary;
 import org.opencds.cqf.fhir.cr.measure.common.CodeDef;
 import org.opencds.cqf.fhir.cr.measure.common.ConceptDef;
 import org.opencds.cqf.fhir.cr.measure.common.CqlExpressionValue;
@@ -37,6 +43,7 @@ import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
 public class R4SupportingEvidenceExtension {
 
     private static final R4DateHelper DATE_HELPER = new R4DateHelper();
+    private static final FhirTypeConverter TYPE_CONVERTER = new FhirTypeConverterFactory().create(FhirVersionEnum.R4);
     private static final int MAX_DEPTH = 25;
 
     // Primitive annotation URLs (match your examples)
@@ -60,16 +67,40 @@ public class R4SupportingEvidenceExtension {
             MeasureReport.MeasureReportGroupPopulationComponent reportPopulation,
             List<SupportingEvidenceDef> supportingEvidenceDefs) {
 
-        if (reportPopulation == null || supportingEvidenceDefs == null || supportingEvidenceDefs.isEmpty()) {
+        if (reportPopulation == null) {
             return;
         }
+        buildSupportingEvidenceExtensions(supportingEvidenceDefs).forEach(reportPopulation::addExtension);
+    }
 
+    /**
+     * Report-level variant, used for the entries synthesized for expressions the measure does not
+     * declare.
+     */
+    public static void addSupportingEvidenceExtensions(
+            MeasureReport report, List<SupportingEvidenceDef> supportingEvidenceDefs) {
+
+        if (report == null) {
+            return;
+        }
+        buildSupportingEvidenceExtensions(supportingEvidenceDefs).forEach(report::addExtension);
+    }
+
+    private static List<Extension> buildSupportingEvidenceExtensions(
+            List<SupportingEvidenceDef> supportingEvidenceDefs) {
+
+        if (supportingEvidenceDefs == null || supportingEvidenceDefs.isEmpty()) {
+            return List.of();
+        }
+
+        List<Extension> extensions = new ArrayList<>();
         for (SupportingEvidenceDef def : supportingEvidenceDefs) {
             Extension seExt = buildSupportingEvidenceExtension(def);
             if (seExt != null) {
-                reportPopulation.addExtension(seExt);
+                extensions.add(seExt);
             }
         }
+        return extensions;
     }
 
     private static Extension buildSupportingEvidenceExtension(SupportingEvidenceDef def) {
@@ -331,7 +362,8 @@ public class R4SupportingEvidenceExtension {
             return;
         }
 
-        // Interval<DateTime>/Interval<Date> -> Period
+        // Interval<DateTime>/Interval<Date> -> Period. Kept ahead of the delegating tail, which
+        // renders DateTime endpoints under a different offset; other intervals fall through.
         Interval interval = asInterval(leaf);
         if (interval != null) {
             Period p = tryBuildPeriod(interval);
@@ -339,7 +371,6 @@ public class R4SupportingEvidenceExtension {
                 valueExt.setValue(p); // valuePeriod
                 return;
             }
-            // non-date interval -> fall through
         }
 
         // Tuple -> represented as nested extensions under this "value"
@@ -359,6 +390,36 @@ public class R4SupportingEvidenceExtension {
         if (leaf instanceof org.opencds.cqf.cql.engine.runtime.Code cqlCode) {
             valueExt.setValue(new StringType(formatCqlCode(cqlCode)));
             return;
+        }
+
+        // R4 has no integer64; render the numeral as a string rather than a range-guarded integer
+        if (leaf instanceof org.opencds.cqf.cql.engine.runtime.Long cqlLong) {
+            valueExt.setValue(new StringType(String.valueOf(cqlLong.getValue())));
+            return;
+        }
+
+        // ValueSet/CodeSystem -> canonical reference, versioned when the library pins one
+        if (leaf instanceof Vocabulary vocabulary) {
+            valueExt.setValue(new CanonicalType(canonicalReference(vocabulary)));
+            return;
+        }
+
+        if (leaf instanceof ClassInstance classInstance) {
+            String reference = getId(classInstance);
+            if (reference != null) {
+                valueExt.setValue(new StringType(reference));
+                return;
+            }
+        }
+
+        // Remaining System types (Quantity, Ratio, Concept, Time, non-temporal Interval) delegate
+        // to the engine's converter; ClassInstance stays on the reference-string path below.
+        if (leaf instanceof Value cqlLeaf && !(leaf instanceof ClassInstance) && TYPE_CONVERTER.isCqlType(cqlLeaf)) {
+            var converted = TYPE_CONVERTER.toFhirType(cqlLeaf);
+            if (converted instanceof org.hl7.fhir.r4.model.Type fhirType) {
+                valueExt.setValue(fhirType);
+                return;
+            }
         }
 
         var value = leaf instanceof Value cqlValue ? convertToFhirR4(cqlValue) : leaf;
@@ -384,6 +445,14 @@ public class R4SupportingEvidenceExtension {
     private static String formatCqlCode(org.opencds.cqf.cql.engine.runtime.Code code) {
         return "Code { code: %s, system: %s, version: %s, display: %s }"
                 .formatted(code.getCode(), code.getSystem(), code.getVersion(), code.getDisplay());
+    }
+
+    private static String canonicalReference(Vocabulary vocabulary) {
+        String version = vocabulary.getVersion();
+        if (version == null || version.isBlank()) {
+            return vocabulary.getId();
+        }
+        return vocabulary.getId() + "|" + version;
     }
 
     private static Period tryBuildPeriod(Interval interval) {

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4SupportingEvidenceExtension.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/r4/R4SupportingEvidenceExtension.java
@@ -362,83 +362,100 @@ public class R4SupportingEvidenceExtension {
             return;
         }
 
+        // Tuple -> represented as nested extensions under this "value"
+        if (leaf instanceof Tuple tuple) {
+            encodeTupleIntoValue(valueExt, tuple);
+            return;
+        }
+
+        org.hl7.fhir.r4.model.Type specialized = specializedLeafValue(leaf);
+        valueExt.setValue(specialized != null ? specialized : genericLeafValue(leaf));
+    }
+
+    /** Tuple fields become repeated nested "value" slices under a per-field extension. */
+    private static void encodeTupleIntoValue(Extension valueExt, Tuple tuple) {
+        for (Map.Entry<String, Value> entry : tuple.getElements().entrySet()) {
+            Extension fieldExt = new Extension(entry.getKey());
+            addValues(fieldExt, entry.getValue());
+            valueExt.addExtension(fieldExt);
+        }
+    }
+
+    /**
+     * Leaf types carrying a representation of their own, ahead of the generic tail. Returns null
+     * when the leaf has no specialized form, which hands it to {@link #genericLeafValue(Object)}.
+     */
+    private static org.hl7.fhir.r4.model.Type specializedLeafValue(Object leaf) {
+
         // Interval<DateTime>/Interval<Date> -> Period. Kept ahead of the delegating tail, which
         // renders DateTime endpoints under a different offset; other intervals fall through.
         Interval interval = asInterval(leaf);
         if (interval != null) {
-            Period p = tryBuildPeriod(interval);
-            if (p != null) {
-                valueExt.setValue(p); // valuePeriod
-                return;
+            Period period = tryBuildPeriod(interval);
+            if (period != null) {
+                return period;
             }
-        }
-
-        // Tuple -> represented as nested extensions under this "value"
-        if (leaf instanceof Tuple tuple) {
-            for (Map.Entry<String, Value> entry : tuple.getElements().entrySet()) {
-                Extension fieldExt = new Extension(entry.getKey());
-                // field values become repeated nested "value" slices under the field extension
-                addValues(fieldExt, entry.getValue());
-                valueExt.addExtension(fieldExt);
-            }
-            return;
         }
 
         // CQL-5 changed Code.toString() to a quoted, multi-line form; render the stable single-line
         // representation the supporting-evidence string value has always carried. Handle this before
         // convertToFhirR4, which would coerce the Code into a bare CodeType losing system/display.
         if (leaf instanceof org.opencds.cqf.cql.engine.runtime.Code cqlCode) {
-            valueExt.setValue(new StringType(formatCqlCode(cqlCode)));
-            return;
+            return new StringType(formatCqlCode(cqlCode));
         }
 
         // R4 has no integer64; render the numeral as a string rather than a range-guarded integer
         if (leaf instanceof org.opencds.cqf.cql.engine.runtime.Long cqlLong) {
-            valueExt.setValue(new StringType(String.valueOf(cqlLong.getValue())));
-            return;
+            return new StringType(String.valueOf(cqlLong.getValue()));
         }
 
         // ValueSet/CodeSystem -> canonical reference, versioned when the library pins one
         if (leaf instanceof Vocabulary vocabulary) {
-            valueExt.setValue(new CanonicalType(canonicalReference(vocabulary)));
-            return;
+            return new CanonicalType(canonicalReference(vocabulary));
         }
 
         if (leaf instanceof ClassInstance classInstance) {
             String reference = getId(classInstance);
             if (reference != null) {
-                valueExt.setValue(new StringType(reference));
-                return;
+                return new StringType(reference);
             }
         }
 
-        // Remaining System types (Quantity, Ratio, Concept, Time, non-temporal Interval) delegate
-        // to the engine's converter; ClassInstance stays on the reference-string path below.
+        return engineConvertedValue(leaf);
+    }
+
+    /**
+     * Remaining System types (Quantity, Ratio, Concept, Time, non-temporal Interval) delegate to
+     * the engine's converter; ClassInstance stays on the reference-string path.
+     */
+    private static org.hl7.fhir.r4.model.Type engineConvertedValue(Object leaf) {
         if (leaf instanceof Value cqlLeaf && !(leaf instanceof ClassInstance) && TYPE_CONVERTER.isCqlType(cqlLeaf)) {
             var converted = TYPE_CONVERTER.toFhirType(cqlLeaf);
             if (converted instanceof org.hl7.fhir.r4.model.Type fhirType) {
-                valueExt.setValue(fhirType);
-                return;
+                return fhirType;
             }
         }
+        return null;
+    }
 
+    /** Scalars / resources / numeric, after handing anything CQL-native to the converter. */
+    private static org.hl7.fhir.r4.model.Type genericLeafValue(Object leaf) {
         var value = leaf instanceof Value cqlValue ? convertToFhirR4(cqlValue) : leaf;
 
-        // Scalars / resources / numeric
         if (value instanceof Boolean b) {
-            valueExt.setValue(new BooleanType(b));
+            return new BooleanType(b);
         } else if (value instanceof Integer i) {
-            valueExt.setValue(new IntegerType(i));
+            return new IntegerType(i);
         } else if (value instanceof BigDecimal bd) {
-            valueExt.setValue(new DecimalType(bd));
+            return new DecimalType(bd);
         } else if (value instanceof String s) {
-            valueExt.setValue(new StringType(s));
+            return new StringType(s);
         } else if (value instanceof IBaseResource r) {
-            valueExt.setValue(new StringType(resourceIdString(r)));
+            return new StringType(resourceIdString(r));
         } else if (value instanceof org.hl7.fhir.r4.model.Type t) {
-            valueExt.setValue(t);
+            return t;
         } else {
-            valueExt.setValue(new StringType(String.valueOf(leaf)));
+            return new StringType(String.valueOf(leaf));
         }
     }
 

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/Measure.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/Measure.java
@@ -28,6 +28,7 @@ import org.opencds.cqf.fhir.cr.measure.MeasureEvaluationOptions;
 import org.opencds.cqf.fhir.cr.measure.common.MeasureEnvironment;
 import org.opencds.cqf.fhir.cr.measure.common.MeasurePeriodValidator;
 import org.opencds.cqf.fhir.cr.measure.common.MeasureReference;
+import org.opencds.cqf.fhir.cr.measure.common.SupportingEvidenceMode;
 import org.opencds.cqf.fhir.cr.measure.r4.selected.def.SelectedMeasureDef;
 import org.opencds.cqf.fhir.cr.measure.r4.selected.report.SelectedMeasureReport;
 import org.opencds.cqf.fhir.cr.measure.r4.selected.report.SelectedMeasureReportContained;
@@ -139,6 +140,11 @@ public class Measure {
 
         public Given evaluationOptions(MeasureEvaluationOptions evaluationOptions) {
             this.evaluationOptions = evaluationOptions;
+            return this;
+        }
+
+        public Given supportingEvidenceMode(SupportingEvidenceMode supportingEvidenceMode) {
+            this.evaluationOptions.setSupportingEvidenceMode(supportingEvidenceMode);
             return this;
         }
 

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureAllExpressionSupportingEvidenceTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureAllExpressionSupportingEvidenceTest.java
@@ -2,6 +2,8 @@ package org.opencds.cqf.fhir.cr.measure.r4;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.EXT_SUPPORTING_EVIDENCE_URL;
 
@@ -17,6 +19,7 @@ import org.opencds.cqf.fhir.cr.measure.r4.Measure.Given;
  * Verifies that under {@link SupportingEvidenceMode#ALL_EXPRESSIONS} every evaluated expression
  * surfaces as supporting evidence from unmodified measures.
  */
+@SuppressWarnings({"java:S2699"})
 class MeasureAllExpressionSupportingEvidenceTest {
 
     private static final Given given =
@@ -107,8 +110,8 @@ class MeasureAllExpressionSupportingEvidenceTest {
         // The authored entry is untouched: still at population level, still carrying its metadata.
         assertEquals(1, populationEvidence.size());
         assertEquals(List.of("DenominatorResource"), evidenceNames(populationEvidence));
-        assertTrue(
-                populationEvidence.get(0).getExtensionByUrl("description") != null,
+        assertNotNull(
+                populationEvidence.get(0).getExtensionByUrl("description"),
                 "declared entry should keep its authored description");
 
         var reportNames = evidenceNames(reportLevelEvidence(report));
@@ -140,28 +143,29 @@ class MeasureAllExpressionSupportingEvidenceTest {
         var quantity = evidenceByName(report, "Quantity Value")
                 .getExtensionByUrl("value")
                 .getValue();
-        assertTrue(quantity instanceof org.hl7.fhir.r4.model.Quantity, () -> "was " + quantity.fhirType());
-        assertEquals(
-                "31.5", ((org.hl7.fhir.r4.model.Quantity) quantity).getValue().toPlainString());
+        var quantityValue =
+                assertInstanceOf(org.hl7.fhir.r4.model.Quantity.class, quantity, () -> "was " + quantity.fhirType());
+        assertEquals("31.5", quantityValue.getValue().toPlainString());
 
         var ratio =
                 evidenceByName(report, "Ratio Value").getExtensionByUrl("value").getValue();
-        assertTrue(ratio instanceof org.hl7.fhir.r4.model.Ratio, () -> "was " + ratio.fhirType());
+        assertInstanceOf(org.hl7.fhir.r4.model.Ratio.class, ratio, () -> "was " + ratio.fhirType());
 
         var concept = evidenceByName(report, "Concept Value")
                 .getExtensionByUrl("value")
                 .getValue();
-        assertTrue(concept instanceof org.hl7.fhir.r4.model.CodeableConcept, () -> "was " + concept.fhirType());
+        assertInstanceOf(org.hl7.fhir.r4.model.CodeableConcept.class, concept, () -> "was " + concept.fhirType());
 
         var range = evidenceByName(report, "Interval Quantity Value")
                 .getExtensionByUrl("value")
                 .getValue();
-        assertTrue(range instanceof org.hl7.fhir.r4.model.Range, () -> "was " + range.fhirType());
+        assertInstanceOf(org.hl7.fhir.r4.model.Range.class, range, () -> "was " + range.fhirType());
 
         // R4 has no integer64, so a Long renders as a string carrying the numeral.
         var longValue = evidenceByName(report, "Long Value").getExtensionByUrl("value");
-        assertTrue(
-                longValue.getValue() instanceof org.hl7.fhir.r4.model.StringType,
+        assertInstanceOf(
+                org.hl7.fhir.r4.model.StringType.class,
+                longValue.getValue(),
                 () -> "was " + longValue.getValue().fhirType());
         assertEquals("31", longValue.getValue().primitiveValue());
 

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureAllExpressionSupportingEvidenceTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureAllExpressionSupportingEvidenceTest.java
@@ -1,0 +1,274 @@
+package org.opencds.cqf.fhir.cr.measure.r4;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.EXT_SUPPORTING_EVIDENCE_URL;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.MeasureReport;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.cr.measure.common.SupportingEvidenceMode;
+import org.opencds.cqf.fhir.cr.measure.r4.Measure.Given;
+
+/**
+ * Verifies that under {@link SupportingEvidenceMode#ALL_EXPRESSIONS} every evaluated expression
+ * surfaces as supporting evidence from unmodified measures.
+ */
+class MeasureAllExpressionSupportingEvidenceTest {
+
+    private static final Given given =
+            Measure.given().repositoryFor("MeasureTest").supportingEvidenceMode(SupportingEvidenceMode.ALL_EXPRESSIONS);
+
+    private static Given givenMode(SupportingEvidenceMode mode) {
+        return Measure.given().repositoryFor("MeasureTest").supportingEvidenceMode(mode);
+    }
+
+    private static List<Extension> populationLevelEvidence(MeasureReport report) {
+        return report.getGroupFirstRep().getPopulationFirstRep().getExtension().stream()
+                .filter(e -> EXT_SUPPORTING_EVIDENCE_URL.equals(e.getUrl()))
+                .toList();
+    }
+
+    private static List<Extension> reportLevelEvidence(MeasureReport report) {
+        return report.getExtension().stream()
+                .filter(e -> EXT_SUPPORTING_EVIDENCE_URL.equals(e.getUrl()))
+                .toList();
+    }
+
+    private static List<String> evidenceNames(List<Extension> evidence) {
+        return evidence.stream()
+                .map(e -> e.getExtensionByUrl("name").getValue().primitiveValue())
+                .toList();
+    }
+
+    private static Extension evidenceByName(MeasureReport report, String name) {
+        return reportLevelEvidence(report).stream()
+                .filter(e -> name.equals(e.getExtensionByUrl("name").getValue().primitiveValue()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No report-level evidence named '%s'. Present: %s"
+                        .formatted(name, evidenceNames(reportLevelEvidence(report)))));
+    }
+
+    private static String valueOf(Extension evidence) {
+        return evidence.getExtension().stream()
+                .filter(e -> "value".equals(e.getUrl()))
+                .map(e -> e.getValue() == null ? "(no value)" : e.getValue().primitiveValue())
+                .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Verifies a measure that declares no supporting evidence still yields report-level evidence.
+     */
+    @Test
+    void measureWithNoDeclaredEvidenceProducesReportLevelEvidence() {
+        MeasureReport report = given.when()
+                .measureId("CohortBooleanAllPopulations")
+                .subject("patient-9")
+                .evaluate()
+                .then()
+                .measureReport();
+
+        var evidence = reportLevelEvidence(report);
+        var names = evidenceNames(evidence);
+
+        assertFalse(evidence.isEmpty(), "expected report-level evidence from an undeclared measure");
+
+        // Expressions the measure never references, surfaced without touching its definition.
+        assertTrue(names.contains("test tuple"), names::toString);
+        assertTrue(names.contains("TestIntervalList"), names::toString);
+        assertTrue(names.contains("Patient Age Bracket"), names::toString);
+
+        // Resource-valued expressions surface as reference strings.
+        assertTrue(names.contains("All Encounters"), names::toString);
+        assertTrue(names.contains("PatientRes"), names::toString);
+        assertEquals("Patient/patient-9", valueOf(evidenceByName(report, "PatientRes")));
+
+        // Every name appears once, and each entry carries its name slice.
+        assertEquals(names.size(), names.stream().distinct().count(), names::toString);
+    }
+
+    /**
+     * Verifies declared evidence stays at population level and is not repeated at report level.
+     */
+    @Test
+    void measureWithDeclaredSubsetKeepsItAtPopulationLevelAndAddsTheRest() {
+        MeasureReport report = given.when()
+                .measureId("CohortBooleanSupportingEvidence")
+                .subject("patient-9")
+                .evaluate()
+                .then()
+                .measureReport();
+
+        var populationEvidence = populationLevelEvidence(report);
+
+        // The authored entry is untouched: still at population level, still carrying its metadata.
+        assertEquals(1, populationEvidence.size());
+        assertEquals(List.of("DenominatorResource"), evidenceNames(populationEvidence));
+        assertTrue(
+                populationEvidence.get(0).getExtensionByUrl("description") != null,
+                "declared entry should keep its authored description");
+
+        var reportNames = evidenceNames(reportLevelEvidence(report));
+
+        // The declared expression is not repeated at report level.
+        assertFalse(reportNames.contains("Denominator Resource"), reportNames::toString);
+        assertFalse(reportNames.contains("DenominatorResource"), reportNames::toString);
+
+        // Undeclared expressions are surfaced alongside it.
+        assertTrue(reportNames.contains("test tuple"), reportNames::toString);
+        assertTrue(reportNames.contains("always true"), reportNames::toString);
+    }
+
+    /**
+     * Verifies previously unencodable types encode at report level, and Time is valid FHIR.
+     */
+    @Test
+    void previouslyUnencodableTypesAreEncodedAtReportLevel() {
+        MeasureReport report = given.when()
+                .measureId("SupportingEvidenceUndeclared")
+                .subject("patient-9")
+                .evaluate()
+                .then()
+                .measureReport();
+
+        assertEquals("14:30:00", valueOf(evidenceByName(report, "Time Value")));
+        assertEquals("08:00:00, 14:30:00", valueOf(evidenceByName(report, "List Time Value")));
+
+        var quantity = evidenceByName(report, "Quantity Value")
+                .getExtensionByUrl("value")
+                .getValue();
+        assertTrue(quantity instanceof org.hl7.fhir.r4.model.Quantity, () -> "was " + quantity.fhirType());
+        assertEquals(
+                "31.5", ((org.hl7.fhir.r4.model.Quantity) quantity).getValue().toPlainString());
+
+        var ratio =
+                evidenceByName(report, "Ratio Value").getExtensionByUrl("value").getValue();
+        assertTrue(ratio instanceof org.hl7.fhir.r4.model.Ratio, () -> "was " + ratio.fhirType());
+
+        var concept = evidenceByName(report, "Concept Value")
+                .getExtensionByUrl("value")
+                .getValue();
+        assertTrue(concept instanceof org.hl7.fhir.r4.model.CodeableConcept, () -> "was " + concept.fhirType());
+
+        var range = evidenceByName(report, "Interval Quantity Value")
+                .getExtensionByUrl("value")
+                .getValue();
+        assertTrue(range instanceof org.hl7.fhir.r4.model.Range, () -> "was " + range.fhirType());
+
+        // R4 has no integer64, so a Long renders as a string carrying the numeral.
+        var longValue = evidenceByName(report, "Long Value").getExtensionByUrl("value");
+        assertTrue(
+                longValue.getValue() instanceof org.hl7.fhir.r4.model.StringType,
+                () -> "was " + longValue.getValue().fhirType());
+        assertEquals("31", longValue.getValue().primitiveValue());
+
+        // ValueSet results render as canonical references, versioned when the library pins one.
+        var valueSet = evidenceByName(report, "ValueSet Value").getExtensionByUrl("value");
+        assertTrue(
+                valueSet.getValue() instanceof org.hl7.fhir.r4.model.CanonicalType,
+                () -> "was " + valueSet.getValue().fhirType());
+        assertEquals(
+                "http://example.org/ValueSet/example-conditions",
+                valueSet.getValue().primitiveValue());
+        assertEquals(
+                "http://example.org/ValueSet/example-conditions-versioned|1.0",
+                valueOf(evidenceByName(report, "Versioned ValueSet Value")));
+
+        // The engine has no visitCodeSystemRef, so a CodeSystem-typed define evaluates to null
+        // and surfaces as the data-absent marker instead of a canonical reference.
+        var codeSystem = evidenceByName(report, "CodeSystem Value").getExtensionByUrl("value");
+        assertTrue(codeSystem.getValue().hasExtension("http://hl7.org/fhir/StructureDefinition/data-absent-reason"));
+
+        // Resource-valued expressions surface as reference strings.
+        assertEquals("Patient/patient-9", valueOf(evidenceByName(report, "Resource List Value")));
+        assertEquals("Patient/patient-9", valueOf(evidenceByName(report, "Single Resource Value")));
+    }
+
+    /**
+     * Verifies the default DECLARED mode emits declared evidence only, as shipped.
+     */
+    @Test
+    void declaredModeEmitsOnlyDeclaredEvidence() {
+        MeasureReport report = givenMode(SupportingEvidenceMode.DECLARED)
+                .when()
+                .measureId("CohortBooleanSupportingEvidence")
+                .subject("patient-9")
+                .evaluate()
+                .then()
+                .measureReport();
+
+        assertEquals(List.of("DenominatorResource"), evidenceNames(populationLevelEvidence(report)));
+        assertTrue(reportLevelEvidence(report).isEmpty(), "DECLARED must not add report-level evidence");
+    }
+
+    /**
+     * Verifies OFF suppresses declared evidence as well as report-level evidence.
+     */
+    @Test
+    void offModeEmitsNoEvidenceAnywhere() {
+        MeasureReport report = givenMode(SupportingEvidenceMode.OFF)
+                .when()
+                .measureId("CohortBooleanSupportingEvidence")
+                .subject("patient-9")
+                .evaluate()
+                .then()
+                .measureReport();
+
+        assertTrue(populationLevelEvidence(report).isEmpty(), "OFF must suppress declared evidence");
+        assertTrue(reportLevelEvidence(report).isEmpty(), "OFF must suppress report-level evidence");
+    }
+
+    /**
+     * Verifies collection is visible on MeasureDef, independently of report building.
+     */
+    @Test
+    void evaluatedExpressionsAreVisibleOnMeasureDef() {
+        given.when()
+                .measureId("CohortBooleanSupportingEvidence")
+                .subject("patient-9")
+                .evaluate()
+                .then()
+                .def()
+                .hasNoErrors()
+                // Collected: evaluated, in scope, not declared.
+                .hasEvaluatedExpression("test tuple")
+                .hasEvaluatedExpression("always true")
+                // Resource-valued, collected as evidence alongside the rest.
+                .hasEvaluatedExpression("All Encounters")
+                // Declared on a population, so left to the population-level slice.
+                .hasNoEvaluatedExpression("Denominator Resource");
+    }
+
+    /**
+     * Verifies nothing is collected onto MeasureDef unless the mode enables it.
+     */
+    @Test
+    void declaredModeCollectsNothingOntoMeasureDef() {
+        givenMode(SupportingEvidenceMode.DECLARED)
+                .when()
+                .measureId("CohortBooleanSupportingEvidence")
+                .subject("patient-9")
+                .evaluate()
+                .then()
+                .def()
+                .hasNoEvaluatedExpressions();
+    }
+
+    /**
+     * Verifies summary reports carry no report-level evidence in any mode.
+     */
+    @Test
+    void summaryReportsCarryNoEvidenceInAnyMode() {
+        MeasureReport report = given.when()
+                .measureId("CohortBooleanSupportingEvidence")
+                .evaluate()
+                .then()
+                .measureReport();
+
+        assertEquals(MeasureReport.MeasureReportType.SUMMARY, report.getType());
+        assertTrue(reportLevelEvidence(report).isEmpty(), "summary reports must carry no evidence");
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureSupportingEvidenceTypeEncodingTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureSupportingEvidenceTypeEncodingTest.java
@@ -12,6 +12,7 @@ import org.opencds.cqf.fhir.cr.measure.r4.selected.report.SelectedMeasureReportP
  * Concept, non-temporal Interval). Each previously-failing type is declared on its own measure so
  * a single regression cannot mask the others.
  */
+@SuppressWarnings({"java:S2699"})
 class MeasureSupportingEvidenceTypeEncodingTest {
 
     private static final Given given = Measure.given().repositoryFor("MeasureTest");

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureSupportingEvidenceTypeEncodingTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MeasureSupportingEvidenceTypeEncodingTest.java
@@ -1,0 +1,92 @@
+package org.opencds.cqf.fhir.cr.measure.r4;
+
+import org.hl7.fhir.r4.model.MeasureReport.MeasureReportStatus;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.cr.measure.common.MeasurePopulationType;
+import org.opencds.cqf.fhir.cr.measure.r4.Measure.Given;
+import org.opencds.cqf.fhir.cr.measure.r4.selected.report.SelectedMeasureReportPopulation;
+
+/**
+ * Verifies the declared supporting-evidence path encodes every CQL System type, including the
+ * types that previously failed the whole $evaluate-measure operation (Long, Quantity, Ratio,
+ * Concept, non-temporal Interval). Each previously-failing type is declared on its own measure so
+ * a single regression cannot mask the others.
+ */
+class MeasureSupportingEvidenceTypeEncodingTest {
+
+    private static final Given given = Measure.given().repositoryFor("MeasureTest");
+
+    private static SelectedMeasureReportPopulation initialPopulation(String measureId) {
+        return given.when()
+                .measureId(measureId)
+                .subject("patient-9")
+                .evaluate()
+                .then()
+                .report()
+                .hasStatus(MeasureReportStatus.COMPLETE)
+                .firstGroup()
+                .population(MeasurePopulationType.INITIALPOPULATION);
+    }
+
+    @Test
+    void longEncodesAsString() {
+        initialPopulation("SupportingEvidenceTypeLong")
+                .getPopulationExtension("LongValue")
+                .hasStringValue("31");
+    }
+
+    @Test
+    void quantityEncodesAsQuantity() {
+        initialPopulation("SupportingEvidenceTypeQuantity")
+                .getPopulationExtension("QuantityValue")
+                .hasQuantityValue(31.5, "mg");
+    }
+
+    @Test
+    void ratioEncodesAsRatio() {
+        initialPopulation("SupportingEvidenceTypeRatio")
+                .getPopulationExtension("RatioValue")
+                .hasRatioValue(1, 2);
+    }
+
+    @Test
+    void conceptEncodesAsCodeableConcept() {
+        initialPopulation("SupportingEvidenceTypeConcept")
+                .getPopulationExtension("ConceptValue")
+                .hasCodeableConceptValue("http://hl7.org/fhir/v3/AdministrativeGender", "M");
+    }
+
+    @Test
+    void integerIntervalEncodesAsCqlText() {
+        initialPopulation("SupportingEvidenceTypeIntervalInteger")
+                .getPopulationExtension("IntervalIntegerValue")
+                .hasStringValue("Interval[1, 10]");
+    }
+
+    @Test
+    void quantityIntervalEncodesAsRange() {
+        initialPopulation("SupportingEvidenceTypeIntervalQuantity")
+                .getPopulationExtension("IntervalQuantityValue")
+                .hasRangeValue(1, 10);
+    }
+
+    /**
+     * A measure declaring the full type domain evaluates to a COMPLETE report, and the encodings
+     * with shipped behaviour keep their shape: Time is valid FHIR (not the CQL literal), Code
+     * keeps its string form.
+     */
+    @Test
+    void allTypesDeclaredTogetherProduceACompleteReport() {
+        var population = initialPopulation("SupportingEvidenceAllTypes");
+
+        population.getPopulationExtension("TimeValue").hasTimeValue("14:30:00");
+        population
+                .getPopulationExtension("CodeValue")
+                .hasStringValue(
+                        "Code { code: M, system: http://hl7.org/fhir/v3/AdministrativeGender, version: null, display: Male }");
+        population.getPopulationExtension("DateValue").hasStringValue("2026-01-01");
+        population.getPopulationExtension("NullValue").hasNullResult();
+        population.getPopulationExtension("EmptyListValue").hasEmptyListResult();
+        population.getPopulationExtension("SingleResourceValue").hasResourceIdValue("Patient/patient-9");
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasure.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasure.java
@@ -50,6 +50,7 @@ import org.opencds.cqf.fhir.cr.measure.common.MeasureEnvironment;
 import org.opencds.cqf.fhir.cr.measure.common.MeasurePeriodValidator;
 import org.opencds.cqf.fhir.cr.measure.common.MeasurePopulationType;
 import org.opencds.cqf.fhir.cr.measure.common.MeasureReference;
+import org.opencds.cqf.fhir.cr.measure.common.SupportingEvidenceMode;
 import org.opencds.cqf.fhir.cr.measure.constant.MeasureConstants;
 import org.opencds.cqf.fhir.cr.measure.r4.selected.def.SelectedMeasureDefCollection;
 import org.opencds.cqf.fhir.utility.BundleHelper;
@@ -142,6 +143,11 @@ class MultiMeasure {
 
         public MultiMeasure.Given evaluationOptions(MeasureEvaluationOptions evaluationOptions) {
             this.evaluationOptions = evaluationOptions;
+            return this;
+        }
+
+        public MultiMeasure.Given supportingEvidenceMode(SupportingEvidenceMode supportingEvidenceMode) {
+            this.evaluationOptions.setSupportingEvidenceMode(supportingEvidenceMode);
             return this;
         }
 

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasureAllExpressionSupportingEvidenceTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/MultiMeasureAllExpressionSupportingEvidenceTest.java
@@ -1,0 +1,138 @@
+package org.opencds.cqf.fhir.cr.measure.r4;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opencds.cqf.fhir.cr.measure.constant.MeasureReportConstants.EXT_SUPPORTING_EVIDENCE_URL;
+
+import java.util.List;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.MeasureReport;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.fhir.cr.measure.common.SupportingEvidenceMode;
+import org.opencds.cqf.fhir.cr.measure.r4.MultiMeasure.Given;
+
+/**
+ * Verifies {@link SupportingEvidenceMode} over the multi-measure path, where several measures share
+ * one evaluation and one CQL engine.
+ *
+ * <p>The single-measure tests already reach the same per-measure plumbing with a one-element
+ * measure list, so what is specific here is breadth rather than a separate code path: multiple
+ * measures plus subject mode is the only combination routed to
+ * {@code R4MultiMeasureService.subjectReport}, and the only case where
+ * {@code CompositeEvaluationResultsPerMeasure} carries more than one measure's results. A report
+ * picking up a sibling measure's expressions can therefore only surface here.
+ */
+@SuppressWarnings({"java:S2699"})
+class MultiMeasureAllExpressionSupportingEvidenceTest {
+
+    private static final String COHORT_URL = "http://example.com/Measure/CohortBooleanSupportingEvidence";
+    private static final String UNDECLARED_URL = "http://example.com/Measure/SupportingEvidenceUndeclared";
+
+    private static Given givenMode(SupportingEvidenceMode mode) {
+        return MultiMeasure.given().repositoryFor("MeasureTest").supportingEvidenceMode(mode);
+    }
+
+    private static List<Extension> reportLevelEvidence(MeasureReport report) {
+        return report.getExtension().stream()
+                .filter(e -> EXT_SUPPORTING_EVIDENCE_URL.equals(e.getUrl()))
+                .toList();
+    }
+
+    private static List<String> evidenceNames(MeasureReport report) {
+        return reportLevelEvidence(report).stream()
+                .map(e -> e.getExtensionByUrl("name").getValue().primitiveValue())
+                .toList();
+    }
+
+    /**
+     * Both measures are evaluated in a single call under ALL_EXPRESSIONS. Each report must carry
+     * its own expressions and none of its sibling's, which is what distinguishes a per-measure
+     * evidence collection from one accumulated across the batch.
+     */
+    @Test
+    void allExpressionsReachesEveryMeasureInTheBatch() {
+        var then = givenMode(SupportingEvidenceMode.ALL_EXPRESSIONS)
+                .when()
+                .measureId("CohortBooleanSupportingEvidence")
+                .measureId("SupportingEvidenceUndeclared")
+                .reportType("subject")
+                .subject("patient-9")
+                .evaluate()
+                .then();
+
+        // One subject, so one bundle carrying one report per measure.
+        then.hasBundleCount(1).hasMeasureReportCount(2);
+
+        var cohortNames = evidenceNames(then.measureReport(COHORT_URL).measureReport());
+        var undeclaredNames = evidenceNames(then.measureReport(UNDECLARED_URL).measureReport());
+
+        assertFalse(cohortNames.isEmpty(), "cohort measure should carry report-level evidence");
+        assertFalse(undeclaredNames.isEmpty(), "undeclared measure should carry report-level evidence");
+
+        assertTrue(cohortNames.contains("test tuple"), cohortNames::toString);
+        assertTrue(cohortNames.contains("always true"), cohortNames::toString);
+
+        assertTrue(undeclaredNames.contains("Time Value"), undeclaredNames::toString);
+        assertTrue(undeclaredNames.contains("Quantity Value"), undeclaredNames::toString);
+
+        // Neither report may pick up the other's expressions.
+        assertFalse(cohortNames.contains("Time Value"), cohortNames::toString);
+        assertFalse(cohortNames.contains("Quantity Value"), cohortNames::toString);
+        assertFalse(undeclaredNames.contains("test tuple"), undeclaredNames::toString);
+        assertFalse(undeclaredNames.contains("always true"), undeclaredNames::toString);
+    }
+
+    /**
+     * The collector gates on {@code mode != ALL_EXPRESSIONS || !isSubjectScoped(evalType)}. The
+     * subject-mode tests cover the first half of that guard; this covers the second, on the
+     * multi-measure population branch, where report-level evidence stays off whatever the mode.
+     */
+    @Test
+    void allExpressionsAddsNoReportLevelEvidenceToPopulationReports() {
+        var then = givenMode(SupportingEvidenceMode.ALL_EXPRESSIONS)
+                .when()
+                .measureId("CohortBooleanSupportingEvidence")
+                .measureId("SupportingEvidenceUndeclared")
+                .reportType("population")
+                .evaluate()
+                .then();
+
+        // Population mode yields one bundle holding a report per measure.
+        then.hasBundleCount(1).hasMeasureReportCount(2);
+
+        assertEquals(
+                List.of(),
+                evidenceNames(then.measureReport(COHORT_URL).measureReport()),
+                "population reports are not subject-scoped, so they carry no report-level evidence");
+        assertEquals(
+                List.of(),
+                evidenceNames(then.measureReport(UNDECLARED_URL).measureReport()),
+                "population reports are not subject-scoped, so they carry no report-level evidence");
+    }
+
+    /**
+     * The default mode must not start emitting report-level evidence just because the evaluation
+     * runs through the multi-measure path.
+     */
+    @Test
+    void declaredModeAddsNoReportLevelEvidenceInTheBatch() {
+        var then = givenMode(SupportingEvidenceMode.DECLARED)
+                .when()
+                .measureId("CohortBooleanSupportingEvidence")
+                .measureId("SupportingEvidenceUndeclared")
+                .reportType("subject")
+                .subject("patient-9")
+                .evaluate()
+                .then();
+
+        assertEquals(
+                List.of(),
+                evidenceNames(then.measureReport(COHORT_URL).measureReport()),
+                "DECLARED must leave the cohort report free of report-level evidence");
+        assertEquals(
+                List.of(),
+                evidenceNames(then.measureReport(UNDECLARED_URL).measureReport()),
+                "DECLARED must leave the undeclared report free of report-level evidence");
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/selected/def/SelectedMeasureDef.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/selected/def/SelectedMeasureDef.java
@@ -5,11 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.Map;
 import org.opencds.cqf.fhir.cr.measure.common.CqlEvaluationResult;
 import org.opencds.cqf.fhir.cr.measure.common.EvaluationResultFormatter;
 import org.opencds.cqf.fhir.cr.measure.common.GroupDef;
 import org.opencds.cqf.fhir.cr.measure.common.MeasureDef;
+import org.opencds.cqf.fhir.cr.measure.common.SupportingEvidenceDef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -166,6 +168,47 @@ public class SelectedMeasureDef<P> extends org.opencds.cqf.fhir.cr.measure.r4.Me
         assertNotNull(value(), "MeasureDef is null");
         assertTrue(value().errors().isEmpty(), "Expected no errors, but found: " + value().errors());
         return this;
+    }
+
+    /**
+     * Assert an expression was collected as evidence without the measure declaring it.
+     *
+     * @param expression the CQL expression name
+     */
+    public SelectedMeasureDef<P> hasEvaluatedExpression(String expression) {
+        assertNotNull(value(), "MeasureDef is null");
+        assertTrue(
+                evaluatedExpressionNames().contains(expression),
+                "Expected evaluated expression '" + expression + "', but found: " + evaluatedExpressionNames());
+        return this;
+    }
+
+    /**
+     * Assert an expression was not collected, whether because it is declared, out of scope, or
+     * the mode did not enable collection.
+     *
+     * @param expression the CQL expression name
+     */
+    public SelectedMeasureDef<P> hasNoEvaluatedExpression(String expression) {
+        assertNotNull(value(), "MeasureDef is null");
+        assertFalse(
+                evaluatedExpressionNames().contains(expression),
+                "Expected no evaluated expression '" + expression + "', but found it");
+        return this;
+    }
+
+    public SelectedMeasureDef<P> hasNoEvaluatedExpressions() {
+        assertNotNull(value(), "MeasureDef is null");
+        assertTrue(
+                value().evaluatedExpressions().isEmpty(),
+                "Expected no evaluated expressions, but found: " + evaluatedExpressionNames());
+        return this;
+    }
+
+    private List<String> evaluatedExpressionNames() {
+        return value().evaluatedExpressions().stream()
+                .map(SupportingEvidenceDef::getExpression)
+                .toList();
     }
 
     /**

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/selected/report/SelectedMeasureReportPopulationExt.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/r4/selected/report/SelectedMeasureReportPopulationExt.java
@@ -15,7 +15,11 @@ import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.Period;
 import org.hl7.fhir.r4.model.PrimitiveType;
+import org.hl7.fhir.r4.model.Quantity;
+import org.hl7.fhir.r4.model.Range;
+import org.hl7.fhir.r4.model.Ratio;
 import org.hl7.fhir.r4.model.StringType;
+import org.hl7.fhir.r4.model.TimeType;
 import org.opencds.cqf.fhir.cr.measure.r4.Measure.Selected;
 
 public class SelectedMeasureReportPopulationExt extends Selected<Extension, SelectedMeasureReportPopulation> {
@@ -204,6 +208,86 @@ public class SelectedMeasureReportPopulationExt extends Selected<Extension, Sele
 
         assertEquals(expectedEnd.toInstant(), actual.getEnd().toInstant(), "Period.end mismatch");
 
+        return this;
+    }
+
+    public SelectedMeasureReportPopulationExt hasTimeValue(String expected) {
+        String actual = valueSlices().stream()
+                .map(Extension::getValue)
+                .filter(TimeType.class::isInstance)
+                .map(TimeType.class::cast)
+                .map(TimeType::getValue)
+                .findFirst()
+                .orElse(null);
+
+        assertEquals(expected, actual, "Time value mismatch");
+        return this;
+    }
+
+    public SelectedMeasureReportPopulationExt hasQuantityValue(double expectedValue, String expectedUnit) {
+        Quantity actual = valueSlices().stream()
+                .map(Extension::getValue)
+                .filter(Quantity.class::isInstance)
+                .map(Quantity.class::cast)
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(actual, "Expected quantity value but none was found");
+        assertEquals(0, BigDecimal.valueOf(expectedValue).compareTo(actual.getValue()), "Quantity value mismatch");
+        assertEquals(expectedUnit, actual.getUnit(), "Quantity unit mismatch");
+        return this;
+    }
+
+    public SelectedMeasureReportPopulationExt hasRatioValue(double expectedNumerator, double expectedDenominator) {
+        Ratio actual = valueSlices().stream()
+                .map(Extension::getValue)
+                .filter(Ratio.class::isInstance)
+                .map(Ratio.class::cast)
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(actual, "Expected ratio value but none was found");
+        assertEquals(
+                0,
+                BigDecimal.valueOf(expectedNumerator)
+                        .compareTo(actual.getNumerator().getValue()),
+                "Ratio numerator mismatch");
+        assertEquals(
+                0,
+                BigDecimal.valueOf(expectedDenominator)
+                        .compareTo(actual.getDenominator().getValue()),
+                "Ratio denominator mismatch");
+        return this;
+    }
+
+    public SelectedMeasureReportPopulationExt hasRangeValue(double expectedLow, double expectedHigh) {
+        Range actual = valueSlices().stream()
+                .map(Extension::getValue)
+                .filter(Range.class::isInstance)
+                .map(Range.class::cast)
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(actual, "Expected range value but none was found");
+        assertEquals(
+                0, BigDecimal.valueOf(expectedLow).compareTo(actual.getLow().getValue()), "Range low mismatch");
+        assertEquals(
+                0, BigDecimal.valueOf(expectedHigh).compareTo(actual.getHigh().getValue()), "Range high mismatch");
+        return this;
+    }
+
+    public SelectedMeasureReportPopulationExt hasCodeableConceptValue(String expectedSystem, String expectedCode) {
+        CodeableConcept actual = valueSlices().stream()
+                .map(Extension::getValue)
+                .filter(CodeableConcept.class::isInstance)
+                .map(CodeableConcept.class::cast)
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(actual, "Expected codeableConcept value but none was found");
+        boolean found = actual.getCoding().stream()
+                .anyMatch(c -> expectedSystem.equals(c.getSystem()) && expectedCode.equals(c.getCode()));
+        assertTrue(found, "CodeableConcept missing coding: system=" + expectedSystem + " code=" + expectedCode);
         return this;
     }
 

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/cql/SupportingEvidenceTypes.cql
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/cql/SupportingEvidenceTypes.cql
@@ -1,0 +1,101 @@
+library SupportingEvidenceTypes
+
+using FHIR version '4.0.1'
+
+codesystem "Example CodeSystem": 'http://example.org/CodeSystem/example' version '2.1'
+valueset "Example ValueSet": 'http://example.org/ValueSet/example-conditions'
+valueset "Versioned ValueSet": 'http://example.org/ValueSet/example-conditions-versioned' version '1.0'
+
+parameter "Measurement Period" Interval<DateTime> default Interval[@2024-01-01T00:00:00, @2024-12-31T23:59:59]
+
+context Patient
+
+define "Initial Population":
+  true
+
+// One define per CQL System type, values chosen to make the serialized form unambiguous.
+
+define "Boolean Value":
+  true
+
+define "Integer Value":
+  31
+
+define "Long Value":
+  31L
+
+define "Decimal Value":
+  31.31
+
+define "String Value":
+  'string test'
+
+define "Date Value":
+  @2026-01-01
+
+define "DateTime Value":
+  @2026-12-30T23:59:59
+
+define "Time Value":
+  @T14:30:00
+
+define "Quantity Value":
+  31.5 'mg'
+
+define "Ratio Value":
+  1 'mg' : 2 'mg'
+
+define "Code Value":
+  Code { code: 'M', system: 'http://hl7.org/fhir/v3/AdministrativeGender', display: 'Male' }
+
+define "Concept Value":
+  Concept {
+    codes: { Code { code: 'M', system: 'http://hl7.org/fhir/v3/AdministrativeGender', display: 'Male' } },
+    display: 'Male concept'
+  }
+
+define "Interval Date Value":
+  Interval[@2024-01-01, @2024-12-31]
+
+define "Interval DateTime Value":
+  Interval[@2024-01-01T00:00:00, @2024-12-31T23:59:59]
+
+define "Interval Integer Value":
+  Interval[1, 10]
+
+define "Interval Quantity Value":
+  Interval[1 'mg', 10 'mg']
+
+define "Tuple Value":
+  Tuple { number: 31, text: 'string test', nestedDates: { @2024-01-01, @2024-01-02 } }
+
+define "List Integer Value":
+  { 31, 88, 11 }
+
+define "List Time Value":
+  { @T08:00:00, @T14:30:00 }
+
+define "Empty List Value":
+  {}
+
+define "Null Value":
+  null
+
+define "ValueSet Value":
+  "Example ValueSet"
+
+define "Versioned ValueSet Value":
+  "Versioned ValueSet"
+
+// The engine's EvaluationVisitor has no visitCodeSystemRef, so a CodeSystem-typed define
+// evaluates to null and surfaces as a data-absent marker rather than a canonical reference.
+define "CodeSystem Value":
+  "Example CodeSystem"
+
+// Resource-valued expressions, surfaced as reference strings.
+
+define "Resource List Value":
+  [Patient]
+
+define "Single Resource Value":
+  First([Patient])

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/library/SupportingEvidenceTypes.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/library/SupportingEvidenceTypes.json
@@ -1,0 +1,17 @@
+{
+  "resourceType": "Library",
+  "id": "SupportingEvidenceTypes",
+  "url": "http://example.com/Library/SupportingEvidenceTypes",
+  "name": "SupportingEvidenceTypes",
+  "status": "active",
+  "type": {
+    "coding": [ {
+      "system": "http://terminology.hl7.org/CodeSystem/library-type",
+      "code": "logic-library"
+    } ]
+  },
+  "content": [ {
+    "contentType": "text/cql",
+    "url": "../../cql/SupportingEvidenceTypes.cql"
+  } ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/SupportingEvidenceAllTypes.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/SupportingEvidenceAllTypes.json
@@ -1,0 +1,183 @@
+{
+  "resourceType": "Measure",
+  "id": "SupportingEvidenceAllTypes",
+  "url": "http://example.com/Measure/SupportingEvidenceAllTypes",
+  "library": [
+    "http://example.com/Library/SupportingEvidenceTypes"
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+          "valueCode": "boolean"
+        }
+      ],
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "BooleanValue",
+                "expression": "Boolean Value"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "IntegerValue",
+                "expression": "Integer Value"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "DecimalValue",
+                "expression": "Decimal Value"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "StringValue",
+                "expression": "String Value"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "DateValue",
+                "expression": "Date Value"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "DateTimeValue",
+                "expression": "DateTime Value"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "TimeValue",
+                "expression": "Time Value"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "CodeValue",
+                "expression": "Code Value"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "IntervalDateValue",
+                "expression": "Interval Date Value"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "IntervalDateTimeValue",
+                "expression": "Interval DateTime Value"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "TupleValue",
+                "expression": "Tuple Value"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "ListIntegerValue",
+                "expression": "List Integer Value"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "ListTimeValue",
+                "expression": "List Time Value"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "EmptyListValue",
+                "expression": "Empty List Value"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "NullValue",
+                "expression": "Null Value"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "ResourceListValue",
+                "expression": "Resource List Value"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "SingleResourceValue",
+                "expression": "Single Resource Value"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/SupportingEvidenceTypeConcept.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/SupportingEvidenceTypeConcept.json
@@ -1,0 +1,55 @@
+{
+  "resourceType": "Measure",
+  "id": "SupportingEvidenceTypeConcept",
+  "url": "http://example.com/Measure/SupportingEvidenceTypeConcept",
+  "library": [
+    "http://example.com/Library/SupportingEvidenceTypes"
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+          "valueCode": "boolean"
+        }
+      ],
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "ConceptValue",
+                "expression": "Concept Value"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/SupportingEvidenceTypeIntervalInteger.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/SupportingEvidenceTypeIntervalInteger.json
@@ -1,0 +1,55 @@
+{
+  "resourceType": "Measure",
+  "id": "SupportingEvidenceTypeIntervalInteger",
+  "url": "http://example.com/Measure/SupportingEvidenceTypeIntervalInteger",
+  "library": [
+    "http://example.com/Library/SupportingEvidenceTypes"
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+          "valueCode": "boolean"
+        }
+      ],
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "IntervalIntegerValue",
+                "expression": "Interval Integer Value"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/SupportingEvidenceTypeIntervalQuantity.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/SupportingEvidenceTypeIntervalQuantity.json
@@ -1,0 +1,55 @@
+{
+  "resourceType": "Measure",
+  "id": "SupportingEvidenceTypeIntervalQuantity",
+  "url": "http://example.com/Measure/SupportingEvidenceTypeIntervalQuantity",
+  "library": [
+    "http://example.com/Library/SupportingEvidenceTypes"
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+          "valueCode": "boolean"
+        }
+      ],
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "IntervalQuantityValue",
+                "expression": "Interval Quantity Value"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/SupportingEvidenceTypeLong.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/SupportingEvidenceTypeLong.json
@@ -1,0 +1,55 @@
+{
+  "resourceType": "Measure",
+  "id": "SupportingEvidenceTypeLong",
+  "url": "http://example.com/Measure/SupportingEvidenceTypeLong",
+  "library": [
+    "http://example.com/Library/SupportingEvidenceTypes"
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+          "valueCode": "boolean"
+        }
+      ],
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "LongValue",
+                "expression": "Long Value"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/SupportingEvidenceTypeQuantity.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/SupportingEvidenceTypeQuantity.json
@@ -1,0 +1,55 @@
+{
+  "resourceType": "Measure",
+  "id": "SupportingEvidenceTypeQuantity",
+  "url": "http://example.com/Measure/SupportingEvidenceTypeQuantity",
+  "library": [
+    "http://example.com/Library/SupportingEvidenceTypes"
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+          "valueCode": "boolean"
+        }
+      ],
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "QuantityValue",
+                "expression": "Quantity Value"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/SupportingEvidenceTypeRatio.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/SupportingEvidenceTypeRatio.json
@@ -1,0 +1,55 @@
+{
+  "resourceType": "Measure",
+  "id": "SupportingEvidenceTypeRatio",
+  "url": "http://example.com/Measure/SupportingEvidenceTypeRatio",
+  "library": [
+    "http://example.com/Library/SupportingEvidenceTypes"
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+          "valueCode": "boolean"
+        }
+      ],
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population"
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-supportingEvidenceDefinition",
+              "valueExpression": {
+                "language": "text/cql-identifier",
+                "name": "RatioValue",
+                "expression": "Ratio Value"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/SupportingEvidenceUndeclared.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/resources/measure/SupportingEvidenceUndeclared.json
@@ -1,0 +1,45 @@
+{
+  "resourceType": "Measure",
+  "id": "SupportingEvidenceUndeclared",
+  "url": "http://example.com/Measure/SupportingEvidenceUndeclared",
+  "library": [
+    "http://example.com/Library/SupportingEvidenceTypes"
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+          "valueCode": "boolean"
+        }
+      ],
+      "population": [
+        {
+          "id": "initial-population",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Initial Population"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/vocabulary/codesystem/example.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/vocabulary/codesystem/example.json
@@ -1,0 +1,15 @@
+{
+  "resourceType": "CodeSystem",
+  "id": "example",
+  "url": "http://example.org/CodeSystem/example",
+  "version": "2.1",
+  "name": "ExampleCodeSystem",
+  "status": "active",
+  "content": "complete",
+  "concept": [
+    {
+      "code": "cond-1",
+      "display": "Example condition"
+    }
+  ]
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/vocabulary/valueset/example-conditions-versioned.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/vocabulary/valueset/example-conditions-versioned.json
@@ -1,0 +1,21 @@
+{
+  "resourceType": "ValueSet",
+  "id": "example-conditions-versioned",
+  "url": "http://example.org/ValueSet/example-conditions-versioned",
+  "version": "1.0",
+  "name": "ExampleConditionsVersioned",
+  "status": "active",
+  "compose": {
+    "include": [
+      {
+        "system": "http://example.org/CodeSystem/example",
+        "concept": [
+          {
+            "code": "cond-1",
+            "display": "Example condition"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/vocabulary/valueset/example-conditions.json
+++ b/cqf-fhir-cr/src/test/resources/org/opencds/cqf/fhir/cr/measure/r4/MeasureTest/input/vocabulary/valueset/example-conditions.json
@@ -1,0 +1,20 @@
+{
+  "resourceType": "ValueSet",
+  "id": "example-conditions",
+  "url": "http://example.org/ValueSet/example-conditions",
+  "name": "ExampleConditions",
+  "status": "active",
+  "compose": {
+    "include": [
+      {
+        "system": "http://example.org/CodeSystem/example",
+        "concept": [
+          {
+            "code": "cond-1",
+            "display": "Example condition"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds `MeasureEvaluationOptions.supportingEvidenceMode` (`OFF | DECLARED | ALL_EXPRESSIONS`, default `DECLARED`). Under `ALL_EXPRESSIONS`, every top-level expression that the CQL engine already evaluates is written as a report-level `cqf-supportingEvidence` extension on subject-mode MeasureReports. The existing feature is used, and extended. `DECLARED` is the default, and current behavior. Expressions declared via `cqf-supportingEvidenceDefinition` stay at population level and are not duplicated. Under `OFF`, no supporting evidence is generated anywhere.

The selection step and type filter live as version-neutral changes, while report writing and value encoding necessarily stay per-version. The value filter scopes out FHIR elements and the merged function-evaluation accumulators. FHIR resources are encoded as reference strings.

This also incidentally closes standing encoder gaps on the shared supporting-evidence path (these previously failed the whole $evaluate-measure operation when declared, and for all intents and purposes, were not supported):
- Quantity, Ratio, Concept, non-temporal Interval — now delegate to the CQL engine's `FhirTypeConverter`
- Time — now valid FHIR, `14:30:00`, where previously emitted as an illegal CQL literal (`@T14:30:00`)
- Long — `valueString`
- ValueSet/CodeSystem — `valueCanonical`, `|version`-suffixed when pinned
- Resource-valued leaves now read their reference off the `ClassInstance`

And lastly, Code serialization is unchanged. It keeps its existing string form for compatibility.

The great majority of the diff is tests + test resources to cover the new cases.

Testing: report-level behaviour per mode, one declared-path encoding test per previously-failing type, full `cqf-fhir-cr` suite green. Validated end-to-end on a 400-member HEDIS cohort (90,981 resources) against local MinIO: 88 evidence entries per subject report, all names resolving to library defines, +6% report size on this sample. Backwards-compatibility was also tested, and default/existing behaviour remains untouched. 
