### PR TITLE
Key the measure sets on resource identity instead of comparing pairwise

### DIFF
--- a/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/ClassInstanceHelper.kt
+++ b/cqf-fhir-cql/src/main/java/org/opencds/cqf/fhir/cql/ClassInstanceHelper.kt
@@ -17,6 +17,10 @@ object ClassInstanceHelper {
         org.hl7.fhir.dstu3.model.ResourceType.entries.map { obj -> obj.name }
     val R4_RESOURCE_TYPE_NAMES = org.hl7.fhir.r4.model.ResourceType.entries.map { obj -> obj.name }
 
+    /** Every name that is a resource type in some modelled FHIR version. See [isFhirResource]. */
+    private val ALL_RESOURCE_TYPE_NAMES: Set<kotlin.String> =
+        (DSTU3_RESOURCE_TYPE_NAMES + R4_RESOURCE_TYPE_NAMES).toSet()
+
     @JvmStatic
     fun getId(classInstance: ClassInstance): kotlin.String? {
         if (classInstance.type.namespaceURI == fhirModelNamespaceUri && classInstance.has("id")) {
@@ -74,5 +78,22 @@ object ClassInstanceHelper {
             return resourceTypes.contains(classInstance.type.localPart)
         }
         return false
+    }
+
+    /**
+     * Whether the instance is a FHIR resource in any FHIR version modelled here, for callers that
+     * hold no FHIR version of their own. A [ClassInstance] names its type but not the version that
+     * type came from, and the versions disagree about which names are resources ("Sequence" is a
+     * DSTU3 resource; R4 renamed it "MolecularSequence"), so this asks every version rather than
+     * assuming one.
+     *
+     * Sound only for questions whose answer does not depend on the version — telling a resource
+     * from a complex datatype so it can be keyed by its id, for instance. Converting to HAPI FHIR
+     * is not such a question: use the version-qualified overload there.
+     */
+    @JvmStatic
+    fun isFhirResource(classInstance: ClassInstance): Boolean {
+        return classInstance.type.namespaceURI == fhirModelNamespaceUri &&
+            ALL_RESOURCE_TYPE_NAMES.contains(classInstance.type.localPart)
     }
 }

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/FhirResourceAndCqlTypeUtils.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/FhirResourceAndCqlTypeUtils.java
@@ -5,17 +5,20 @@ import java.util.Map;
 import java.util.Objects;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.opencds.cqf.cql.engine.elm.executing.EqualEvaluator;
-import org.opencds.cqf.cql.engine.runtime.Date;
+import org.opencds.cqf.cql.engine.runtime.ClassInstance;
 import org.opencds.cqf.cql.engine.runtime.Value;
+import org.opencds.cqf.fhir.cql.ClassInstanceHelper;
 
 /**
  * Utility class providing equality comparison methods for FHIR resources and CQL types.
  * <p/>
- * FHIR resources are compared by their resource type and logical ID (IdElement),
- * while CQL types are compared using their {@code equal()} method.
+ * FHIR resources are compared by their resource type and logical ID, whether they arrive as HAPI
+ * objects or as the CQL engine's native {@link ClassInstance}. Everything else is compared with CQL
+ * {@code equal()} semantics, or {@code Objects.equals} for values that are neither.
  * <p/>
- * This class exists to compensate for the fact that FHIR resource classes and CQL types
- * do not implement equals() and hashCode() in a way that reflects their logical identity.
+ * This relation is the one {@link IdentityKey} keys on, so a set or map built on those keys answers
+ * {@code add}, {@code contains}, {@code remove} and {@code retainAll} with the relation implemented
+ * here rather than with whatever {@code equals()} the value happens to carry.
  */
 public class FhirResourceAndCqlTypeUtils {
 
@@ -24,13 +27,47 @@ public class FhirResourceAndCqlTypeUtils {
     }
 
     public static boolean areObjectsEqual(Object obj, Object item) {
-        if (obj instanceof IBaseResource objResource && item instanceof IBaseResource itemResource) {
-            return areEqualResources(objResource, itemResource);
-        } else if (obj instanceof Value objCqlType && item instanceof Value itemCqlType) {
-            return areEqualCqlTypes(objCqlType, itemCqlType);
-        } else {
-            return Objects.equals(item, obj);
+        final String objIdentity = resourceIdentity(obj);
+        final String itemIdentity = resourceIdentity(item);
+
+        // A resource is only ever equal to the same resource, never to a non-resource, so one
+        // identity being present settles the comparison on its own.
+        if (objIdentity != null || itemIdentity != null) {
+            return objIdentity != null && objIdentity.equals(itemIdentity);
         }
+
+        if (obj instanceof Value objCqlType && item instanceof Value itemCqlType) {
+            return areEqualCqlTypes(objCqlType, itemCqlType);
+        }
+
+        return Objects.equals(item, obj);
+    }
+
+    /**
+     * The identity a FHIR resource is compared by: its resource type and logical id, rendered as
+     * {@code Type/id}. Null for anything that is not a FHIR resource.
+     * <p/>
+     * A HAPI resource and the engine-native {@link ClassInstance} of the same resource yield the
+     * same identity. They are the same resource, and since SDE accumulation stopped converting
+     * resources eagerly the pipeline holds both forms.
+     * <p/>
+     * A HAPI resource with no id keeps the relation this class has always had - all id-less
+     * resources of a type are one. An id-less {@code ClassInstance} has no identity at all and
+     * falls back to CQL equality, which is the relation that form already had.
+     */
+    @Nullable
+    public static String resourceIdentity(Object value) {
+        if (value instanceof IBaseResource resource) {
+            var idElement = resource.getIdElement();
+            var idPart = idElement == null ? null : idElement.getIdPart();
+            return resource.fhirType() + "/" + (idPart == null ? "" : idPart);
+        }
+
+        if (value instanceof ClassInstance classInstance && ClassInstanceHelper.isFhirResource(classInstance)) {
+            return ClassInstanceHelper.getId(classInstance);
+        }
+
+        return null;
     }
 
     public static boolean areEqualResources(IBaseResource resource1, IBaseResource resource2) {
@@ -38,46 +75,26 @@ public class FhirResourceAndCqlTypeUtils {
             return true;
         }
 
-        if (resource1.getIdElement() == null || resource2.getIdElement() == null) {
+        if (resource1 == null || resource2 == null) {
             return false;
         }
 
-        // In case we have IDs that are identical but different resource types,
-        // e.g. Patient/123 vs Observation/123
-        if (resource1.getClass() != resource2.getClass()) {
-            return false;
-        }
-
-        return Objects.equals(resource1.getIdElement(), resource2.getIdElement());
+        return resourceIdentity(resource1).equals(resourceIdentity(resource2));
     }
 
-    public static boolean areEqualCqlTypes(Value cqlDate1, Value cqlDate2) {
-        if (cqlDate1 == cqlDate2) {
+    public static boolean areEqualCqlTypes(Value cqlValue1, Value cqlValue2) {
+        if (cqlValue1 == cqlValue2) {
             return true;
         }
 
-        if (cqlDate1 == null || cqlDate2 == null) {
+        if (cqlValue1 == null || cqlValue2 == null) {
             return false;
         }
 
         // We're relying on all CqlTypes to implement equal() properly
         // Note this is equal(), not Object.equals()
-        var result = EqualEvaluator.equal(cqlDate1, cqlDate2);
+        var result = EqualEvaluator.equal(cqlValue1, cqlValue2);
         return result != null && result.getValue();
-    }
-
-    public static IBaseResource castToResourceIfApplicable(Object obj) {
-        if (obj instanceof IBaseResource resource) {
-            return resource;
-        }
-        return null;
-    }
-
-    public static Value castToCqlTypeIfApplicable(Object obj) {
-        if (obj instanceof Date cqlDate) {
-            return cqlDate;
-        }
-        return null;
     }
 
     /**

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/HashSetForCqlExpressionValues.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/HashSetForCqlExpressionValues.java
@@ -1,149 +1,42 @@
 package org.opencds.cqf.fhir.cr.measure.common;
 
-import jakarta.annotation.Nonnull;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
 /**
- * A {@link HashSet} of {@link CqlExpressionValue} that compares elements by the FHIR-resource and
- * CQL-type identity rules of their underlying value (via {@link FhirResourceAndCqlTypeUtils}).
+ * A Set of {@link CqlExpressionValue} that identifies elements by what they wrap.
  * <p/>
  * Sister type to {@link HashSetForFhirResourcesAndCqlTypes} for use when the population pipeline
- * stores wrappers rather than raw {@link Object}s. Two wrappers around FHIR resources with the
- * same resource type and logical ID are considered equal, even if the wrappers (or the underlying
- * resource instances) are different object instances. Same applies to CQL types via
- * {@link org.opencds.cqf.cql.engine.runtime.CqlType#equal}.
+ * stores wrappers rather than raw {@link Object}s: two wrappers around the same FHIR resource are
+ * one element, and {@code contains} / {@code remove} accept either a wrapper or a raw value, so a
+ * caller can ask "does this set hold resource X?" directly.
  * <p/>
- * Bucket placement still uses the wrapper's default {@code Object.hashCode()} (the wrapper
- * doesn't implement {@code equals} / {@code hashCode}), so {@code add} / {@code remove} /
- * {@code contains} / {@code retainAll} fall through to linear-time identity checks via
- * {@link FhirResourceAndCqlTypeUtils#areObjectsEqual}. This is acceptable — per-subject
- * population sets are small.
+ * Keying on the wrapped value is the whole of the difference from the parent, which is why this is
+ * a few lines rather than a parallel implementation. It used to be a parallel implementation, and
+ * the two drifted: the wrapper carries no {@code equals}, so {@code add} deduplicated by wrapper
+ * identity - that is, not at all - while {@code contains} compared what was wrapped.
  */
-@SuppressWarnings("squid:S3776")
-public class HashSetForCqlExpressionValues extends HashSet<CqlExpressionValue> {
+public class HashSetForCqlExpressionValues extends HashSetForFhirResourcesAndCqlTypes<CqlExpressionValue> {
 
     public HashSetForCqlExpressionValues() {
         super();
     }
 
     public HashSetForCqlExpressionValues(Collection<CqlExpressionValue> collection) {
-        super();
-        for (CqlExpressionValue value : collection) {
-            this.add(value);
-        }
+        super(collection);
     }
 
     public HashSetForCqlExpressionValues(Iterable<CqlExpressionValue> iterable) {
-        super();
-        for (CqlExpressionValue value : iterable) {
-            this.add(value);
-        }
+        super(iterable);
     }
 
     /**
-     * Linear-search check that any wrapper in this set has an underlying value equal — by FHIR
-     * resource / CQL type identity — to {@code other}. Accepts either a {@link CqlExpressionValue}
-     * (the typical case) or a raw object (so callers can ask "does this set contain a wrapper
-     * around resource X?" directly).
+     * Keys on the wrapped value, so a wrapper and the raw value it wraps resolve to the same key.
      */
     @Override
-    public boolean contains(Object other) {
-        return containsByIdentity(this, unwrap(other));
-    }
-
-    /**
-     * Adds {@code newElement} only if no existing wrapper in this set has an underlying value
-     * equal to {@code newElement.raw()} by FHIR identity.
-     */
-    @Override
-    public boolean add(CqlExpressionValue newElement) {
-        if (newElement == null) {
-            return super.add(null);
-        }
-        Object newRaw = newElement.raw();
-        if (newRaw == null
-                || (FhirResourceAndCqlTypeUtils.castToResourceIfApplicable(newRaw) == null
-                        && FhirResourceAndCqlTypeUtils.castToCqlTypeIfApplicable(newRaw) == null)) {
-            return super.add(newElement);
-        }
-        for (CqlExpressionValue existing : this) {
-            if (existing != null && FhirResourceAndCqlTypeUtils.areObjectsEqual(existing.raw(), newRaw)) {
-                return false;
-            }
-        }
-        return super.add(newElement);
-    }
-
-    /**
-     * Removes the wrapper whose underlying value matches {@code removalCandidate} by FHIR
-     * identity. {@code removalCandidate} may be a {@link CqlExpressionValue} or a raw resource.
-     */
-    @Override
-    public boolean remove(Object removalCandidate) {
-        Object targetRaw = unwrap(removalCandidate);
-        if (targetRaw == null) {
-            return super.remove(removalCandidate);
-        }
-        if (FhirResourceAndCqlTypeUtils.castToResourceIfApplicable(targetRaw) == null
-                && FhirResourceAndCqlTypeUtils.castToCqlTypeIfApplicable(targetRaw) == null) {
-            return super.remove(removalCandidate);
-        }
-        for (CqlExpressionValue existing : this) {
-            if (existing != null && FhirResourceAndCqlTypeUtils.areObjectsEqual(existing.raw(), targetRaw)) {
-                return super.remove(existing);
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public boolean retainAll(@Nonnull Collection<?> otherCollection) {
-        Objects.requireNonNull(otherCollection);
-
-        if (otherCollection instanceof HashSetForCqlExpressionValues) {
-            return super.retainAll(otherCollection);
-        }
-
-        boolean modified = false;
-        Iterator<CqlExpressionValue> it = iterator();
-        while (it.hasNext()) {
-            CqlExpressionValue next = it.next();
-            if (!otherContains(otherCollection, next)) {
-                it.remove();
-                modified = true;
-            }
-        }
-        return modified;
-    }
-
-    private static boolean otherContains(Collection<?> collection, CqlExpressionValue value) {
-        Object raw = value == null ? null : value.raw();
-        for (Object other : collection) {
-            Object otherRaw = unwrap(other);
-            if (FhirResourceAndCqlTypeUtils.areObjectsEqual(raw, otherRaw)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean containsByIdentity(Iterable<CqlExpressionValue> elements, Object targetRaw) {
-        for (CqlExpressionValue existing : elements) {
-            Object existingRaw = existing == null ? null : existing.raw();
-            if (FhirResourceAndCqlTypeUtils.areObjectsEqual(existingRaw, targetRaw)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static Object unwrap(Object o) {
-        return o instanceof CqlExpressionValue v ? v.raw() : o;
+    IdentityKey keyFor(Object element) {
+        return super.keyFor(element instanceof CqlExpressionValue value ? value.raw() : element);
     }
 
     @Override
@@ -151,13 +44,13 @@ public class HashSetForCqlExpressionValues extends HashSet<CqlExpressionValue> {
         if (isEmpty()) {
             return "[]";
         }
-        Object firstRaw = iterator().next() == null ? null : iterator().next().raw();
-        if (firstRaw instanceof IBaseResource) {
+        var firstElement = iterator().next();
+        if (firstElement != null && firstElement.raw() instanceof IBaseResource) {
             return stream()
                     .map(CqlExpressionValue::raw)
                     .filter(IBaseResource.class::isInstance)
                     .map(IBaseResource.class::cast)
-                    .map(r -> r.getIdElement().getValueAsString())
+                    .map(resource -> resource.getIdElement().getValueAsString())
                     .collect(Collectors.joining(",", "[", "]"));
         }
         return super.toString();

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/HashSetForFhirResourcesAndCqlTypes.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/HashSetForFhirResourcesAndCqlTypes.java
@@ -1,38 +1,53 @@
 package org.opencds.cqf.fhir.cr.measure.common;
 
 import jakarta.annotation.Nonnull;
+import java.util.AbstractSet;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.opencds.cqf.cql.engine.runtime.Value;
 
 /**
- * A HashSet implementation that uses FHIR resource identity rules when comparing resources or
- * Cql.equal.
- * This means that two resources with the same resource type and logical ID are considered
- * equal, even if they are different object instances.
+ * A Set that identifies FHIR resources by resource type and logical ID, so two objects describing
+ * the same resource are one element even when they are different instances - or different
+ * representations, since a resource reaches this pipeline either as a HAPI object or as the CQL
+ * engine's native {@link org.opencds.cqf.cql.engine.runtime.ClassInstance}. Values that are not
+ * resources keep CQL {@code =} semantics, and everything else its own {@code equals}.
  * <p/>
- * This class exists strictly to compensate for the fact that FHIR resource classes and CQL types
- * do not implement equals() and hashCode().
+ * Elements are stored under an {@link IdentityKey}, which is what makes that one relation apply to
+ * every operation. The class this replaces compared elements pairwise, which had two consequences
+ * worth stating, since both are the reason for the rewrite rather than incidental to it:
+ * <ul>
+ *   <li>{@code add} and {@code remove} routed CQL values into {@code HashSet}'s own equality while
+ *       {@code contains} and {@code retainAll} routed them into CQL {@code =}. Under CQL 5 every
+ *       expression result is a {@code ClassInstance}, which those two relations need not agree
+ *       about, so a set could fail to contain a value it had just added.</li>
+ *   <li>Every operation was a linear scan, and under CQL 5 each comparison in that scan walked a
+ *       resource graph. Building an n-element set was O(n²) in deep structural comparisons.</li>
+ * </ul>
  *
  * <p/>For a wrapper-aware sister type used by {@code PopulationDef.subjectResources}, see
  * {@link HashSetForCqlExpressionValues}.
+ *
  * @param <T> the type of elements in this set, which may or may not be a {@link IBaseResource}
  *           or a {@link Value}
  */
-@SuppressWarnings("squid:S3776")
-public class HashSetForFhirResourcesAndCqlTypes<T> extends HashSet<T> {
+public class HashSetForFhirResourcesAndCqlTypes<T> extends AbstractSet<T> {
+
+    /** Insertion-ordered so iteration is stable, as it was when this extended {@code HashSet}. */
+    private final Map<IdentityKey, T> elementsByKey = new LinkedHashMap<>();
 
     public HashSetForFhirResourcesAndCqlTypes() {
         super();
     }
 
     public HashSetForFhirResourcesAndCqlTypes(Collection<T> collection) {
-        super(collection);
+        this((Iterable<T>) collection);
     }
 
     public HashSetForFhirResourcesAndCqlTypes(Iterable<T> iterable) {
@@ -48,144 +63,90 @@ public class HashSetForFhirResourcesAndCqlTypes<T> extends HashSet<T> {
     }
 
     /**
-     * This logic is triggered by retainAll() and removeAll(), whose behaviour we're trying
-     * to modify to use FHIR resource identity rules.
-     *
-     * @param other object to be checked for containment in this set
-     * @return true if this set contains the specified element
+     * The key {@code element} is stored under. Subclasses that hold wrappers rather than the values
+     * themselves override this to key on what they wrap.
+     * <p/>
+     * Package-private rather than protected: {@link IdentityKey} is an implementation detail of this
+     * package, so a subclass outside it could neither name the return type nor override this.
      */
-    @Override
-    public boolean contains(Object other) {
-        return contains(this, other);
+    IdentityKey keyFor(Object element) {
+        return IdentityKey.of(element);
     }
 
-    /**
-     * If we don't override this logic, we'll get duplicate resources since the comparison to
-     * existing resources in the set will be based on object identity, not FHIR resource identity
-     * The default implementation calls to HashMap, which means it's not based on contains()
-     * <p/>
-     * This is also called from super.allAll()
-     *
-     * @param newElement element to be added to this set
-     * @return true if this set did not already contain the specified element
-     */
     @Override
     public boolean add(T newElement) {
-        final IBaseResource newElementResource = FhirResourceAndCqlTypeUtils.castToResourceIfApplicable(newElement);
-
-        if (newElementResource != null) {
-            if (this.contains(newElementResource)) {
-                return false;
-            } else {
-                return super.add(newElement);
-            }
+        var key = keyFor(newElement);
+        if (elementsByKey.containsKey(key)) {
+            return false;
         }
-
-        final Value newElementCqlType = FhirResourceAndCqlTypeUtils.castToCqlTypeIfApplicable(newElement);
-
-        if (newElementCqlType != null) {
-            if (this.contains(newElementCqlType)) {
-                return false;
-            } else {
-                return super.add(newElement);
-            }
-        }
-
-        return super.add(newElement);
+        elementsByKey.put(key, newElement);
+        return true;
     }
 
-    /**
-     * If we don't override this logic, we'll get duplicate resources since the comparison to
-     * existing resources in the set will be based on object identity, not FHIR resource identity
-     * The default implementation calls to HashMap, which means it's not based on contains()
-     * <p/>
-     * This is also called from super.removeAll()
-     *
-     * @param removalCandidate object to be removed from this set, if present
-     * @return true if this set contained the specified element
-     */
+    @Override
+    public boolean contains(Object other) {
+        return elementsByKey.containsKey(keyFor(other));
+    }
+
     @Override
     public boolean remove(Object removalCandidate) {
-        final IBaseResource removalCandidateResource =
-                FhirResourceAndCqlTypeUtils.castToResourceIfApplicable(removalCandidate);
-
-        if (removalCandidateResource != null) {
-            for (T next : this) {
-                if (next instanceof IBaseResource nextResource
-                        && FhirResourceAndCqlTypeUtils.areEqualResources(nextResource, removalCandidateResource)) {
-                    return super.remove(nextResource);
-                }
-            }
+        var key = keyFor(removalCandidate);
+        if (!elementsByKey.containsKey(key)) {
             return false;
         }
-
-        final Value removalCandidateCqlType = FhirResourceAndCqlTypeUtils.castToCqlTypeIfApplicable(removalCandidate);
-
-        if (removalCandidateCqlType != null) {
-            for (T next : this) {
-                if (next instanceof Value nextCqlType
-                        && FhirResourceAndCqlTypeUtils.areEqualCqlTypes(nextCqlType, removalCandidateCqlType)) {
-                    return super.remove(nextCqlType);
-                }
-            }
-            return false;
-        }
-
-        return super.remove(removalCandidate);
+        elementsByKey.remove(key);
+        return true;
     }
 
     /**
-     * If we don't override this logic, we'll get duplicate resources since the comparison to
-     * existing resources in the set will be based on object identity, not FHIR resource identity
-     * The default implementation calls to HashMap, which means it's not based on contains()
+     * Retains the elements whose identity appears in {@code otherCollection}.
      * <p/>
-     *
-     * @param otherCollection collection containing elements to be retained in this set
-     * @return true if this set changed as a result of the call
+     * The inherited implementation would ask {@code otherCollection} what it contains, and a plain
+     * {@code List} or {@code HashSet} answers that by Java object identity - which is how a
+     * population intersection silently drops resources. Keying the other collection first means the
+     * comparison runs in this set's relation regardless of what the other collection is.
      */
     @Override
     public boolean retainAll(@Nonnull Collection<?> otherCollection) {
         Objects.requireNonNull(otherCollection);
 
-        // Both Collections are HashSetForFhirResources, so we can use the default implementation,
-        // which calls HashSetForFhirResources.contains().
-        if (otherCollection instanceof HashSetForFhirResourcesAndCqlTypes) {
-            return super.retainAll(otherCollection);
+        var retainedKeys = new HashSet<IdentityKey>();
+        for (Object other : otherCollection) {
+            retainedKeys.add(keyFor(other));
         }
+        return elementsByKey.keySet().retainAll(retainedKeys);
+    }
 
-        // Now we're dealing with another Collection, which calls its own contains() method when
-        // we invoke super.retainAll()
+    /**
+     * Removes the elements whose identity appears in {@code otherCollection}. Overridden for the
+     * same reason as {@link #retainAll(Collection)}: the inherited implementation delegates to the
+     * other collection's {@code contains} once this set is the smaller of the two.
+     */
+    @Override
+    public boolean removeAll(@Nonnull Collection<?> otherCollection) {
+        Objects.requireNonNull(otherCollection);
+
         boolean modified = false;
-        Iterator<?> it = iterator();
-        while (it.hasNext()) {
-            if (!contains(otherCollection, it.next())) {
-                it.remove();
-                modified = true;
-            }
+        for (Object other : otherCollection) {
+            modified |= remove(other);
         }
         return modified;
     }
 
-    private static boolean contains(Collection<?> collection, Object obj) {
-        final IBaseResource otherResource = FhirResourceAndCqlTypeUtils.castToResourceIfApplicable(obj);
-        final Value otherCqlType = FhirResourceAndCqlTypeUtils.castToCqlTypeIfApplicable(obj);
-
-        // prevent infinite recursion
-        if (otherResource != null || otherCqlType != null || collection instanceof HashSetForFhirResourcesAndCqlTypes) {
-            return containsInner(collection, obj);
-        }
-
-        return collection.contains(obj);
+    @Override
+    @Nonnull
+    public Iterator<T> iterator() {
+        return elementsByKey.values().iterator();
     }
 
-    private static boolean containsInner(Collection<?> collection, Object obj) {
-        for (Object item : collection) {
-            if (FhirResourceAndCqlTypeUtils.areObjectsEqual(obj, item)) {
-                return true;
-            }
-        }
+    @Override
+    public int size() {
+        return elementsByKey.size();
+    }
 
-        return false;
+    @Override
+    public void clear() {
+        elementsByKey.clear();
     }
 
     @Override
@@ -199,8 +160,7 @@ public class HashSetForFhirResourcesAndCqlTypes<T> extends HashSet<T> {
         if (firstElement instanceof IBaseResource) {
             return stream()
                     .map(IBaseResource.class::cast)
-                    .map(IBaseResource::getIdElement)
-                    .map(IPrimitiveType::getValueAsString)
+                    .map(resource -> resource.getIdElement().getValueAsString())
                     .collect(Collectors.joining(",", "[", "]"));
         }
 

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/IdentityKey.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/IdentityKey.java
@@ -1,0 +1,70 @@
+package org.opencds.cqf.fhir.cr.measure.common;
+
+import java.util.Objects;
+import org.opencds.cqf.cql.engine.runtime.Value;
+
+/**
+ * The key a value is stored under in {@link HashSetForFhirResourcesAndCqlTypes}, carrying the
+ * identity {@link FhirResourceAndCqlTypeUtils} defines for it.
+ * <p/>
+ * Keying is what lets one relation answer every set operation. Comparing elements pairwise instead
+ * - which is what these collections used to do - lets {@code add} and {@code contains} disagree,
+ * because they reached for different notions of equality, and costs a linear scan per operation.
+ */
+sealed interface IdentityKey {
+
+    static IdentityKey of(Object value) {
+        var resourceIdentity = FhirResourceAndCqlTypeUtils.resourceIdentity(value);
+        if (resourceIdentity != null) {
+            return new ResourceKey(resourceIdentity);
+        }
+        if (value instanceof Value cqlValue) {
+            return new CqlValueKey(cqlValue);
+        }
+        return new PlainKey(value);
+    }
+
+    /**
+     * A FHIR resource, keyed by resource type and logical id. This is the case that matters: it
+     * turns a deep structural walk of a resource graph into a string comparison.
+     */
+    record ResourceKey(String identity) implements IdentityKey {}
+
+    /**
+     * A CQL value that is not a FHIR resource, compared with CQL {@code =}.
+     * <p/>
+     * CQL {@code =} is not hash-compatible - {@code 1.0 = 1.00} is true where the two have different
+     * structural hashes, and DateTime comparison across precisions can be uncertain rather than
+     * false - so there is no key to spread these across buckets. They all share one, which makes
+     * lookups among them linear, exactly as before. There are few: resources take the keyed path
+     * above, and these are the {@code Date}s and {@code Decimal}s a stratifier returns.
+     */
+    record CqlValueKey(Value value) implements IdentityKey {
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other
+                    || (other instanceof CqlValueKey otherKey
+                            && FhirResourceAndCqlTypeUtils.areEqualCqlTypes(value, otherKey.value));
+        }
+    }
+
+    /** Anything else - a String, a Map of criteria results - on its own {@code equals}/{@code hashCode}. */
+    record PlainKey(Object value) implements IdentityKey {
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(value);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof PlainKey otherKey && Objects.equals(value, otherKey.value));
+        }
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/HashSetForCqlExpressionValuesTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/HashSetForCqlExpressionValuesTest.java
@@ -1,0 +1,114 @@
+package org.opencds.cqf.fhir.cr.measure.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opencds.cqf.fhir.cr.measure.common.HashSetForFhirResourcesAndCqlTypesTest.encounterInstance;
+
+import java.util.List;
+import org.hl7.fhir.r4.model.Encounter;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The wrapper-aware set keys on what it wraps, so a wrapper and the raw value inside it are the
+ * same element. Before that, the wrapper carried no {@code equals}, so {@code add} deduplicated by
+ * wrapper identity - not at all - while {@code contains} compared the wrapped values.
+ */
+class HashSetForCqlExpressionValuesTest {
+
+    private static final String ENCOUNTER_ID = "encounter-1";
+    private static final String EXPRESSION = "Qualifying Encounters";
+
+    @Test
+    void wrappersAroundTheSameResourceAreOneElement() {
+        var set = new HashSetForCqlExpressionValues();
+
+        assertTrue(set.add(wrap(encounterInstance(ENCOUNTER_ID))));
+        assertFalse(set.add(wrap(encounterInstance(ENCOUNTER_ID))));
+        assertEquals(1, set.size());
+    }
+
+    @Test
+    void wrappersAroundDifferentResourcesAreDistinct() {
+        var set = new HashSetForCqlExpressionValues();
+
+        assertTrue(set.add(wrap(encounterInstance(ENCOUNTER_ID))));
+        assertTrue(set.add(wrap(encounterInstance("encounter-2"))));
+        assertEquals(2, set.size());
+    }
+
+    @Test
+    void containsAcceptsARawResource() {
+        var set = new HashSetForCqlExpressionValues();
+        set.add(wrap(encounterInstance(ENCOUNTER_ID)));
+
+        assertTrue(set.contains(encounterInstance(ENCOUNTER_ID)));
+        assertFalse(set.contains(encounterInstance("encounter-2")));
+    }
+
+    @Test
+    void containsAcceptsAHapiResourceForAnEngineNativeElement() {
+        var set = new HashSetForCqlExpressionValues();
+        set.add(wrap(encounterInstance(ENCOUNTER_ID)));
+
+        var hapiEncounter = new Encounter();
+        hapiEncounter.setId(ENCOUNTER_ID);
+
+        assertTrue(set.contains(hapiEncounter));
+    }
+
+    @Test
+    void removeAcceptsARawResource() {
+        var set = new HashSetForCqlExpressionValues();
+        set.add(wrap(encounterInstance(ENCOUNTER_ID)));
+        set.add(wrap(encounterInstance("encounter-2")));
+
+        assertTrue(set.remove(encounterInstance(ENCOUNTER_ID)));
+
+        assertEquals(1, set.size());
+        assertTrue(set.contains(encounterInstance("encounter-2")));
+    }
+
+    /**
+     * {@code PopulationDef.retainAllResources} intersects one population's per-subject resources
+     * against another's.
+     */
+    @Test
+    void retainAllIntersectsByWrappedResource() {
+        var set = new HashSetForCqlExpressionValues();
+        set.add(wrap(encounterInstance(ENCOUNTER_ID)));
+        set.add(wrap(encounterInstance("encounter-2")));
+
+        set.retainAll(new HashSetForCqlExpressionValues(List.of(wrap(encounterInstance(ENCOUNTER_ID)))));
+
+        assertEquals(1, set.size());
+        assertTrue(set.contains(encounterInstance(ENCOUNTER_ID)));
+    }
+
+    @Test
+    void retainAllAcceptsAPlainListOfRawResources() {
+        var set = new HashSetForCqlExpressionValues();
+        set.add(wrap(encounterInstance(ENCOUNTER_ID)));
+        set.add(wrap(encounterInstance("encounter-2")));
+
+        set.retainAll(List.of(encounterInstance(ENCOUNTER_ID)));
+
+        assertEquals(1, set.size());
+        assertTrue(set.contains(encounterInstance(ENCOUNTER_ID)));
+    }
+
+    @Test
+    void addThenContainsAgreeForANonResourceValue() {
+        var set = new HashSetForCqlExpressionValues();
+
+        assertTrue(set.add(wrap("a plain string")));
+        assertTrue(set.contains(wrap("a plain string")));
+        assertTrue(set.contains("a plain string"));
+        assertFalse(set.add(wrap("a plain string")));
+        assertEquals(1, set.size());
+    }
+
+    private static CqlExpressionValue wrap(Object raw) {
+        return CqlExpressionValue.ofRaw(EXPRESSION, raw, null);
+    }
+}

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/HashSetForFhirResourcesAndCqlTypesTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/HashSetForFhirResourcesAndCqlTypesTest.java
@@ -4,20 +4,27 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.List;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.Test;
+import org.opencds.cqf.cql.engine.runtime.ClassInstance;
 import org.opencds.cqf.cql.engine.runtime.Date;
+import org.opencds.cqf.cql.engine.runtime.Decimal;
 import org.opencds.cqf.cql.engine.runtime.Precision;
+import org.opencds.cqf.fhir.utility.model.FhirModelResolverCache;
 
 class HashSetForFhirResourcesAndCqlTypesTest {
 
     public static final String PATIENT_ID_1 = "patient-1";
     public static final String PATIENT_ID_2 = "patient-2";
+    public static final String ENCOUNTER_ID = "encounter-1";
 
     @Test
     void addFhirResourceWithSameIdIsNotAddedTwice() {
@@ -309,6 +316,152 @@ class HashSetForFhirResourcesAndCqlTypesTest {
 
         // Just verify no exception was thrown - if we got here, the test passed
         assertTrue(true, "Remove operation should complete without NPE");
+    }
+
+    // ==================== One relation across every operation ====================
+
+    /**
+     * The set holds elements under a single identity, so nothing it accepted can be absent from it.
+     * <p/>
+     * These are the value shapes the measure pipeline puts in these sets. Before the set was keyed,
+     * {@code add} and {@code contains} reached for different notions of equality and could disagree
+     * about the same element; the CQL {@code Decimal} case below is one that actually did.
+     */
+    @Test
+    void addThenContainsAgreeForEveryValueShape() {
+        var values = List.of(
+                createPatientWithId(PATIENT_ID_1),
+                encounterInstance(ENCOUNTER_ID),
+                new Date(LocalDate.of(2024, Month.JANUARY, 1)),
+                new Decimal(new BigDecimal("1.0")),
+                "a plain string");
+
+        for (Object value : values) {
+            var set = new HashSetForFhirResourcesAndCqlTypes<>();
+            assertTrue(set.add(value), () -> "add returned false for " + value);
+            assertTrue(set.contains(value), () -> "contains disagreed with add for " + value);
+            assertFalse(set.add(value), () -> "add accepted a duplicate of " + value);
+            assertEquals(1, set.size());
+        }
+    }
+
+    /**
+     * CQL {@code =} says {@code 1.0 = 1.00}; {@code Decimal.equals} is scale-sensitive and says the
+     * opposite. Whichever the set uses, it has to use it for both operations.
+     */
+    @Test
+    void addAndContainsAgreeOnCqlDecimalScale() {
+        var set = new HashSetForFhirResourcesAndCqlTypes<Decimal>();
+        var oneDecimalPlace = new Decimal(new BigDecimal("1.0"));
+        var twoDecimalPlaces = new Decimal(new BigDecimal("1.00"));
+
+        assertTrue(set.add(oneDecimalPlace));
+        assertTrue(set.contains(twoDecimalPlaces));
+        assertFalse(set.add(twoDecimalPlaces));
+        assertEquals(1, set.size());
+    }
+
+    // ==================== Engine-native (ClassInstance) resources ====================
+
+    /**
+     * The same resource retrieved twice is one element even when the two copies differ in content -
+     * a differing {@code meta.versionId} here. Structural comparison calls those two resources
+     * distinct, and CQL {@code =} calls the comparison uncertain, so before id-keying a set of
+     * evaluated resources could hold the same resource more than once.
+     */
+    @Test
+    void engineNativeResourcesWithSameIdAreOneElement() {
+        var set = new HashSetForFhirResourcesAndCqlTypes<ClassInstance>();
+
+        assertTrue(set.add(encounterInstance(ENCOUNTER_ID)));
+        assertFalse(set.add(encounterInstanceWithVersion(ENCOUNTER_ID, "7")));
+        assertEquals(1, set.size());
+    }
+
+    @Test
+    void engineNativeResourcesWithDifferentIdsAreDistinct() {
+        var set = new HashSetForFhirResourcesAndCqlTypes<ClassInstance>();
+
+        assertTrue(set.add(encounterInstance(ENCOUNTER_ID)));
+        assertTrue(set.add(encounterInstance("encounter-2")));
+        assertEquals(2, set.size());
+    }
+
+    /**
+     * A resource reaches the pipeline either as a HAPI object or as an engine-native value, and it
+     * is the same resource in both forms.
+     */
+    @Test
+    void engineNativeAndHapiFormsOfOneResourceAreOneElement() {
+        var set = new HashSetForFhirResourcesAndCqlTypes<>();
+        var hapiEncounter = new Encounter();
+        hapiEncounter.setId(ENCOUNTER_ID);
+
+        assertTrue(set.add(hapiEncounter));
+        assertTrue(set.contains(encounterInstance(ENCOUNTER_ID)));
+        assertFalse(set.add(encounterInstance(ENCOUNTER_ID)));
+        assertEquals(1, set.size());
+    }
+
+    /**
+     * The population/stratifier intersection at {@code MeasureMultiSubjectEvaluator} retains against
+     * a plain {@code List}, whose own {@code contains} compares by Java object identity. The
+     * comparison has to run in this set's relation regardless of what it is handed.
+     */
+    @Test
+    void retainAllAgainstPlainListOfEngineNativeResources() {
+        var set = new HashSetForFhirResourcesAndCqlTypes<ClassInstance>();
+        set.add(encounterInstance(ENCOUNTER_ID));
+        set.add(encounterInstance("encounter-2"));
+
+        set.retainAll(List.of(encounterInstance(ENCOUNTER_ID)));
+
+        assertEquals(1, set.size());
+        assertTrue(set.contains(encounterInstance(ENCOUNTER_ID)));
+        assertFalse(set.contains(encounterInstance("encounter-2")));
+    }
+
+    @Test
+    void removeAllAgainstPlainListOfEngineNativeResources() {
+        var set = new HashSetForFhirResourcesAndCqlTypes<ClassInstance>();
+        set.add(encounterInstance(ENCOUNTER_ID));
+        set.add(encounterInstance("encounter-2"));
+
+        set.removeAll(List.of(encounterInstance("encounter-2")));
+
+        assertEquals(1, set.size());
+        assertTrue(set.contains(encounterInstance(ENCOUNTER_ID)));
+    }
+
+    @Test
+    void iterationOrderFollowsInsertion() {
+        var set = new HashSetForFhirResourcesAndCqlTypes<Patient>();
+        var patient1 = createPatientWithId(PATIENT_ID_1);
+        var patient2 = createPatientWithId(PATIENT_ID_2);
+        set.add(patient1);
+        set.add(patient2);
+
+        assertEquals(List.of(patient1, patient2), List.copyOf(set));
+    }
+
+    static ClassInstance encounterInstance(String id) {
+        var encounter = new Encounter();
+        encounter.setId(id);
+        encounter.setStatus(Encounter.EncounterStatus.FINISHED);
+        return toEngineNative(encounter);
+    }
+
+    private static ClassInstance encounterInstanceWithVersion(String id, String versionId) {
+        var encounter = new Encounter();
+        encounter.setId(id);
+        encounter.setStatus(Encounter.EncounterStatus.FINISHED);
+        encounter.getMeta().setVersionId(versionId);
+        return toEngineNative(encounter);
+    }
+
+    private static ClassInstance toEngineNative(IBaseResource resource) {
+        return (ClassInstance)
+                FhirModelResolverCache.resolverForVersion(FhirVersionEnum.R4).toCqlValue(resource, false);
     }
 
     private static Patient createPatientWithId(String id) {


### PR DESCRIPTION
Cherry-picks @lukedegruchy's `20087354d` from `ld-20260901-sde-lazy-conversion` onto `main`, without the SDE / lazy-conversion commits from that branch. Authorship is preserved.

### Why lift it out

The change is independent of the SDE work (no file overlap with `177131a83`, `4e56afd86`, `a95a05efa`) and valuable on its own: it is a correctness fix as well as a performance one.

`HashSetForFhirResourcesAndCqlTypes` and `HashSetForCqlExpressionValues` compared elements pairwise, leaving two relations in play at once - `add` and `remove` routed through `HashSet`'s equality while `contains` and `retainAll` routed through CQL `=`. Under CQL 5 every expression result is a `ClassInstance`, so that split ran on every value and a set could fail to contain something it had just accepted. Every operation was also a linear scan whose comparisons walked a resource graph, making set construction O(n^2).

Elements are now stored under an `IdentityKey`: FHIR resources key on (resource type, logical id), other CQL values share one bucket keyed on CQL `=` (which is not hash-compatible), everything else on its own `equals`.

### Commits

- `Add a version-agnostic isFhirResource overload for ClassInstance`. The cherry-pick needs a single-argument `ClassInstanceHelper.isFhirResource`, added on Luke's branch by `4e56afd86`. Ported that ~20 lines rather than pulling the SDE commit in. Scoped to DSTU3/R4, which is what `main` models, where the original unions four versions. Lands first so the commit that follows compiles standalone.
- `Key the measure sets on resource identity instead of comparing pairwise` - Luke's, unmodified.

### Verification

Luke's new tests (`HashSetForFhirResourcesAndCqlTypesTest`, `HashSetForCqlExpressionValuesTest`) pass on `main`. Full `cqf-fhir-cr` suite shows no regressions against a clean-`main` baseline; test count rises by his 16 new tests.

### Notes

- @lukedegruchy — this duplicates a commit on your branch. If you'd rather land it through your own PR, close this and I'll drop the branch; the only piece worth keeping separately is the `ClassInstanceHelper` overload.
- Pairs with https://github.com/cqframework/clinical_quality_language/pull/1837, which stops the engine deduplicating. That change relies on this one to keep the deduplication cheap.