### PR TITLE
Key the SDE and function-handler evaluated resource sets by identity

### DIFF
--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/FunctionEvaluationHandler.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/FunctionEvaluationHandler.java
@@ -273,7 +273,9 @@ public class FunctionEvaluationHandler {
         // FhirResourceAndCqlTypeUtils.areObjectsEqual where needed; nothing in the downstream pipeline
         // does random-access lookup by input, so a List is sufficient and self-documenting.
         final List<ObservationEntry> functionResults = new ArrayList<>();
-        final Set<Value> evaluatedResources = new HashSet<>();
+        // Identity-keyed: these accumulate engine values whose hashCode walks the whole
+        // element tree. See HashSetForFhirResourcesAndCqlTypes.
+        final Set<Value> evaluatedResources = new HashSetForFhirResourcesAndCqlTypes<>();
 
         final String exceptionMessageIfNotFunction = """
             Measure: '%s', MeasureObservation population expression '%s' must be a CQL function
@@ -407,7 +409,9 @@ public class FunctionEvaluationHandler {
             // this will be used in MeasureEvaluator (Criteria population Id and Stratifier Expression)
             var expressionName = popDef.id() + "-" + stratifierExpression;
             final List<FunctionResultEntry> functionResults = new ArrayList<>();
-            final Set<Value> evaluatedResources = new HashSet<>();
+            // Identity-keyed: these accumulate engine values whose hashCode walks the whole
+        // element tree. See HashSetForFhirResourcesAndCqlTypes.
+        final Set<Value> evaluatedResources = new HashSetForFhirResourcesAndCqlTypes<>();
 
             for (var result : resultsIter) {
                 final ExpressionResult functionResult = evaluateNonSubValueStratifiersFunction(
@@ -426,7 +430,6 @@ public class FunctionEvaluationHandler {
                             + "' returned null evaluatedResources for measure: " + measureUrl);
                 }
                 evaluatedResources.addAll(evaluated);
-                evaluatedResources.addAll(functionResult.getEvaluatedResources());
             }
             // add to EvaluationResult
             addToEvaluationResult(

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/FunctionEvaluationHandler.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/FunctionEvaluationHandler.java
@@ -4,7 +4,6 @@ import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -410,8 +409,8 @@ public class FunctionEvaluationHandler {
             var expressionName = popDef.id() + "-" + stratifierExpression;
             final List<FunctionResultEntry> functionResults = new ArrayList<>();
             // Identity-keyed: these accumulate engine values whose hashCode walks the whole
-        // element tree. See HashSetForFhirResourcesAndCqlTypes.
-        final Set<Value> evaluatedResources = new HashSetForFhirResourcesAndCqlTypes<>();
+            // element tree. See HashSetForFhirResourcesAndCqlTypes.
+            final Set<Value> evaluatedResources = new HashSetForFhirResourcesAndCqlTypes<>();
 
             for (var result : resultsIter) {
                 final ExpressionResult functionResult = evaluateNonSubValueStratifiersFunction(

--- a/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/SdeDef.java
+++ b/cqf-fhir-cr/src/main/java/org/opencds/cqf/fhir/cr/measure/common/SdeDef.java
@@ -1,7 +1,6 @@
 package org.opencds.cqf.fhir.cr.measure.common;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -18,7 +17,14 @@ public class SdeDef {
 
     // Pre-accumulated state (populated by MeasureMultiSubjectEvaluator)
     private final Map<StratumValueWrapper, Long> accumulatedValues = new HashMap<>();
-    private final Set<Value> allEvaluatedResources = new HashSet<>();
+
+    /**
+     * Keyed by resource identity rather than by {@link Value#hashCode}. These are engine values —
+     * a FHIR resource arrives as a {@code ClassInstance} whose hash is a recursive walk of the whole
+     * element tree — and {@link #accumulate} merges every subject's set into this one, so a plain
+     * {@link HashSet} pays that walk per resource per subject.
+     */
+    private final Set<Value> allEvaluatedResources = new HashSetForFhirResourcesAndCqlTypes<>();
 
     public SdeDef(String id, ConceptDef code, String expression) {
         this(id, code, expression, null);

--- a/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/SdeDefAccumulateTest.java
+++ b/cqf-fhir-cr/src/test/java/org/opencds/cqf/fhir/cr/measure/common/SdeDefAccumulateTest.java
@@ -1,0 +1,137 @@
+package org.opencds.cqf.fhir.cr.measure.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.xml.namespace.QName;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.cql.engine.runtime.ClassInstance;
+import org.opencds.cqf.cql.engine.runtime.Value;
+
+/**
+ * {@link SdeDef#accumulate()} merges every subject's evaluated resources into one set. That set is
+ * keyed by resource identity rather than by {@link Value#hashCode}, which for a
+ * {@link ClassInstance} is a recursive walk of the whole element tree.
+ *
+ * <p>The retrieve path builds a fresh {@code ClassInstance} per retrieve, so the same record
+ * reaches this method as several structurally-equal-but-distinct instances. They must collapse to
+ * one entry, and they must do so without hashing the graph.
+ */
+class SdeDefAccumulateTest {
+
+    private static final String FHIR_NS = "http://hl7.org/fhir";
+
+    /** As {@link #resource}, plus one extra element so two instances differ structurally. */
+    private static ClassInstance resource(String type, String id, String statusValue) {
+        var instance = resource(type, id);
+        instance.getElements().put("status", new org.opencds.cqf.cql.engine.runtime.String(statusValue));
+        return instance;
+    }
+
+    /** A FHIR-namespaced {@link ClassInstance}, the shape a retrieve produces. */
+    private static ClassInstance resource(String type, String id) {
+        Map<String, Value> idElements = new LinkedHashMap<>();
+        idElements.put("value", new org.opencds.cqf.cql.engine.runtime.String(id));
+        Map<String, Value> elements = new LinkedHashMap<>();
+        elements.put("id", new ClassInstance(new QName(FHIR_NS, "id", "FHIR"), idElements));
+        return new ClassInstance(new QName(FHIR_NS, type, "FHIR"), elements);
+    }
+
+    private static SdeDef sdeDef() {
+        return new SdeDef("sde-1", null, "SDE Sex");
+    }
+
+    @Test
+    void collapsesSeparateInstancesOfTheSameResource() {
+        var firstRetrieve = resource("Encounter", "enc-1");
+        var secondRetrieve = resource("Encounter", "enc-1");
+
+        // Precondition: distinct objects standing for one record, or this proves nothing.
+        assertNotSame(firstRetrieve, secondRetrieve);
+
+        var sde = sdeDef();
+        sde.putResult("Patient/1", "SDE Sex", null, Set.of(firstRetrieve));
+        sde.putResult("Patient/2", "SDE Sex", null, Set.of(secondRetrieve));
+
+        sde.accumulate();
+
+        assertEquals(
+                1,
+                sde.getAllEvaluatedResources().size(),
+                "one record retrieved twice should be one evaluated resource");
+    }
+
+    @Test
+    void collapsesOneRecordArrivingWithDifferentContent() {
+        // The case that separates resource identity from structural equality: the same record read
+        // twice, differing in some element — a status that moved on, a bumped versionId. Deep
+        // equality calls these two records and keeps both; identity calls them one.
+        var earlier = resource("Encounter", "enc-1", "planned");
+        var later = resource("Encounter", "enc-1", "finished");
+
+        assertNotEquals(earlier, later, "fixture should differ structurally");
+
+        var sde = sdeDef();
+        sde.putResult("Patient/1", "SDE Sex", null, Set.of(earlier));
+        sde.putResult("Patient/2", "SDE Sex", null, Set.of(later));
+
+        sde.accumulate();
+
+        assertEquals(
+                1,
+                sde.getAllEvaluatedResources().size(),
+                "one record is one evaluated resource regardless of which read arrived");
+    }
+
+    @Test
+    void keepsDistinctResources() {
+        var sde = sdeDef();
+        sde.putResult("Patient/1", "SDE Sex", null, Set.of(resource("Encounter", "enc-1")));
+        sde.putResult("Patient/2", "SDE Sex", null, Set.of(resource("Encounter", "enc-2")));
+
+        sde.accumulate();
+
+        assertEquals(2, sde.getAllEvaluatedResources().size());
+    }
+
+    @Test
+    void keepsResourcesOfDifferentTypesSharingAnId() {
+        // Identity is (resource type, logical id), not the id alone — Encounter/1 and Observation/1
+        // are different records.
+        var sde = sdeDef();
+        sde.putResult("Patient/1", "SDE Sex", null, Set.of(resource("Encounter", "shared-id")));
+        sde.putResult("Patient/2", "SDE Sex", null, Set.of(resource("Observation", "shared-id")));
+
+        sde.accumulate();
+
+        assertEquals(2, sde.getAllEvaluatedResources().size());
+    }
+
+    @Test
+    void mergesAcrossManySubjectsRetrievingTheSameRecord() {
+        // The shape that made this expensive: one record reached by many subjects, each carrying
+        // its own instance of it.
+        var sde = sdeDef();
+        for (int subject = 0; subject < 50; subject++) {
+            sde.putResult("Patient/" + subject, "SDE Sex", null, Set.of(resource("Encounter", "enc-1")));
+        }
+
+        sde.accumulate();
+
+        assertEquals(1, sde.getAllEvaluatedResources().size());
+    }
+
+    @Test
+    void accumulatingNothingYieldsAnEmptySet() {
+        var sde = sdeDef();
+
+        sde.accumulate();
+
+        assertTrue(sde.getAllEvaluatedResources().isEmpty());
+    }
+}


### PR DESCRIPTION
### Problem

Three collections that accumulate engine `Value`s were plain `HashSet`s, so every insert recursively hashed a `ClassInstance`'s entire element tree. For FHIR resources that is a walk of the whole resource graph, per resource, per subject.

- `SdeDef.allEvaluatedResources` - `accumulate()` merges every subject's evaluated resources into this one set
- `FunctionEvaluationHandler`, measure-observation accumulation
- `FunctionEvaluationHandler`, stratifier-function accumulation

#1100 keyed the other evaluated-resource collections by resource identity; these three were missed.

### What this does

Switches all three to `HashSetForFhirResourcesAndCqlTypes`, so membership is decided by the `IdentityKey` machinery #1100 introduced rather than by a deep structural hash. No new types and no behavioural change - the same values are retained, and the same duplicates collapse.

Also removes a duplicated `addAll` in the stratifier path, where `evaluated` and `functionResult.getEvaluatedResources()` are the same collection assigned three lines apart, so the set was populated twice. That is a no-op for correctness and pure waste on the hot path.

### Evidence

Found by JFR profiling a 400-member HEDIS `AAB-Details` population run: every one of the 567 deep-hash samples resolved to `SdeDef.accumulate`, via `MeasureEvaluationResultHandler.processResults` and `MeasureMultiSubjectEvaluator.postEvaluationMultiSubject`.

After the change, `StructuredValue.hashCode` accounts for 0.0% of samples, down from 15.4%. The measure-report build phase improves to a normalised ratio of 0.609 against an unpatched build measured in the same interleaved sweep.

This cost scales with how many evaluated resources reach report building, so it is most visible on measures that retrieve broadly - `AAB-Details` retrieves `[Claim]` unfiltered, and claims were 64% of the test dataset.

### Verification

Full `:cqf-fhir-cr:test` suite shows no regressions against a clean `main` baseline captured on the same commit: 412 failing with this change versus 415 without, the difference being three known-flaky tests. Correctness held across twelve end-to-end measure evaluations - 400 of 400 members, zero errors, populations unchanged.